### PR TITLE
Hide Email branding

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1040,6 +1040,8 @@ def link_service_to_organisation(service_id):
 @user_has_permissions('manage_service')
 def branding_request(service_id):
 
+    abort(404)
+
     branding_type = 'govuk'
 
     if current_service.email_branding:

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -414,7 +414,7 @@ class Service(JSONModel):
     @cached_property
     def email_branding_name(self):
         if self.email_branding is None:
-            return 'GOV.UK'
+            return 'default'
         return self.email_branding['name']
 
     @property

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -121,10 +121,10 @@
   {% endcall %}
 {%- endmacro %}
 
-{% macro edit_field(text, link, permissions=[]) -%}
+{% macro edit_field(text, link, permissions=[], attributes="") -%}
   {% call field(align='right') %}
     {% if not permissions or current_user.has_permissions(*permissions) %}
-      <a href="{{ link }}">{{ text }}</a>
+      <a {{attributes}} href="{{ link }}">{{ text }}</a>
     {% endif %}
   {% endcall %}
 {%- endmacro %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -107,6 +107,7 @@
             'Change',
             url_for('.branding_request', service_id=current_service.id),
             permissions=['manage_service'],
+            attributes="style=display:none"
           )}}
         {% endcall %}
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -66,7 +66,7 @@ def mock_get_service_settings_page_common(
         'Label Value Action',
         'Send emails On Change',
         'Reply-to email addresses Not set Manage',
-        'Email branding GOV.UK Change',
+        'Email branding default Change',
 
         'Label Value Action',
         'Send text messages On Change',
@@ -85,7 +85,7 @@ def mock_get_service_settings_page_common(
         'Label Value Action',
         'Send emails On Change',
         'Reply-to email addresses Not set Manage',
-        'Email branding GOV.UK Change',
+        'Email branding default Change',
 
         'Label Value Action',
         'Send text messages On Change',
@@ -99,7 +99,7 @@ def mock_get_service_settings_page_common(
         'Count in list of live services Yes Change',
         'Organisation Test Organisation Central government Change',
         'Free text message allowance 250,000 Change',
-        'Email branding GOV.UK Change',
+        'Email branding default Change',
         'Letter branding Not set Change',
         'Data retention email Change',
         'Receive inbound SMS Off Change',
@@ -4290,6 +4290,7 @@ def test_update_service_organisation_does_not_update_if_same_value(
     mock_update_service_organisation.called is False
 
 
+@pytest.mark.skip(reason="feature not in use")
 def test_show_email_branding_request_page_when_no_email_branding_is_set(
     client_request,
     mock_get_email_branding
@@ -4312,6 +4313,7 @@ def test_show_email_branding_request_page_when_no_email_branding_is_set(
         assert radios[index]['value'] == option
 
 
+@pytest.mark.skip(reason="feature not in use")
 def test_show_email_branding_request_page_when_email_branding_is_set(
     client_request,
     mock_get_email_branding,
@@ -4352,6 +4354,7 @@ def test_show_email_branding_request_page_when_email_branding_is_set(
     (None, 'Can’t tell (domain is user.canada.ca)'),
     ('Test Organisation', 'Test Organisation'),
 ))
+@pytest.mark.skip(reason="feature not in use")
 def test_submit_email_branding_request(
     client_request,
     mocker,
@@ -4390,7 +4393,7 @@ def test_submit_email_branding_request(
             'http://localhost/services/596364a0-858e-42c8-9062-a8fe822260eb',
             '',
             '---',
-            'Current branding: GOV.UK',
+            'Current branding: default',
             'Branding requested: {}',
         ]).format(expected_organisation, requested_branding),
         subject='Email branding request - service one',


### PR DESCRIPTION
Hide Email branding ins settings for now so we can manage user expectations

1. hides the "change" link and list the e-mail branding as "default"
2. 404s the branding request page

<img width="849" alt="Screen Shot 2019-07-30 at 1 04 10 PM" src="https://user-images.githubusercontent.com/62242/62149804-8d94fc00-b2ca-11e9-877e-0585fe2a12e4.png">

Note: Leaves most of the code intact so we can revert back easily


Closes https://github.com/cds-snc/notification-api/issues/157