### PR TITLE
Add service content updates #108

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ Set a variable
  </div>
 ```
 
+For forms
+
+```
+from flask_babel import _
+```
+
+Wrap your text
+```
+_('Your text here')
+```
+
 - Extract
 
 ```bash

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -584,9 +584,9 @@ class OrganisationDomainsForm(StripWhitespaceForm):
 
 class CreateServiceForm(StripWhitespaceForm):
     name = StringField(
-        u'What’s your service called?',
+        _('What’s your service called?'),
         validators=[
-            DataRequired(message='Can’t be empty')
+            DataRequired(message=_('Can’t be empty'))
         ])
     organisation_type = organisation_type()
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -319,11 +319,7 @@ class User(JSONModel, UserMixin):
 
     @property
     def default_organisation_type(self):
-        if self.default_organisation:
-            return self.default_organisation.organisation_type
-        if self.has_nhs_email_address:
-            return 'nhs'
-        return None
+        return 'central' # CDS note: defaulted to central (hides radio options)
 
     @property
     def has_access_to_live_and_trial_mode_services(self):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -319,7 +319,7 @@ class User(JSONModel, UserMixin):
 
     @property
     def default_organisation_type(self):
-        return 'central' # CDS note: defaulted to central (hides radio options)
+        return 'central'  # CDS note: defaulted to central (hides radio options)
 
     @property
     def has_access_to_live_and_trial_mode_services(self):

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -13,18 +13,18 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-
-    {{ page_header('About your service') }}
+    {% set header_txt = _('About your service') %}
+    {{ page_header(header_txt) }}
 
     {% call form_wrapper() %}
-
-      {{ textbox(form.name, hint="You can change this later") }}
-
+      {% set hint_txt = _('You can change this later') %}
+      {{ textbox(form.name, hint=hint_txt) }}
+      {# not in use - default to central for all users  #}
       {% if not current_user.default_organisation_type %}
         {{ radios(form.organisation_type) }}
       {% endif %}
-
-      {{ page_footer('Add service') }}
+      {% set button_txt = _('Add service') %}
+      {{ page_footer(button_txt) }}
 
     {% endcall %}
 

--- a/app/translations/fr/LC_MESSAGES/messages.po
+++ b/app/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-07-19 13:21-0400\n"
+"POT-Creation-Date: 2019-07-22 08:21-0400\n"
 "PO-Revision-Date: 2019-07-19 13:22-0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -17,6 +17,30 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.7.0\n"
+
+#: app/main/forms.py:493
+msgid "Please enter security code"
+msgstr ""
+
+#: app/main/forms.py:587
+msgid "What’s your service called?"
+msgstr ""
+
+#: app/main/forms.py:589
+msgid "Can’t be empty"
+msgstr ""
+
+#: app/templates/views/add-service.html:16
+msgid "About your service"
+msgstr ""
+
+#: app/templates/views/add-service.html:20
+msgid "You can change this later"
+msgstr ""
+
+#: app/templates/views/add-service.html:26
+msgid "Add service"
+msgstr ""
 
 #: app/templates/views/documentation.html:9
 msgid "Documentation"
@@ -36,6 +60,18 @@ msgid ""
 "office system. Links to documentation open in a new tab."
 msgstr ""
 
+#: app/templates/views/register.html:14 app/templates/views/signedout.html:25
+msgid "Create an account"
+msgstr ""
+
+#: app/templates/views/register.html:17
+msgid "Must be a federal government email address"
+msgstr ""
+
+#: app/templates/views/register.html:20
+msgid "We’ll send you a security code by text message"
+msgstr ""
+
 #: app/templates/views/signedout.html:18
 msgid "Send emails and text messages to your users"
 msgstr "Envoyer des emails et des SMS à vos utilisateurs"
@@ -43,10 +79,6 @@ msgstr "Envoyer des emails et des SMS à vos utilisateurs"
 #: app/templates/views/signedout.html:21
 msgid "Try Notification if you work in the federal government."
 msgstr "Essayez Notification si vous travaillez au gouvernement fédéral."
-
-#: app/templates/views/signedout.html:25
-msgid "Create an account"
-msgstr ""
 
 #: app/templates/views/signedout.html:27
 msgid "or"
@@ -90,5 +122,37 @@ msgstr ""
 
 #: app/templates/views/signedout.html:79
 msgid "if you have a question or want to give feedback."
+msgstr ""
+
+#: app/templates/views/two-factor-email.html:13
+msgid "We’ve emailed you a link to sign in to Notification."
+msgstr ""
+
+#: app/templates/views/two-factor-email.html:14
+msgid "Use the link to open Notification in a new browser window."
+msgstr ""
+
+#: app/templates/views/two-factor-email.html:15
+msgid "Not received an email"
+msgstr ""
+
+#: app/templates/views/two-factor.html:8
+msgid "Text verification"
+msgstr ""
+
+#: app/templates/views/two-factor.html:15
+msgid "Check your phone"
+msgstr ""
+
+#: app/templates/views/two-factor.html:16
+msgid "Continue"
+msgstr ""
+
+#: app/templates/views/two-factor.html:17
+msgid "Not received a text message?"
+msgstr ""
+
+#: app/templates/views/two-factor.html:18
+msgid "We’ve sent you a text message with a security code."
 msgstr ""
 

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -35,21 +35,6 @@ def test_get_should_render_add_service_template(
     )
     page = client_request.get('main.add_service')
     assert page.select_one('h1').text.strip() == 'About your service'
-    assert page.select_one('input[name=name]')['value'] == ''
-    assert [
-        label.text.strip() for label in page.select('.multiple-choice label')
-    ] == [
-        'Central government',
-        'Local government',
-        'NHS',
-    ]
-    assert [
-        radio['value'] for radio in page.select('.multiple-choice input')
-    ] == [
-        'central',
-        'local',
-        'nhs',
-    ]
 
 
 def test_get_should_not_render_radios_if_org_type_known(
@@ -70,11 +55,8 @@ def test_get_should_not_render_radios_if_org_type_known(
 ))
 @pytest.mark.parametrize('inherited, posted, persisted, sms_limit', (
     (None, 'central', 'central', 250000),
-    ('central', None, 'central', 250000),
-    ('nhs', None, 'nhs', 25000),
-    ('local', None, 'local', 25000),
-    ('central', 'local', 'central', 250000),
 ))
+@pytest.mark.skip(reason="feature not in use - defaults to central")
 def test_should_add_service_and_redirect_to_tour_when_no_services(
     mocker,
     client_request,
@@ -129,6 +111,7 @@ def test_should_add_service_and_redirect_to_tour_when_no_services(
     mock_create_or_update_free_sms_fragment_limit.assert_called_once_with(101, sms_limit)
 
 
+@pytest.mark.skip(reason="feature not in use - defaults to central")
 def test_add_service_has_to_choose_org_type(
     mocker,
     client_request,
@@ -193,9 +176,7 @@ def test_add_service_guesses_org_type_for_unknown_nhs_orgs(
 
 
 @pytest.mark.parametrize('organisation_type, free_allowance', [
-    ('central', 250 * 1000),
-    ('local', 25 * 1000),
-    ('nhs', 25 * 1000),
+    ('central', 250 * 1000)
 ])
 def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
     app_,


### PR DESCRIPTION
Forces `central` as  `organisation_type` value in turn turns off radio options from the form.


Fixes "Who runs this service":

https://github.com/cds-snc/notification-api/issues/108