### PR TITLE
Remove service_id from session after the service is deleted

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -328,6 +328,7 @@ def archive_service(service_id):
         abort(403)
     if request.method == 'POST':
         service_api_client.archive_service(service_id)
+        session.pop('service_id', None)
         flash(
             '‘{}’ was deleted'.format(current_service.name),
             'default_with_tick',


### PR DESCRIPTION
Fixes https://github.com/cds-snc/notification-api/issues/200