### PR TITLE
Add bucket for csv files

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -58,7 +58,7 @@ class Config(object):
     SHOW_STYLEGUIDE = True
     WTF_CSRF_ENABLED = True
     WTF_CSRF_TIME_LIMIT = None
-    CSV_UPLOAD_BUCKET_NAME = 'local-notifications-csv-upload'
+    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     ACTIVITY_STATS_LIMIT_DAYS = 7
     TEST_MESSAGE_FILENAME = 'Report'
 
@@ -87,7 +87,7 @@ class Development(Config):
     SESSION_COOKIE_SECURE = False
     SESSION_PROTECTION = None
     STATSD_ENABLED = False
-    CSV_UPLOAD_BUCKET_NAME = 'development-notifications-csv-upload'
+    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-tools'
     MOU_BUCKET_NAME = 'notify.tools-mou'
 
@@ -108,7 +108,7 @@ class Test(Development):
     TESTING = True
     STATSD_ENABLED = False
     WTF_CSRF_ENABLED = False
-    CSV_UPLOAD_BUCKET_NAME = 'test-notifications-csv-upload'
+    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-test'
     MOU_BUCKET_NAME = 'test-mou'
     NOTIFY_ENVIRONMENT = 'test'
@@ -128,7 +128,7 @@ class Preview(Config):
     HTTP_PROTOCOL = 'https'
     HEADER_COLOUR = '#F499BE'  # $baby-pink
     STATSD_ENABLED = True
-    CSV_UPLOAD_BUCKET_NAME = 'preview-notifications-csv-upload'
+    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-preview'
     MOU_BUCKET_NAME = 'notify.works-mou'
     NOTIFY_ENVIRONMENT = 'preview'
@@ -142,7 +142,7 @@ class Staging(Config):
     HTTP_PROTOCOL = 'https'
     HEADER_COLOUR = '#6F72AF'  # $mauve
     STATSD_ENABLED = True
-    CSV_UPLOAD_BUCKET_NAME = 'staging-notifications-csv-upload'
+    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-staging'
     MOU_BUCKET_NAME = 'staging-notify.works-mou'
     NOTIFY_ENVIRONMENT = 'staging'
@@ -156,7 +156,7 @@ class Live(Config):
     HEADER_COLOUR = '#005EA5'  # $govuk-blue
     HTTP_PROTOCOL = 'https'
     STATSD_ENABLED = True
-    CSV_UPLOAD_BUCKET_NAME = 'live-notifications-csv-upload'
+    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-production'
     MOU_BUCKET_NAME = 'notifications.service.gov.uk-mou'
     NOTIFY_ENVIRONMENT = 'live'
@@ -174,7 +174,7 @@ class Sandbox(CloudFoundryConfig):
     HTTP_PROTOCOL = 'https'
     HEADER_COLOUR = '#F499BE'  # $baby-pink
     STATSD_ENABLED = True
-    CSV_UPLOAD_BUCKET_NAME = 'cf-sandbox-notifications-csv-upload'
+    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'cf-sandbox-notifications-logo-upload'
     NOTIFY_ENVIRONMENT = 'sandbox'
 

--- a/app/config.py
+++ b/app/config.py
@@ -58,7 +58,7 @@ class Config(object):
     SHOW_STYLEGUIDE = True
     WTF_CSRF_ENABLED = True
     WTF_CSRF_TIME_LIMIT = None
-    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
+    CSV_UPLOAD_BUCKET_NAME = os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     ACTIVITY_STATS_LIMIT_DAYS = 7
     TEST_MESSAGE_FILENAME = 'Report'
 
@@ -87,7 +87,7 @@ class Development(Config):
     SESSION_COOKIE_SECURE = False
     SESSION_PROTECTION = None
     STATSD_ENABLED = False
-    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
+    CSV_UPLOAD_BUCKET_NAME = os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-tools'
     MOU_BUCKET_NAME = 'notify.tools-mou'
 
@@ -108,7 +108,7 @@ class Test(Development):
     TESTING = True
     STATSD_ENABLED = False
     WTF_CSRF_ENABLED = False
-    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
+    CSV_UPLOAD_BUCKET_NAME = os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-test'
     MOU_BUCKET_NAME = 'test-mou'
     NOTIFY_ENVIRONMENT = 'test'
@@ -128,7 +128,7 @@ class Preview(Config):
     HTTP_PROTOCOL = 'https'
     HEADER_COLOUR = '#F499BE'  # $baby-pink
     STATSD_ENABLED = True
-    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
+    CSV_UPLOAD_BUCKET_NAME = os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-preview'
     MOU_BUCKET_NAME = 'notify.works-mou'
     NOTIFY_ENVIRONMENT = 'preview'
@@ -142,7 +142,7 @@ class Staging(Config):
     HTTP_PROTOCOL = 'https'
     HEADER_COLOUR = '#6F72AF'  # $mauve
     STATSD_ENABLED = True
-    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
+    CSV_UPLOAD_BUCKET_NAME = os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-staging'
     MOU_BUCKET_NAME = 'staging-notify.works-mou'
     NOTIFY_ENVIRONMENT = 'staging'
@@ -156,7 +156,7 @@ class Live(Config):
     HEADER_COLOUR = '#005EA5'  # $govuk-blue
     HTTP_PROTOCOL = 'https'
     STATSD_ENABLED = True
-    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
+    CSV_UPLOAD_BUCKET_NAME = os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'public-logos-production'
     MOU_BUCKET_NAME = 'notifications.service.gov.uk-mou'
     NOTIFY_ENVIRONMENT = 'live'
@@ -174,7 +174,7 @@ class Sandbox(CloudFoundryConfig):
     HTTP_PROTOCOL = 'https'
     HEADER_COLOUR = '#F499BE'  # $baby-pink
     STATSD_ENABLED = True
-    CSV_UPLOAD_BUCKET_NAME =  os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
+    CSV_UPLOAD_BUCKET_NAME = os.getenv('CSV_UPLOAD_BUCKET_NAME', 'development-notification-canada-ca-csv-upload')
     LOGO_UPLOAD_BUCKET_NAME = 'cf-sandbox-notifications-logo-upload'
     NOTIFY_ENVIRONMENT = 'sandbox'
 

--- a/tests/app/s3_client/test_s3_csv_client.py
+++ b/tests/app/s3_client/test_s3_csv_client.py
@@ -14,7 +14,7 @@ def test_sets_metadata(client, mocker):
 
     mocked_get_s3_object.assert_called_once_with('1234', '5678')
     mocked_s3_object.copy_from.assert_called_once_with(
-        CopySource='test-notifications-csv-upload/service-1234-notify/5678.csv',
+        CopySource='development-notification-canada-ca-csv-upload/service-1234-notify/5678.csv',
         Metadata={'baz': 'True', 'foo': 'bar'},
         MetadataDirective='REPLACE',
         ServerSideEncryption='AES256',


### PR DESCRIPTION
Adds .env info for S3 bucket name:

**Preview after the upload:**
<img width="753" alt="Screen Shot 2019-07-18 at 8 04 46 AM" src="https://user-images.githubusercontent.com/62242/61455968-f5466100-a932-11e9-9e9b-ec3acbb6af30.png">

Note: Using the same bucket across environments for now so we can demo.
