### PR TITLE
Fix focus styles on email-branding page

### DIFF
--- a/app/templates/views/email-branding/select-branding.html
+++ b/app/templates/views/email-branding/select-branding.html
@@ -10,17 +10,13 @@
 
   {{ page_header('Email branding') }}
   {{ live_search(target_selector='.email-brand', show=True, form=search_form) }}
-  <nav>
-    {% for brand in email_brandings %}
-      <div class="email-brand">
-        <div class="message-name">
-          <a href="{{ url_for('.update_email_branding', branding_id=brand.id) }}">
-            {{ brand.name or 'Unnamed' }}
-          </a>
-        </div>
-      </div>
-    {% endfor %}
-  </nav>
+  {% for brand in email_brandings %}
+    <p class="email-brand">
+      <a href="{{ url_for('.update_email_branding', branding_id=brand.id) }}">
+        {{ brand.name or 'Unnamed' }}
+      </a>
+    </p>
+  {% endfor %}
   <div class="js-stick-at-bottom-when-scrolling">
     <a href="{{ url_for('.create_email_branding') }}" class="button-secondary">{{ _('New brand') }}</a>
   </div>

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -26,7 +26,7 @@ def test_email_branding_page_shows_full_branding_list(
 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    links = page.select('.message-name a')
+    links = page.select('.email-brand a')
     brand_names = [normalize_spaces(link.text) for link in links]
     hrefs = [link['href'] for link in links]
 


### PR DESCRIPTION
I removed some divs and the nav element - not sure why these were there? It is just a simple list of links. I copied the markdown from /platform-admin/reports that also is just a list of links. 

I had to keep the `email-brand` class so the search bar will work.

Closes #390 