### PR TITLE
Mask password with a digest

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -1,5 +1,6 @@
-import os
 import hashlib
+import os
+
 from notifications_python_client.errors import HTTPError
 
 from app.models.roles_and_permissions import (

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -57,7 +57,7 @@ def test_client_updates_password_separately(mocker, api_user_active):
     mock_update_password = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
 
     user_api_client.update_password(api_user_active['id'], expected_params['_password'])
-    mock_update_password.assert_called_once_with(expected_url, data=expected_params)
+    mock_update_password.assert_called_once_with(expected_url, data={'_password': '272dfee24acc4d6cc0f81a26d17a406cad1ee7579bcc1671c22f530b6d6845c3'})
 
 
 def test_client_activates_if_pending(mocker, api_user_pending):

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -57,7 +57,9 @@ def test_client_updates_password_separately(mocker, api_user_active):
     mock_update_password = mocker.patch('app.notify_client.user_api_client.UserApiClient.post')
 
     user_api_client.update_password(api_user_active['id'], expected_params['_password'])
-    mock_update_password.assert_called_once_with(expected_url, data={'_password': '272dfee24acc4d6cc0f81a26d17a406cad1ee7579bcc1671c22f530b6d6845c3'})
+    mock_update_password.assert_called_once_with(
+        expected_url,
+        data={'_password': '272dfee24acc4d6cc0f81a26d17a406cad1ee7579bcc1671c22f530b6d6845c3'})
 
 
 def test_client_activates_if_pending(mocker, api_user_pending):


### PR DESCRIPTION
Closes https://github.com/cds-snc/notification-api/issues/240

The idea here is that clear text passwords should not show up in API logs. The simple solution was to mask them as a message digest with a secret salt before they get passed to the API. This does not stop the clear text password from showing up in the Admin logs or somebody using the salt to build a rainbow table for the logs if they had access to both.

Using a more complex hashing solution like bcrypt does not work because each time the password is hashed before it goes to the API it receives a new salt which will then be a different string. The API does not know if this is a hashed string or a clear string password.