### PR TITLE
Fix dependency not found issue

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,7 +8,7 @@ Flask-Login==0.4.1
 Flask-Caching==1.8.0
 
 blinker==1.4
-pyexcel==0.6.0
+pyexcel==0.6.1
 pyexcel-io==0.5.20
 pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-Login==0.4.1
 Flask-Caching==1.8.0
 
 blinker==1.4
-pyexcel==0.6.0
+pyexcel==0.6.1
 pyexcel-io==0.5.20
 pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.8
@@ -39,10 +39,10 @@ itsdangerous==0.24  # pyup: <1.0.0
 git+https://github.com/cds-snc/notifier-utils.git@41.0.1#egg=notifications-utils==41.0.1
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.49
+awscli==1.18.51
 bleach==3.1.4
 boto3==1.12.13
-botocore==1.15.49
+botocore==1.16.1
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.2
@@ -79,6 +79,7 @@ s3transfer==0.3.3
 six==1.14.0
 smartypants==2.0.1
 statsd==3.3.0
+texttable==1.6.2
 urllib3==1.25.9
 webencodings==0.5.1
 Werkzeug==1.0.1


### PR DESCRIPTION
Ran into this:
![Screen Shot 2020-05-04 at 9 08 33 AM](https://user-images.githubusercontent.com/5498428/80981848-bdd47280-8de7-11ea-9c7c-f45536411302.png)


Updated pyexcel since the version we were specifying did not exist?! ran make freeze-requirements