### PR TITLE
Add the inbound SMS option back in

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -209,7 +209,6 @@
           )
           }}
         {% endcall %}
-        <!--
         {% call settings_row(if_has_permission='sms') %}
           {% set txt = _('Receive text messages') %}
           {{ text_field(txt) }}
@@ -222,7 +221,6 @@
           )
           }}
         {% endcall %}
-        -->
       {% endcall %}
      
     {% if current_service.trial_mode %}
@@ -349,15 +347,11 @@
 
           {% for permission in service_permissions %}
             {% if not service_permissions[permission].requires or current_service.has_permission(service_permissions[permission].requires) %}
-
-              {% if not permission == "inbound_sms" %}
-                {% call row() %}
-                  {{ text_field(service_permissions[permission].title)}}
-                  {{ boolean_field(current_service.has_permission(permission)) }}
-                  {{ edit_field('Change', url_for(service_permissions[permission].endpoint or '.service_set_permission', service_id=current_service.id, permission=permission if not service_permissions[permission].endpoint else None)) }}
-                {% endcall %}
-              {% endif %}
-
+              {% call row() %}
+                {{ text_field(service_permissions[permission].title)}}
+                {{ boolean_field(current_service.has_permission(permission)) }}
+                {{ edit_field('Change', url_for(service_permissions[permission].endpoint or '.service_set_permission', service_id=current_service.id, permission=permission if not service_permissions[permission].endpoint else None)) }}
+              {% endcall %}
             {% endif %}
           {% endfor %}
 

--- a/tests/app/main/views/service_settings/test_service_setting_permissions.py
+++ b/tests/app/main/views/service_settings/test_service_setting_permissions.py
@@ -71,6 +71,7 @@ def test_service_set_permission(
     ({'restricted': False}, '.service_switch_live', {}, 'Live On Change'),
     ({'permissions': ['upload_document']}, '.service_switch_can_upload_document', {}, 'Send files by email On Change'),
     ({'permissions': []}, '.service_switch_can_upload_document', {}, 'Send files by email Off Change'),
+    ({'permissions': ['sms']}, '.service_set_inbound_number', {}, 'Receive inbound SMS Off Change'),
     ({'permissions': ['letter']}, '.service_set_permission', {'permission': 'upload_letters'}, 'Uploading letters Off Change'),
 ])
 def test_service_setting_toggles_show(get_service_settings_page, service_one, service_fields, endpoint, kwargs, text):
@@ -106,7 +107,7 @@ def test_service_setting_button_toggles(
 
 
 @pytest.mark.parametrize('permissions,permissions_text,visible', [
-    # ('sms', 'inbound SMS', True),
+    ('sms', 'inbound SMS', True),
     ('inbound_sms', 'inbound SMS', False),                 # no sms parent permission
     # also test no permissions set
     ('', 'inbound SMS', False),

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -73,6 +73,7 @@ def mock_get_service_settings_page_common(
         'Text message senders GOVUK Manage',
         'Start text messages with service name On Change',
         'Send international text messages Off Change',
+        'Receive text messages Off Change',
 
     ]),
     (platform_admin_user, [
@@ -91,6 +92,7 @@ def mock_get_service_settings_page_common(
         'Text message senders GOVUK Manage',
         'Start text messages with service name On Change',
         'Send international text messages Off Change',
+        'Receive text messages Off Change',
 
         'Label Value Action',
         'Live Off Change',
@@ -100,6 +102,7 @@ def mock_get_service_settings_page_common(
         'Email branding default Change',
         'Letter branding Not set Change',
         'Data retention email Change',
+        'Receive inbound SMS Off Change',
         'Email authentication Off Change',
         'Send files by email Off Change',
     ]),
@@ -150,10 +153,10 @@ def test_no_go_live_link_for_service_without_organisation(
     page = client_request.get('main.service_settings', service_id=SERVICE_ONE_ID)
 
     assert page.find('h1').text == 'Settings'
-    assert normalize_spaces(page.select('tr')[13].text) == (
+    assert normalize_spaces(page.select('tr')[14].text) == (
         'Live No (organisation must be set first)'
     )
-    assert normalize_spaces(page.select('tr')[15].text) == (
+    assert normalize_spaces(page.select('tr')[16].text) == (
         'Organisation Not set Central government Change'
     )
 
@@ -178,7 +181,7 @@ def test_organisation_name_links_to_org_dashboard(
         'main.service_settings', service_id=SERVICE_ONE_ID
     )
 
-    org_row = response.select('tr')[15]
+    org_row = response.select('tr')[16]
     assert org_row.find('a')['href'] == url_for('main.organisation_dashboard', org_id=ORGANISATION_ID)
     assert normalize_spaces(org_row.find('a').text) == 'Test Organisation'
 
@@ -199,7 +202,7 @@ def test_organisation_name_links_to_org_dashboard(
         'Text message senders GOVUK Manage',
         'Start text messages with service name On Change',
         'Send international text messages On Change',
-        # 'Receive text messages On Change',
+        'Receive text messages On Change',
 
     ]),
     (['email', 'sms', 'email_auth'], [
@@ -217,7 +220,7 @@ def test_organisation_name_links_to_org_dashboard(
         'Text message senders GOVUK Manage',
         'Start text messages with service name On Change',
         'Send international text messages Off Change',
-        # 'Receive text messages Off Change',
+        'Receive text messages Off Change',
 
     ]),
 ])


### PR DESCRIPTION
Part of https://github.com/cds-snc/notification-api/issues/732

This PR is to re-enable the option for a service to have an inbound SMS number associated with it. We had disabled this feature here: https://github.com/cds-snc/notification-admin/commit/ca1cf32b03df0d3d27800ea20a3ecda536f774bf#diff-bae99f6539d22562f5f956a9bf295549

We need to re-enable it so that we can use it to set a longcode for a given service and use it to send through Pinpoint, as per discussion here: https://github.com/cds-snc/notification-api/pull/772#issuecomment-617288982