### PR TITLE
Allow language setting via URL and open formatting guide in new tab

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -111,7 +111,7 @@ def get_current_locale(application):
     requestLang = request.accept_languages.best_match(application.config['LANGUAGES'])
     if requestLang is None:
         requestLang = "en"
-    lang = session.get("userlang", requestLang)
+    lang = request.args.get('lang') or session.get("userlang", requestLang)
     session["userlang"] = lang
     return lang
 

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -20,7 +20,7 @@
       <div class="grid-row">
         <div class="column-five-sixths">
           <div class="form-group">
-            <a href="{{ url_for('main.features_templates') }}">{{ _('Formatting Guide') }}</a>
+            <a href="{{ url_for('main.features_templates') }}" target="_blank">{{ _('Formatting Guide') }}</a>
           </div>
           {% set hint_txt = _('Your recipients won’t see this:') %}
           {{ textbox(form.name, width='1-1', hint=hint_txt, rows=10) }}

--- a/app/templates/views/edit-sms-template.html
+++ b/app/templates/views/edit-sms-template.html
@@ -18,7 +18,7 @@
 
     {% call form_wrapper() %}
       <div class="form-group">
-        <a href="{{ url_for('main.features_templates') }}">{{ _('Formatting Guide') }}</a>
+        <a href="{{ url_for('main.features_templates') }}" target="_blank">{{ _('Formatting Guide') }}</a>
       </div>
       {% set txt = _('Your recipients won’t see this') %}
       <div class="grid-row">


### PR DESCRIPTION
Closes https://github.com/cds-snc/notification-api/issues/277, and closes https://github.com/cds-snc/notification-api/issues/276

Example: https://notification-canada-ca-pr-182.herokuapp.com/?lang=fr