### PR TITLE
Fix stats for api key revoke page

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -131,6 +131,12 @@ def create_api_key(service_id):
 @user_has_permissions('manage_api_keys')
 def revoke_api_key(service_id, key_id):
     key_name = current_service.get_api_key(key_id)['name']
+    for item in current_service.api_keys:
+        results = api_key_api_client.get_api_key_statistics(key_id=item["id"])
+        item["email_sends"] = results["email_sends"]
+        item["sms_sends"] = results["sms_sends"]
+        item["total_sends"] = results["total_sends"]
+        item["last_send"] = results["last_send"]
     if request.method == 'GET':
         flash([
             "{} ‘{}’?".format(_l('Are you sure you want to revoke'), key_name),

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -131,12 +131,6 @@ def create_api_key(service_id):
 @user_has_permissions('manage_api_keys')
 def revoke_api_key(service_id, key_id):
     key_name = current_service.get_api_key(key_id)['name']
-    for item in current_service.api_keys:
-        results = api_key_api_client.get_api_key_statistics(key_id=item["id"])
-        item["email_sends"] = results["email_sends"]
-        item["sms_sends"] = results["sms_sends"]
-        item["total_sends"] = results["total_sends"]
-        item["last_send"] = results["last_send"]
     if request.method == 'GET':
         flash([
             "{} ‘{}’?".format(_l('Are you sure you want to revoke'), key_name),

--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -35,7 +35,10 @@
       {% call field() %}
         <div class="file-list">
           {{ item.name }}
-          {% if current_user.platform_admin %}
+          {% if (current_user.platform_admin and 
+              'total_sends' in item and
+              'email_sends' in item and
+              'sms_sends' in item )  %}
             <div class="hint">
               {{ "{:,}".format(item.total_sends) }} {{ _('total sends') }} ({{ "{:,}".format(item.email_sends) }} {{ _('email') }}, {{ "{:,}".format(item.sms_sends) }} {{ _('sms') }})
             </div>

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -4,8 +4,8 @@ from unittest.mock import call
 from uuid import uuid4
 
 import pytest
-from flask import url_for
 from bs4 import BeautifulSoup
+from flask import url_for
 
 from tests import sample_uuid, validate_route_permission
 from tests.conftest import (
@@ -328,6 +328,7 @@ def test_should_show_confirm_revoke_api_key(
         ),
     ]
 
+
 def test_should_show_confirm_revoke_api_key_for_platform_admin(
     platform_admin_client,
     mock_get_api_keys,
@@ -336,7 +337,7 @@ def test_should_show_confirm_revoke_api_key_for_platform_admin(
     url = url_for(
         'main.revoke_api_key', service_id=SERVICE_ONE_ID, key_id=fake_uuid,
         _test_page_title=False,
-        )
+    )
     response = platform_admin_client.get(url)
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert normalize_spaces(page.select('.banner-dangerous')[0].text) == (

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import pytest
 from flask import url_for
+from bs4 import BeautifulSoup
 
 from tests import sample_uuid, validate_route_permission
 from tests.conftest import (
@@ -316,6 +317,28 @@ def test_should_show_confirm_revoke_api_key(
         'main.revoke_api_key', service_id=SERVICE_ONE_ID, key_id=fake_uuid,
         _test_page_title=False,
     )
+    assert normalize_spaces(page.select('.banner-dangerous')[0].text) == (
+        'Are you sure you want to revoke ‘some key name’? '
+        'You will not be able to use this API key to connect to Notify '
+        'Yes, revoke this API key'
+    )
+    assert mock_get_api_keys.call_args_list == [
+        call(
+            '596364a0-858e-42c8-9062-a8fe822260eb'
+        ),
+    ]
+
+def test_should_show_confirm_revoke_api_key_for_platform_admin(
+    platform_admin_client,
+    mock_get_api_keys,
+    fake_uuid,
+):
+    url = url_for(
+        'main.revoke_api_key', service_id=SERVICE_ONE_ID, key_id=fake_uuid,
+        _test_page_title=False,
+        )
+    response = platform_admin_client.get(url)
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert normalize_spaces(page.select('.banner-dangerous')[0].text) == (
         'Are you sure you want to revoke ‘some key name’? '
         'You will not be able to use this API key to connect to Notify '


### PR DESCRIPTION
The keys.html template is rendered for the "are you sure you want to revoke this api key?" page. So the sending stats will appear there if you are a platform admin. But I forgot to add the stats to the `current_service` object for that render.

I added a check that the data exists before trying to display it on the page. And I added a test that platform admins can revoke keys. __There was a test that regular users can revoke api keys, but no test that platform admins can do that.__ This means some sending stats are missing from the revoke page, but I think that is okay since they are still visible on the main page.