### PR TITLE
Additional provincial/territorial and federal email domains

### DIFF
--- a/app/email_domains.txt
+++ b/app/email_domains.txt
@@ -7,5 +7,14 @@ gov.ab.ca
 gouv.qc.ca
 rcafinnovation.ca
 canadacouncil.ca
+idrc.ca
 elections.ca
 gov.bc.ca
+gov.mb.ca
+gov.sk.ca
+gnb.ca
+gov.pe.ca
+gov.nl.ca
+gov.yk.ca
+gov.nt.ca
+gov.nu.ca


### PR DESCRIPTION
Added known P/T email domains based on the March 31 green-light. 🚦 