### PR TITLE
Dev / local jinja support for preview markup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ venv-freeze/
 notify.code-workspace
 
 schedule-message.html
+
+jinja_templates/

--- a/README.md
+++ b/README.md
@@ -198,3 +198,19 @@ pybabel update -i messages.pot -d app/translations
 ```bash
 pybabel compile -d app/translations
 ```
+
+## Using Local Jinja for template changes
+
+HTML and SMS Preview templates (`sms_preview_template.jinja2, email_preview_template.jinja2`) are pulled in from the [notification-utils](https://github.com/cds-snc/notification-utils) repo. To test jinja changes locally (without needing to update the upstream), follow this procedure:
+
+1. Create a `jinja_templates` folder in the project root directory, and put a .gitignore in it so nothing is tracked or pushed to this repo.
+
+2. Copy `./notification-utils/jinja_templates/email_preview_template.jinja2` and `./notification-utils/jinja_templates/sms_preview_template.jinja2` from [notification-utils](https://github.com/cds-snc/notification-utils) into the `jinja_templates` folder created in step 1
+
+3. Set a new .ENV variable: `USE_LOCAL_JINJA_TEMPLATES=True`
+
+4. Make markup changes, and see them locally!
+
+5. When finished, copy any changed jinja files back to notification-utils, and push up the PR for your changes in that repo.
+
+6. Remove `USE_LOCAL_JINJA_TEMPLATES=True` from your .env file, and delete any jinja in `jinja_templates`. Deleting the folder and jinja files is not required, but recommended. Make sure you're pulling up-to-date jinja from notification-utils the next time you need to make changes.

--- a/README.md
+++ b/README.md
@@ -214,3 +214,5 @@ HTML and SMS Preview templates (`sms_preview_template.jinja2, email_preview_temp
 5. When finished, copy any changed jinja files back to notification-utils, and push up the PR for your changes in that repo.
 
 6. Remove `USE_LOCAL_JINJA_TEMPLATES=True` from your .env file, and delete any jinja in `jinja_templates`. Deleting the folder and jinja files is not required, but recommended. Make sure you're pulling up-to-date jinja from notification-utils the next time you need to make changes.
+
+Note: Tests will break if `USE_LOCAL_JINJA_TEMPLATES` is set to `True` in your .env

--- a/README.md
+++ b/README.md
@@ -215,4 +215,4 @@ HTML and SMS Preview templates (`sms_preview_template.jinja2, email_preview_temp
 
 6. Remove `USE_LOCAL_JINJA_TEMPLATES=True` from your .env file, and delete any jinja in `jinja_templates`. Deleting the folder and jinja files is not required, but recommended. Make sure you're pulling up-to-date jinja from notification-utils the next time you need to make changes.
 
-Note: Tests will break if `USE_LOCAL_JINJA_TEMPLATES` is set to `True` in your .env
+Note: Tests may break if `USE_LOCAL_JINJA_TEMPLATES` is set to `True` in your .env

--- a/README.md
+++ b/README.md
@@ -199,20 +199,10 @@ pybabel update -i messages.pot -d app/translations
 pybabel compile -d app/translations
 ```
 
-## Using Local Jinja for template changes
+## Using Local Jinja for testing template changes
 
-HTML and SMS Preview templates (`sms_preview_template.jinja2, email_preview_template.jinja2`) are pulled in from the [notification-utils](https://github.com/cds-snc/notification-utils) repo. To test jinja changes locally (without needing to update the upstream), follow this procedure:
+See the [notification-api](https://github.com/cds-snc/notification-api) README for detailed instructions.
 
-1. Create a `jinja_templates` folder in the project root directory, and put a .gitignore in it so nothing is tracked or pushed to this repo.
-
-2. Copy `./notification-utils/jinja_templates/email_preview_template.jinja2` and `./notification-utils/jinja_templates/sms_preview_template.jinja2` from [notification-utils](https://github.com/cds-snc/notification-utils) into the `jinja_templates` folder created in step 1
-
-3. Set a new .ENV variable: `USE_LOCAL_JINJA_TEMPLATES=True`
-
-4. Make markup changes, and see them locally!
-
-5. When finished, copy any changed jinja files back to notification-utils, and push up the PR for your changes in that repo.
-
-6. Remove `USE_LOCAL_JINJA_TEMPLATES=True` from your .env file, and delete any jinja in `jinja_templates`. Deleting the folder and jinja files is not required, but recommended. Make sure you're pulling up-to-date jinja from notification-utils the next time you need to make changes.
+Template files used in this repo: `sms_preview_template.jinja2, email_preview_template.jinja2`
 
 Note: Tests may break if `USE_LOCAL_JINJA_TEMPLATES` is set to `True` in your .env

--- a/app/utils.py
+++ b/app/utils.py
@@ -381,6 +381,12 @@ def get_template(
     email_reply_to=None,
     sms_sender=None,
 ):
+     # Local Jinja support - add USE_LOCAL_JINJA_TEMPLATES=True to .env
+     # Add a folder to the project root called 'jinja_templates' with copies from notification-utls repo of:
+     # 'email_preview_template.jinja2'
+     # 'sms_preview_template.jinja2'
+    debug_template_path = path.dirname(path.abspath(__file__)) if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is not None else None
+    print(debug_template_path)
     if 'email' == template['template_type']:
         return EmailPreviewTemplate(
             template,
@@ -389,6 +395,7 @@ def get_template(
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
             reply_to=email_reply_to,
+            jinja_path=debug_template_path
         )
     if 'sms' == template['template_type']:
         return SMSPreviewTemplate(
@@ -399,6 +406,7 @@ def get_template(
             show_sender=bool(sms_sender),
             show_recipient=show_recipient,
             redact_missing_personalisation=redact_missing_personalisation,
+            jinja_path=debug_template_path
         )
     if 'letter' == template['template_type']:
         if letter_preview_url:

--- a/app/utils.py
+++ b/app/utils.py
@@ -381,12 +381,13 @@ def get_template(
     email_reply_to=None,
     sms_sender=None,
 ):
-     # Local Jinja support - add USE_LOCAL_JINJA_TEMPLATES=True to .env
-     # Add a folder to the project root called 'jinja_templates' with copies from notification-utls repo of:
-     # 'email_preview_template.jinja2'
-     # 'sms_preview_template.jinja2'
-    debug_template_path = path.dirname(path.abspath(__file__)) if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is not None else None
-    print(debug_template_path)
+    # Local Jinja support - add USE_LOCAL_JINJA_TEMPLATES=True to .env
+    # Add a folder to the project root called 'jinja_templates' with copies from notification-utls repo of:
+    # 'email_preview_template.jinja2'
+    # 'sms_preview_template.jinja2'
+    debug_template_path = (path.dirname(path.abspath(__file__))
+                           if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is not None else None)
+
     if 'email' == template['template_type']:
         return EmailPreviewTemplate(
             template,

--- a/app/utils.py
+++ b/app/utils.py
@@ -386,7 +386,7 @@ def get_template(
     # 'email_preview_template.jinja2'
     # 'sms_preview_template.jinja2'
     debug_template_path = (path.dirname(path.abspath(__file__))
-                           if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is 'True' else None)
+                           if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') == 'True' else None)
 
     if 'email' == template['template_type']:
         return EmailPreviewTemplate(

--- a/app/utils.py
+++ b/app/utils.py
@@ -386,7 +386,7 @@ def get_template(
     # 'email_preview_template.jinja2'
     # 'sms_preview_template.jinja2'
     debug_template_path = (path.dirname(path.abspath(__file__))
-                           if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is not None else None)
+                           if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is 'True' else None)
 
     if 'email' == template['template_type']:
         return EmailPreviewTemplate(

--- a/application.py
+++ b/application.py
@@ -24,6 +24,7 @@ if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') == 'True':
     print('========================================================')  # noqa: T001
     print('')  # noqa: T001
     print('WARNING: USING LOCAL JINJA from /jinja_templates FOLDER!')  # noqa: T001
+    print('.env USE_LOCAL_JINJA_TEMPLATES=True')  # noqa: T001
     print('')  # noqa: T001
     print('========================================================')  # noqa: T001
     print('')  # noqa: T001

--- a/application.py
+++ b/application.py
@@ -19,3 +19,12 @@ application = Flask('app')
 application.wsgi_app = ProxyFix(application.wsgi_app)
 
 create_app(application)
+
+if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') == 'True':
+    print('')  # noqa: T001
+    print('========================================================')  # noqa: T001
+    print('')  # noqa: T001
+    print('WARNING: USING LOCAL JINJA from /jinja_templates FOLDER!')  # noqa: T001
+    print('')  # noqa: T001
+    print('========================================================')  # noqa: T001
+    print('')  # noqa: T001

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -33,4 +33,4 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@40.0.2#egg=notifications-utils==40.0.2
+git+https://github.com/cds-snc/notifier-utils.git@41.0.0#egg=notifications-utils==41.0.0

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,7 +4,7 @@
 ago==0.0.93
 Flask==1.1.2
 Flask-WTF==0.14.3
-Flask-Login==0.5.0
+Flask-Login==0.4.1
 
 blinker==1.4
 pyexcel==0.5.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 ago==0.0.93
 Flask==1.1.2
 Flask-WTF==0.14.3
-Flask-Login==0.4.1
+Flask-Login==0.5.0
 
 blinker==1.4
 pyexcel==0.5.15
@@ -35,13 +35,13 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@40.0.2#egg=notifications-utils==40.0.2
+git+https://github.com/cds-snc/notifier-utils.git@41.0.0#egg=notifications-utils==41.0.0
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.39
-bleach==3.1.4
+awscli==1.18.45
+bleach==3.1.1
 boto3==1.12.13
-botocore==1.15.39
+botocore==1.15.45
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.1
@@ -79,9 +79,9 @@ six==1.14.0
 smartypants==2.0.1
 statsd==3.3.0
 texttable==1.6.2
-urllib3==1.25.8
+urllib3==1.25.9
 webencodings==0.5.1
 Werkzeug==1.0.1
-WTForms==2.2.1
+WTForms==2.3.1
 xlrd==1.2.0
 xlwt==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 ago==0.0.93
 Flask==1.1.2
 Flask-WTF==0.14.3
-Flask-Login==0.5.0
+Flask-Login==0.4.1
 
 blinker==1.4
 pyexcel==0.5.15
@@ -82,6 +82,6 @@ texttable==1.6.2
 urllib3==1.25.9
 webencodings==0.5.1
 Werkzeug==1.0.1
-WTForms==2.3.1
+WTForms==2.2.1
 xlrd==1.2.0
 xlwt==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ git+https://github.com/cds-snc/notifier-utils.git@41.0.0#egg=notifications-utils
 
 ## The following requirements were added by pip freeze:
 awscli==1.18.45
-bleach==3.1.1
+bleach==3.1.4
 boto3==1.12.13
 botocore==1.15.45
 certifi==2020.4.5.1


### PR DESCRIPTION
Part of https://github.com/cds-snc/notification-api/issues/759

Allows email and SMS preview template jinja to be modified locally and viewed in the local admin.

Tests will fail until notification_utils has been updated