### PR TITLE
fixes #106

### DIFF
--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -9,12 +9,13 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large">{{ title }}</h1>
-    <p>We’ve emailed you a link to sign in to Notification.</p>
-    <p>Clicking the link will open Notification in a new browser window, so you can close this one.</p>
+    <h1 class="heading-large">{{ _(title) }}</h1>
+    <p>{{ _('We’ve emailed you a link to sign in to Notification.') }}</p>
+    <p>{{ _('Use the link to open Notification in a new browser window.') }}</p>
+    {% set link_txt = _('Not received an email') %}
     {{ page_footer(
       secondary_link=url_for('main.email_not_received'),
-      secondary_link_text='Not received an email?'
+      secondary_link_text=link_txt
     ) }}
   </div>
 </div>

--- a/app/translations/fr/LC_MESSAGES/messages.po
+++ b/app/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-07-19 10:40-0400\n"
+"POT-Creation-Date: 2019-07-19 14:30-0400\n"
 "PO-Revision-Date: 2019-07-03 11:43-0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -53,6 +53,18 @@ msgstr ""
 #: app/templates/views/signedout.html:18
 msgid "Send emails, text messages and letters to your users"
 msgstr "FR Send emails, text messages and letters to your users"
+
+#: app/templates/views/two-factor-email.html:13
+msgid "We’ve emailed you a link to sign in to Notification."
+msgstr ""
+
+#: app/templates/views/two-factor-email.html:14
+msgid "Use the link to open Notification in a new browser window."
+msgstr ""
+
+#: app/templates/views/two-factor-email.html:15
+msgid "Not received an email"
+msgstr ""
 
 #: app/templates/views/agreement/_agreement-choose.html:2
 msgid "Hello"


### PR DESCRIPTION
Closes : https://github.com/cds-snc/notification-api/issues/106

>Please replace "Clicking the link . . . " with "Use the link to open Notification in a new browser window”.

Page: https://notification.cdssandbox.xyz/two-factor-email-sent