### PR TITLE
POC - Alert message threshold

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -3,7 +3,7 @@ import re
 from collections import OrderedDict
 from datetime import datetime
 
-from flask import abort, flash, redirect, render_template, request, url_for
+from flask import jsonify, abort, flash, redirect, render_template, request, url_for
 from notifications_python_client.errors import HTTPError
 from requests import RequestException
 
@@ -43,13 +43,30 @@ COMPLAINT_THRESHOLD = 0.02
 FAILURE_THRESHOLD = 3
 ZERO_FAILURE_THRESHOLD = 0
 
+@main.route("/platform-admin/threshold")
+def threshold():
+    # detect if a service is near a daily limit
+    allServices = service_api_client.get_live_services_data()["data"]
+    for service in allServices:
+        stats = service_api_client.get_service_statistics(service["service_id"], True)
+        count = stats["email"]["requested"]
+        if(count >1):
+           result = service_api_client.get_service(service["service_id"])["data"]
+           limit = result["message_limit"]
+           remainder = limit - count
+           if(remainder < 100):
+            # alert here
+            msg='Alert: {} => email count {} email limit {}'.format(service["service_name"], count, remainder)
+            print(msg)
+
+    return jsonify({})
+
 
 @main.route("/platform-admin")
 @user_is_platform_admin
 def platform_admin():
     form = DateFilterForm(request.args, meta={'csrf': False})
     api_args = {}
-
     form.validate()
 
     if form.start_date.data:
@@ -58,7 +75,7 @@ def platform_admin():
 
     platform_stats = platform_stats_api_client.get_aggregate_platform_stats(api_args)
     number_of_complaints = complaint_api_client.get_complaint_count(api_args)
-
+   
     return render_template(
         'views/platform-admin/index.html',
         form=form,

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -2,9 +2,17 @@ import itertools
 import re
 from collections import OrderedDict
 from datetime import datetime
-from flask import current_app
 
-from flask import jsonify, abort, flash, redirect, render_template, request, url_for
+from flask import (
+    abort,
+    current_app,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
 from notifications_python_client.errors import HTTPError
 from requests import RequestException
 

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -2,6 +2,7 @@ import itertools
 import re
 from collections import OrderedDict
 from datetime import datetime
+from flask import current_app
 
 from flask import jsonify, abort, flash, redirect, render_template, request, url_for
 from notifications_python_client.errors import HTTPError
@@ -43,6 +44,7 @@ COMPLAINT_THRESHOLD = 0.02
 FAILURE_THRESHOLD = 3
 ZERO_FAILURE_THRESHOLD = 0
 
+
 @main.route("/platform-admin/threshold")
 def threshold():
     # detect if a service is near a daily limit
@@ -50,14 +52,14 @@ def threshold():
     for service in allServices:
         stats = service_api_client.get_service_statistics(service["service_id"], True)
         count = stats["email"]["requested"]
-        if(count >1):
-           result = service_api_client.get_service(service["service_id"])["data"]
-           limit = result["message_limit"]
-           remainder = limit - count
-           if(remainder < 100):
-            # alert here
-            msg='Alert: {} => email count {} email limit {}'.format(service["service_name"], count, remainder)
-            print(msg)
+        if(count > 1):
+            result = service_api_client.get_service(service["service_id"])["data"]
+            limit = result["message_limit"]
+            remainder = limit - count
+            if(remainder < 100):
+                # alert here
+                msg = 'Alert: {} => email count {} email limit {}'.format(service["service_name"], count, remainder)
+                current_app.logger.warning(msg)
 
     return jsonify({})
 
@@ -75,7 +77,7 @@ def platform_admin():
 
     platform_stats = platform_stats_api_client.get_aggregate_platform_stats(api_args)
     number_of_complaints = complaint_api_client.get_complaint_count(api_args)
-   
+
     return render_template(
         'views/platform-admin/index.html',
         form=form,


### PR DESCRIPTION
@maxneuvians 

This proof of concept is an effort to get the ball rolling on this.

This new route could be hit via a lambda / cron function and send an alert accordingly.

1)  This is slow
2) This could tax the DB
3) Could be attacked (to slow down the service)

==========

A better approach might be to run a check after a message gets updated pulled off the queue - i.e. a running total for the day... something more realtime as messages get sent.  Maybe save / reset that value to avoid constant expensive lookups.