### PR TITLE
Displaying send stats for each api key to admin users

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -76,7 +76,11 @@ def safelist(service_id):
 @user_has_permissions('manage_api_keys')
 def api_keys(service_id):
     for item in current_service.api_keys:
-        item["total_sends"] = api_key_api_client.get_api_key_statistics(key_id=item["id"])["total_sends"]
+        results = api_key_api_client.get_api_key_statistics(key_id=item["id"])
+        item["email_sends"] = results["email_sends"]
+        item["sms_sends"] = results["sms_sends"]
+        item["total_sends"] = results["total_sends"]
+        item["last_send"] = results["last_send"]
     return render_template(
         'views/api/keys.html',
     )

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -75,6 +75,8 @@ def safelist(service_id):
 @main.route("/services/<service_id>/api/keys")
 @user_has_permissions('manage_api_keys')
 def api_keys(service_id):
+    for item in current_service.api_keys:
+        item["total_sends"] = api_key_api_client.get_api_key_statistics(key_id=item["id"])["total_sends"]
     return render_template(
         'views/api/keys.html',
     )

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -277,7 +277,6 @@ def aggregate_notifications_stats(template_statistics):
 def get_dashboard_partials(service_id):
     all_statistics = template_statistics_client.get_template_statistics_for_service(service_id, limit_days=7)
     template_statistics = aggregate_template_usage(all_statistics)
-
     scheduled_jobs, immediate_jobs = [], []
     if job_api_client.has_jobs(service_id):
         scheduled_jobs = job_api_client.get_scheduled_jobs(service_id)

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -277,6 +277,7 @@ def aggregate_notifications_stats(template_statistics):
 def get_dashboard_partials(service_id):
     all_statistics = template_statistics_client.get_template_statistics_for_service(service_id, limit_days=7)
     template_statistics = aggregate_template_usage(all_statistics)
+
     scheduled_jobs, immediate_jobs = [], []
     if job_api_client.has_jobs(service_id):
         scheduled_jobs = job_api_client.get_scheduled_jobs(service_id)

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -32,3 +32,4 @@ class ApiKeyApiClient(NotifyAdminAPIClient):
         )['data']
 
 api_key_api_client = ApiKeyApiClient()
+

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -26,5 +26,9 @@ class ApiKeyApiClient(NotifyAdminAPIClient):
             url='/service/{0}/api-key/revoke/{1}'.format(service_id, key_id),
             data=data)
 
+    def get_api_key_statistics(self, key_id):
+        return self.get(
+            url='/api-key/{0}/total-sends'.format(key_id),
+        )['data']
 
 api_key_api_client = ApiKeyApiClient()

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -28,7 +28,7 @@ class ApiKeyApiClient(NotifyAdminAPIClient):
 
     def get_api_key_statistics(self, key_id):
         return self.get(
-            url='/api-key/{0}/total-sends'.format(key_id),
+            url='/api-key/{0}/summary-statistics'.format(key_id),
         )['data']
 
 

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -31,5 +31,5 @@ class ApiKeyApiClient(NotifyAdminAPIClient):
             url='/api-key/{0}/total-sends'.format(key_id),
         )['data']
 
-api_key_api_client = ApiKeyApiClient()
 
+api_key_api_client = ApiKeyApiClient()

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -55,7 +55,7 @@
               Expires: <span class="local-datetime-full">{{ item.expiry_date }}</span>
             </div>
             <div class="hint">
-              Last used: <span class="local-datetime-full">{{ item.last_send }}</span>
+              Last used: <span >{{ item.last_send }}</span>
             </div>
           {% endif %}
         </div>

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -46,16 +46,16 @@
           </div>
           {% if current_user.platform_admin %}
             <div class="hint">
-              {{ item.total_sends }} total sends ({{ item.email_sends }} email, {{ item.sms_sends }} sms)
+              {{ item.total_sends }} {{ _('total sends') }} ({{ item.email_sends }} {{ _('email') }}, {{ item.sms_sends }} {{ _('sms') }})
             </div>
             <div class="hint">
-              Created: <span class="local-datetime-full">{{ item.created_at }}</span>
+              {{ _('Created:') }} <span class="local-datetime-full">{{ item.created_at }}</span>
             </div>
             <div class="hint">
-              Expires: <span class="local-datetime-full">{{ item.expiry_date }}</span>
+              {{ _('Expires') }}: <span class="local-datetime-full">{{ item.expiry_date }}</span>
             </div>
             <div class="hint">
-              Last used: <span >{{ item.last_send }}</span>
+              {{ _('Last used') }}: <span class="local-datetime-full">{{ item.last_send }}</span>
             </div>
           {% endif %}
         </div>

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -41,6 +41,7 @@
             </div>
           {% endif %}
           <div class="hint">
+            {{ _('Key Type:') }}
             {% if item.key_type == 'normal' %}
               {{ _('Live – sends to anyone') }}
             {% elif item.key_type == 'team' %}

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -35,6 +35,11 @@
       {% call field() %}
         <div class="file-list">
           {{ item.name }}
+          {% if current_user.platform_admin %}
+            <div class="hint">
+              {{ item.total_sends }} notifications sent
+            </div>
+          {% endif %}
           <div class="hint">
             {% if item.key_type == 'normal' %}
               {{ _('Live – sends to anyone') }}

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -35,6 +35,11 @@
       {% call field() %}
         <div class="file-list">
           {{ item.name }}
+          {% if current_user.platform_admin %}
+            <div class="hint">
+              {{ "{:,}".format(item.total_sends) }} {{ _('total sends') }} ({{ "{:,}".format(item.email_sends) }} {{ _('email') }}, {{ "{:,}".format(item.sms_sends) }} {{ _('sms') }})
+            </div>
+          {% endif %}
           <div class="hint">
             {% if item.key_type == 'normal' %}
               {{ _('Live – sends to anyone') }}
@@ -45,9 +50,6 @@
             {% endif %}
           </div>
           {% if current_user.platform_admin %}
-            <div class="hint">
-              {{ item.total_sends }} {{ _('total sends') }} ({{ item.email_sends }} {{ _('email') }}, {{ item.sms_sends }} {{ _('sms') }})
-            </div>
             <div class="hint">
               {{ _('Created:') }} <span class="local-datetime-full">{{ item.created_at }}</span>
             </div>

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -41,7 +41,9 @@
             </div>
           {% endif %}
           <div class="hint">
-            {{ _('Key Type:') }}
+            {% if current_user.platform_admin %}
+              {{ _('Key Type:') }}
+            {% endif %}
             {% if item.key_type == 'normal' %}
               {{ _('Live – sends to anyone') }}
             {% elif item.key_type == 'team' %}

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -35,11 +35,6 @@
       {% call field() %}
         <div class="file-list">
           {{ item.name }}
-          {% if current_user.platform_admin %}
-            <div class="hint">
-              {{ item.total_sends }} notifications sent
-            </div>
-          {% endif %}
           <div class="hint">
             {% if item.key_type == 'normal' %}
               {{ _('Live – sends to anyone') }}
@@ -49,6 +44,20 @@
               {{ _('Test – pretends to send messages') }}
             {% endif %}
           </div>
+          {% if current_user.platform_admin %}
+            <div class="hint">
+              {{ item.total_sends }} total sends ({{ item.email_sends }} email, {{ item.sms_sends }} sms)
+            </div>
+            <div class="hint">
+              Created: <span class="local-datetime-full">{{ item.created_at }}</span>
+            </div>
+            <div class="hint">
+              Expires: <span class="local-datetime-full">{{ item.expiry_date }}</span>
+            </div>
+            <div class="hint">
+              Last used: <span class="local-datetime-full">{{ item.last_send }}</span>
+            </div>
+          {% endif %}
         </div>
       {% endcall %}
       {% if item.expiry_date %}

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -376,6 +376,7 @@ def test_route_permissions(
     service_one,
     mock_get_api_keys,
     route,
+    mock_get_api_key_statistics,
 ):
     with app_.test_request_context():
         validate_route_permission(

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -199,6 +199,7 @@ def test_should_show_empty_api_keys_page(
 def test_should_show_api_keys_page(
     client_request,
     mock_get_api_keys,
+    mock_get_api_key_statistics,
 ):
     page = client_request.get('main.api_keys', service_id=SERVICE_ONE_ID)
     rows = [normalize_spaces(row.text) for row in page.select('main tr')]

--- a/tests/app/notify_client/test_api_key_api_client.py
+++ b/tests/app/notify_client/test_api_key_api_client.py
@@ -5,7 +5,7 @@ from app.notify_client.api_key_api_client import ApiKeyApiClient
 
 def test_get_api_key_statistics(mocker, api_user_active):
     api_key_id = uuid.uuid4()
-    expected_url = '/api-key/{}/total-sends'.format(api_key_id)
+    expected_url = '/api-key/{}/summary-statistics'.format(api_key_id)
     client = ApiKeyApiClient()
 
     mock_get = mocker.patch('app.notify_client.api_key_api_client.ApiKeyApiClient.get')

--- a/tests/app/notify_client/test_api_key_api_client.py
+++ b/tests/app/notify_client/test_api_key_api_client.py
@@ -1,0 +1,14 @@
+import uuid
+
+from app.notify_client.api_key_api_client import ApiKeyApiClient
+
+
+def test_get_api_key_statistics(mocker, api_user_active):
+    api_key_id = uuid.uuid4()
+    expected_url = '/api-key/{}/total-sends'.format(api_key_id)
+    client = ApiKeyApiClient()
+
+    mock_get = mocker.patch('app.notify_client.api_key_api_client.ApiKeyApiClient.get')
+
+    client.get_api_key_statistics(api_key_id)
+    mock_get.assert_called_once_with(url=expected_url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1822,6 +1822,13 @@ def mock_get_no_api_keys(mocker):
 
     return mocker.patch('app.api_key_api_client.get_api_keys', side_effect=_get_keys)
 
+@pytest.fixture(scope='function')
+def mock_get_api_key_statistics(mocker):
+    def _get_stats(api_key_id):
+        data = {'total_sends': 20, 'api_key_id': api_key_id}
+        return data
+
+    return mocker.patch('app.api_key_api_client.get_api_key_statistics', side_effect=_get_stats)
 
 @pytest.fixture(scope='function')
 def mock_login(mocker, mock_get_user, mock_update_user_attribute, mock_events):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1827,8 +1827,8 @@ def mock_get_no_api_keys(mocker):
 def mock_get_api_key_statistics(mocker):
     def _get_stats(key_id):
         data = {
-            'total_sends': 20, 
-            'api_key_id': key_id, 
+            'total_sends': 20,
+            'api_key_id': key_id,
             'email_sends': 20,
             'sms_sends': 0,
             'last_send': '2020-03-16T17:32:32.883281Z'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1826,7 +1826,13 @@ def mock_get_no_api_keys(mocker):
 @pytest.fixture(scope='function')
 def mock_get_api_key_statistics(mocker):
     def _get_stats(key_id):
-        data = {'total_sends': 20, 'api_key_id': key_id}
+        data = {
+            'total_sends': 20, 
+            'api_key_id': key_id, 
+            'email_sends': 20,
+            'sms_sends': 0,
+            'last_send': '2020-03-16T17:32:32.883281Z'
+        }
         return data
 
     return mocker.patch('app.api_key_api_client.get_api_key_statistics', side_effect=_get_stats)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1822,6 +1822,7 @@ def mock_get_no_api_keys(mocker):
 
     return mocker.patch('app.api_key_api_client.get_api_keys', side_effect=_get_keys)
 
+
 @pytest.fixture(scope='function')
 def mock_get_api_key_statistics(mocker):
     def _get_stats(api_key_id):
@@ -1829,6 +1830,7 @@ def mock_get_api_key_statistics(mocker):
         return data
 
     return mocker.patch('app.api_key_api_client.get_api_key_statistics', side_effect=_get_stats)
+
 
 @pytest.fixture(scope='function')
 def mock_login(mocker, mock_get_user, mock_update_user_attribute, mock_events):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1825,8 +1825,8 @@ def mock_get_no_api_keys(mocker):
 
 @pytest.fixture(scope='function')
 def mock_get_api_key_statistics(mocker):
-    def _get_stats(api_key_id):
-        data = {'total_sends': 20, 'api_key_id': api_key_id}
+    def _get_stats(key_id):
+        data = {'total_sends': 20, 'api_key_id': key_id}
         return data
 
     return mocker.patch('app.api_key_api_client.get_api_key_statistics', side_effect=_get_stats)


### PR DESCRIPTION
This won't work until my other PR is merged: https://github.com/cds-snc/notification-api/pull/698

698 is now merged, review app is working, here is a page where you can see the change (if your account is a platform admin): https://notification-api-key-st-tjgp75.herokuapp.com/services/10a12f7f-43dd-4828-b690-af5ac4f0b598/api/keys