### PR TITLE
Set preview back button more dynamically

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -787,20 +787,28 @@ def is_current_user_the_recipient():
 
 def get_back_link(service_id, template, step_index):
     if get_help_argument():
-        if step_index == 0:
+        if request.endpoint == 'main.check_notification':
             return url_for(
-                'main.start_tour',
+                'main.send_test',
                 service_id=service_id,
                 template_id=template.id,
+                help=get_help_argument()
             )
-        elif step_index > 0:
-            return url_for(
-                'main.send_test_step',
-                service_id=service_id,
-                template_id=template.id,
-                step_index=step_index - 1,
-                help=2,
-            )
+        else:
+            if step_index == 0:
+                return url_for(
+                    'main.start_tour',
+                    service_id=service_id,
+                    template_id=template.id,
+                )
+            elif step_index > 0:
+                return url_for(
+                    'main.send_test_step',
+                    service_id=service_id,
+                    template_id=template.id,
+                    step_index=step_index - 1,
+                    help=2,
+                )
     elif is_current_user_the_recipient() and step_index > 0:
         return url_for(
             'main.send_test_step',

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -380,6 +380,9 @@ def send_test_step(service_id, template_id, step_index):
         prefill_current_user=(request.endpoint == 'main.send_test_step'),
     )
 
+    # used to set the back link in the check_notification screen
+    session['send_step'] = request.endpoint
+
     try:
         current_placeholder = placeholders[step_index]
     except IndexError:
@@ -875,7 +878,8 @@ def _check_notification(service_id, template_id, exception=None):
         page_count=get_page_count_for_letter(db_template),
     )
 
-    back_link = get_back_link(service_id, template, len(fields_to_fill_in(template)))
+    step_index = len(fields_to_fill_in(template, prefill_current_user=(session.get('send_step') == 'main.send_test_step')))
+    back_link = get_back_link(service_id, template, step_index)
 
     if (
         (

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -787,29 +787,34 @@ def is_current_user_the_recipient():
 
 def get_back_link(service_id, template, step_index):
     if get_help_argument():
-        # if we're on the check page, redirect back to the beginning. anywhere else, don't return the back link
-        if request.endpoint == 'main.check_notification':
+        if step_index == 0:
             return url_for(
-                'main.send_test',
+                'main.start_tour',
                 service_id=service_id,
                 template_id=template.id,
-                help=get_help_argument()
             )
-        else:
-            if step_index == 0:
-                return url_for(
-                    'main.start_tour',
-                    service_id=service_id,
-                    template_id=template.id,
-                )
-            elif step_index > 0:
-                return url_for(
-                    'main.send_test_step',
-                    service_id=service_id,
-                    template_id=template.id,
-                    step_index=step_index - 1,
-                    help=2,
-                )
+        elif step_index > 0:
+            return url_for(
+                'main.send_test_step',
+                service_id=service_id,
+                template_id=template.id,
+                step_index=step_index - 1,
+                help=2,
+            )
+    elif is_current_user_the_recipient() and step_index > 0:
+        return url_for(
+            'main.send_test_step',
+            service_id=service_id,
+            template_id=template.id,
+            step_index=step_index - 1,
+        )
+    elif is_current_user_the_recipient() and step_index == 0:
+        return url_for(
+            'main.send_one_off_step',
+            service_id=service_id,
+            template_id=template.id,
+            step_index=0,
+        )
     elif step_index == 0:
         if should_skip_template_page(template.template_type):
             return url_for(
@@ -822,21 +827,6 @@ def get_back_link(service_id, template, step_index):
                 service_id=service_id,
                 template_id=template.id,
             )
-    elif is_current_user_the_recipient() and step_index > 1:
-        return url_for(
-            'main.send_test_step',
-            service_id=service_id,
-            template_id=template.id,
-            step_index=step_index - 1,
-        )
-    elif is_current_user_the_recipient() and step_index == 1:
-        return url_for(
-            'main.send_one_off_step',
-            service_id=service_id,
-            template_id=template.id,
-            step_index=0,
-        )
-
     else:
         return url_for(
             'main.send_one_off_step',

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1603,18 +1603,18 @@ def test_send_test_email_message_without_placeholders_redirects_to_check_page(
 @pytest.mark.parametrize('permissions, expected_back_link_endpoint, extra_args', (
     (
         {'send_messages', 'manage_templates'},
-        'main.view_template',
-        {'template_id': unchanging_fake_uuid}
+        'main.send_one_off_step',
+        {'template_id': unchanging_fake_uuid, 'step_index': 0},
     ),
     (
         {'send_messages'},
-        'main.choose_template',
-        {},
+        'main.send_one_off_step',
+        {'template_id': unchanging_fake_uuid, 'step_index': 0},
     ),
     (
         {'send_messages', 'view_activity'},
-        'main.choose_template',
-        {},
+        'main.send_one_off_step',
+        {'template_id': unchanging_fake_uuid, 'step_index': 0},
     ),
 ))
 def test_send_test_sms_message_with_placeholders_shows_first_field(


### PR DESCRIPTION
fixes https://github.com/cds-snc/notification-api/issues/682

The issue was that the way `step_index` is determined the the screens depends on whether or not the user clicked "Use my email address". The back button on the last page was being set based on one way of setting it (if the user typed in the email address manually).