### PR TITLE
get env vars dynamically in tests

### DIFF
--- a/tests/app/s3_client/test_s3_csv_client.py
+++ b/tests/app/s3_client/test_s3_csv_client.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock
 
+from flask import current_app
+
 from app.s3_client.s3_csv_client import set_metadata_on_csv_upload
 
 
@@ -14,7 +16,7 @@ def test_sets_metadata(client, mocker):
 
     mocked_get_s3_object.assert_called_once_with('1234', '5678')
     mocked_s3_object.copy_from.assert_called_once_with(
-        CopySource='notification-alpha-canada-ca-csv-upload/service-1234-notify/5678.csv',
+        CopySource=current_app.config['CSV_UPLOAD_BUCKET_NAME'] + '/service-1234-notify/5678.csv',
         Metadata={'baz': 'True', 'foo': 'bar'},
         MetadataDirective='REPLACE',
         ServerSideEncryption='AES256',

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -414,6 +414,6 @@ def test_report_security_finding(mocker):
     client.get_caller_identity.return_value = {"Account": "123456789"}
     report_security_finding("foo", "bar", 50, 50)
 
-    boto_client.client.assert_called_with('securityhub', region_name='us-east-1')
+    boto_client.client.assert_called_with('securityhub', region_name=current_app.config['AWS_REGION'])
     client.get_caller_identity.assert_called()
     client.batch_import_findings.assert_called()


### PR DESCRIPTION
Two tests used hard-coded values of two environment variables that were different than the corresponding staging values, so that the tests would fail locally. This changes those tests to use the values from the environment rather than the hard-coded values.