### PR TITLE
Dashboard update

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -401,7 +401,7 @@ def format_monthly_stats_to_list(historical_stats):
             name=get_month_name(key),
             **aggregate_status_types(value)
         ) for key, value in historical_stats.items()
-    ), key=lambda x: x['date'])
+    ), key=lambda x: x['date'],reverse=True)
 
 
 def get_month_name(string):

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -121,7 +121,7 @@ def template_usage(service_id):
 
     return render_template(
         'views/dashboard/all-template-statistics.html',
-        months=months,
+        months=reversed(months),
         stats=stats,
         most_used_template_count=max(
             max((
@@ -401,7 +401,7 @@ def format_monthly_stats_to_list(historical_stats):
             name=get_month_name(key),
             **aggregate_status_types(value)
         ) for key, value in historical_stats.items()
-    ), key=lambda x: x['date'],reverse=True)
+    ), key=lambda x: x['date'], reverse=True)
 
 
 def get_month_name(string):

--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -12,14 +12,6 @@
 
   <h1 class="heading-large">{{ _('Templates used') }}</h1>
 
-  <div class="bottom-gutter-3-2">
-    {{ pill(
-      items=years,
-      current_value=selected_year,
-      big_number_args={'smallest': True},
-    ) }}
-  </div>
-
   <div class="dashboard">
     {% for month in months %}
       <h2>{{ month.name }}</h2>

--- a/app/templates/views/dashboard/monthly.html
+++ b/app/templates/views/dashboard/monthly.html
@@ -15,13 +15,9 @@
   <h1 class="heading-large">
     {{ _('Messages sent') }}
   </h1>
-  <div class="bottom-gutter">
-    {{ pill(
-      items=years,
-      current_value=selected_year,
-      big_number_args={'smallest': True},
-    ) }}
-  </div>
+  
+  <!-- @todo -> in 2020 add monthly?year=2020 + /monthly?year=2019 -->
+  
   {% if months %}
    {% set spend_txt = _('Total spend') %} 
    {% set heading_1 = _('Month') %} 
@@ -70,9 +66,10 @@
   {% endif %}
 
   
-
+<!--
   <p class="align-with-heading-copy">
     {{ _('Fiscal year ends 31 March.') }}
   </p>
+  -->
 
 {% endblock %}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -593,12 +593,6 @@ def test_stats_pages_show_last_3_years(
         service_id=SERVICE_ONE_ID,
     )
 
-    assert normalize_spaces(page.select_one('.pill').text) == (
-        '2012 to 2013 financial year '
-        '2013 to 2014 financial year '
-        '2014 to 2015 financial year'
-    )
-
 
 def test_monthly_has_equal_length_tables(
     client_request,

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -577,23 +577,6 @@ def test_monthly_shows_letters_in_breakdown(
     assert normalize_spaces(columns[1].text) == 'text messages'
 
 
-@pytest.mark.parametrize('endpoint', [
-    'main.monthly',
-    'main.template_usage',
-])
-@freeze_time("2015-01-01 15:15:15.000000")
-def test_stats_pages_show_last_3_years(
-    client_request,
-    endpoint,
-    mock_get_monthly_notification_stats,
-    mock_get_monthly_template_usage,
-):
-    page = client_request.get(
-        endpoint,
-        service_id=SERVICE_ONE_ID,
-    )
-
-
 def test_monthly_has_equal_length_tables(
     client_request,
     service_one,


### PR DESCRIPTION
Updated the templates + controllers in the admin to handle https://github.com/cds-snc/notification-api/issues/465

<img width="753" alt="Screen Shot 2019-11-27 at 8 19 03 AM" src="https://user-images.githubusercontent.com/62242/69726499-b6999200-10ee-11ea-85d0-6b090536eea0.png">

<hr>

<img width="818" alt="Screen Shot 2019-11-27 at 8 24 52 AM" src="https://user-images.githubusercontent.com/62242/69726898-6c64e080-10ef-11ea-92fe-d5aab93338d3.png">

The monthly dashboard takes a year param monthly?year=2018 so we can work with that for paging....

@willeybryan, @maxneuvians  

That said all the queries etc... are based on Financial years.  So 

1) Are we working based on Financial years?
    1a) If we are what is the start / end month

==== 

Based on the above we should open a new issue for updating the queries financial years etc..(not sure the impact overall for that).  


