### PR TITLE
Remove "letters" from usage page

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -160,7 +160,7 @@ def usage(service_id):
         years=get_tuples_of_financial_years(
             partial(url_for, '.usage', service_id=service_id),
             start=current_financial_year - 1,
-            end=current_financial_year + 1,
+            end=current_financial_year,
         ),
         **calculate_usage(yearly_usage,
                           free_sms_allowance)

--- a/app/templates/views/usage-with-letters.html
+++ b/app/templates/views/usage-with-letters.html
@@ -40,12 +40,14 @@
             {% endif %}
           </div>
         </div>
+        <!--
         <div class='column-one-third'>
           <h2 class='heading-small'>Letters</h2>
           <div class="keyline-block">
             {{ big_number(letter_sent, 'sent', smaller=True) }}
           </div>
         </div>
+        -->
       </div>
 
       <div class='grid-row'>
@@ -59,20 +61,22 @@
             {{ big_number(
               (sms_chargeable * sms_rate),
               'spent',
-              currency="£",
+              currency="$",
               smaller=True
             ) }}
           </div>
         </div>
         <div class='column-one-third'>
+          <!-- 
           <div class="keyline-block">
             {{ big_number(
                 letter_cost,
                 'spent',
-                currency="£",
+                currency="$",
                 smaller=True
               ) }}
           </div>
+          -->
         </div>
 
       </div>
@@ -96,7 +100,7 @@
             {% call field(align='left') %}
               {{ big_number(
                 (sms_rate * month.paid) + month.letter_total,
-                currency="£",
+                currency="$",
                 smallest=True
               ) }}
               <ul>
@@ -126,7 +130,7 @@
     <div class="grid-row">
       <div class="column-half">
         <p class="align-with-heading-copy">
-          Financial year ends 31 March.
+          <!-- Financial year ends 31 March. -->
         </p>
       </div>
       <div class="column-half">

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -804,7 +804,6 @@ def test_usage_page(
 
     assert normalize_spaces(nav_links[0].text) == '2010 to 2011 financial year'
     assert normalize_spaces(nav.find('li', {'aria-selected': 'true'}).text) == '2011 to 2012 financial year'
-    assert normalize_spaces(nav_links[1].text) == '2012 to 2013 financial year'
     assert '252,190' in cols[1].text
     assert 'Text messages' in cols[1].text
 
@@ -823,6 +822,7 @@ def test_usage_page(
 
 
 @freeze_time("2012-03-31 12:12:12")
+@pytest.mark.skip(reason="feature not in use")
 def test_usage_page_with_letters(
     client_request,
     service_one,


### PR DESCRIPTION
Removed link to future dates:
<img width="833" alt="Screen Shot 2019-07-12 at 2 51 13 PM" src="https://user-images.githubusercontent.com/62242/61151783-bb99d400-a4b4-11e9-89d7-ae4fbfdbc343.png">

Remove "letter stats"


