### PR TITLE
Registration form - content updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# notifications-admin
+# Notifications-admin
 
 Notifications admin application.
+
+## Upstream
+This repo is a clone / modifed version of:
+https://github.com/alphagov/notifications-admin
 
 ## Features of this application
 
@@ -109,6 +113,17 @@ When running on preview, staging and production there’s a bit more to it:
 
 ```
 <h1>{{ _('Hello') }}</h1>
+```
+
+- For form hints 
+
+Set a variable
+
+```
+ <div class="extra-tracking">
+  {% set hint_txt = _('We’ll send you a security code by text message') %}
+  {{ textbox(form.mobile_number, width='3-4', hint=hint_txt) }}
+ </div>
 ```
 
 - Extract

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -11,12 +11,14 @@ Create an account
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large">Create an account</h1>
+    <h1 class="heading-large">{{ _('Create an account') }}</h1>
     {% call form_wrapper(autocomplete=True) %}
       {{ textbox(form.name, width='3-4') }}
-      {{ textbox(form.email_address, hint="Must be from a government organisation", width='3-4', safe_error_message=True) }}
+      {% set hint_txt = _('Must be a federal government email address') %}
+      {{ textbox(form.email_address, hint=hint_txt, width='3-4', safe_error_message=True) }}
       <div class="extra-tracking">
-        {{ textbox(form.mobile_number, width='3-4', hint='We’ll send you a security code by text message') }}
+        {% set hint_txt = _('We’ll send you a security code by text message') %}
+        {{ textbox(form.mobile_number, width='3-4', hint=hint_txt) }}
       </div>
       <input class="visually-hidden" aria-hidden="true" tabindex="-1" id="defeat-chrome-autocomplete">
       {{ textbox(form.password, hint="At least 8 characters", width='3-4') }}

--- a/app/translations/fr/LC_MESSAGES/messages.po
+++ b/app/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-07-08 11:36-0400\n"
+"POT-Creation-Date: 2019-07-19 10:40-0400\n"
 "PO-Revision-Date: 2019-07-03 11:43-0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -23,8 +23,8 @@ msgid "Documentation"
 msgstr "FR Documentation"
 
 #: app/templates/views/documentation.html:10
-msgid "Notify API to send messages automatically."
-msgstr "FR Notify API to send messages automatically."
+msgid "Notification API to send messages automatically."
+msgstr ""
 
 #: app/templates/views/documentation.html:11
 msgid "Clients"
@@ -38,6 +38,18 @@ msgstr ""
 "FR Choose a client to integrate our API with your web application or "
 "back-office system. Links to documentation open in a new tab."
 
+#: app/templates/views/register.html:14
+msgid "Create an account"
+msgstr ""
+
+#: app/templates/views/register.html:17
+msgid "Must be a federal government email address"
+msgstr ""
+
+#: app/templates/views/register.html:20
+msgid "We’ll send you a security code by text message"
+msgstr ""
+
 #: app/templates/views/signedout.html:18
 msgid "Send emails, text messages and letters to your users"
 msgstr "FR Send emails, text messages and letters to your users"
@@ -45,4 +57,7 @@ msgstr "FR Send emails, text messages and letters to your users"
 #: app/templates/views/agreement/_agreement-choose.html:2
 msgid "Hello"
 msgstr "Bonjour"
+
+#~ msgid "Notify API to send messages automatically."
+#~ msgstr "FR Notify API to send messages automatically."
 


### PR DESCRIPTION
Covers -> https://github.com/cds-snc/notification-api/issues/103

>Please change "Must be from a government organisation" to "Must be a federal government email address"

**Includes:**

- This PR also wraps the text for translation 
- Updates the Readme indicating how to handle `hint text` translation in the forms.
- Extracted translation text `messages.po`

 
