### PR TITLE
Support routes

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -39,6 +39,9 @@ def support():
 
 @main.route('/support/triage', methods=['GET', 'POST'])
 def triage():
+
+    return redirect(url_for('main.support'))
+
     form = Triage()
     if form.validate_on_submit():
         return redirect(url_for(
@@ -126,6 +129,8 @@ def feedback(ticket_type):
 
 @main.route('/support/escalate', methods=['GET', 'POST'])
 def bat_phone():
+
+    return redirect(url_for('main.support'))
 
     if current_user.is_authenticated:
         return redirect(url_for('main.feedback', ticket_type=PROBLEM_TICKET_TYPE))

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -450,11 +450,15 @@ def test_triage_redirects_to_correct_url(client, choice, expected_redirect_param
     response = client.post(url_for('main.triage'), data={'severe': choice})
     assert response.status_code == 302
     assert response.location == url_for(
-        'main.feedback',
-        ticket_type=PROBLEM_TICKET_TYPE,
-        severe=expected_redirect_param,
-        _external=True,
+        'main.support',
+        _external=True
     )
+    # assert response.location == url_for(
+    #     'main.feedback',
+    #     ticket_type=PROBLEM_TICKET_TYPE,
+    #     severe=expected_redirect_param,
+    #     _external=True,
+    # )
 
 
 @pytest.mark.parametrize(
@@ -531,7 +535,7 @@ def test_should_be_shown_the_bat_email(
     assert logged_in_response.status_code == expected_status_code_when_logged_in
     assert logged_in_response.location == expected_redirect_when_logged_in(_external=True)
 
-
+@pytest.mark.skip(reason="feature not in use")
 def test_bat_email_page(
     client,
     active_user_with_permissions,

--- a/tests/app/main/views/test_feedback.py
+++ b/tests/app/main/views/test_feedback.py
@@ -535,6 +535,7 @@ def test_should_be_shown_the_bat_email(
     assert logged_in_response.status_code == expected_status_code_when_logged_in
     assert logged_in_response.location == expected_redirect_when_logged_in(_external=True)
 
+
 @pytest.mark.skip(reason="feature not in use")
 def test_bat_email_page(
     client,


### PR DESCRIPTION
Closes https://github.com/cds-snc/notification-api/issues/187

Redirects the `/support/escalate` and `/support/triage` to `/support/`