### PR TITLE
Add FR translations for some (most?) of the "x days ago" type strings

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,7 @@
 import itertools
 import os
 import urllib
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from functools import partial
 from numbers import Number
 from time import monotonic

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,6 @@ from functools import partial
 from numbers import Number
 from time import monotonic
 
-import ago
 from flask import (
     current_app,
     flash,
@@ -358,24 +357,6 @@ def _format_datetime_short(datetime):
     return datetime.strftime('%d %B').lstrip('0')
 
 
-def format_delta(date):
-    delta = (
-        datetime.now(timezone.utc)
-    ) - (
-        utc_string_to_aware_gmt_datetime(date)
-    )
-    if delta < timedelta(seconds=30):
-        return "just now"
-    if delta < timedelta(seconds=60):
-        return "in the last minute"
-    return ago.human(
-        delta,
-        future_tense='{} from now',  # No-one should ever see this
-        past_tense='{} ago',
-        precision=1
-    )
-
-
 def format_thousands(value):
     if isinstance(value, Number):
         return '{:,.0f}'.format(value)
@@ -719,7 +700,6 @@ def add_template_filters(application):
         format_date_normal,
         format_date_short,
         format_datetime_relative,
-        format_delta,
         format_notification_status,
         format_notification_type,
         format_notification_status_as_time,

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -47,7 +47,48 @@ window.formatAllDates = function () {
       $(this).text(`${dayStr}, ${timeStr}`);
     }
   });
+  
+  // fr from here: https://github.com/rmm5t/jquery-timeago/blob/master/locales/jquery.timeago.fr.js
+  // en from here: https://github.com/rmm5t/jquery-timeago/blob/master/locales/jquery.timeago.en.js
+  // I removed "about"/"environ" to match the existing language returned by the python ago package
+  let timeAgoSettings = {
+    fr: {
+      prefixAgo: "il y a",
+      prefixFromNow: "d'ici",
+      seconds: "moins d'une minute",
+      minute: "une minute",
+      minutes: "%d minutes",
+      hour: "une heure",
+      hours: "%d heures",
+      day: "un jour",
+      days: "%d jours",
+      month: "un mois",
+      months: "%d mois",
+      year: "un an",
+      years: "%d ans"
+    },
+    en: {
+      prefixAgo: null,
+      prefixFromNow: null,
+      suffixAgo: "ago",
+      suffixFromNow: "from now",
+      seconds: "less than a minute",
+      minute: "a minute",
+      minutes: "%d minutes",
+      hour: "an hour",
+      hours: "%d hours",
+      day: "a day",
+      days: "%d days",
+      month: "a month",
+      months: "%d months",
+      year: "a year",
+      years: "%d years",
+      wordSeparator: " ",
+      numbers: []
+    }
+  };
 
+  window.jQuery.timeago.settings.strings = timeAgoSettings[window.APP_LANG];
   $(() => $("time.timeago").timeago());
 
 }

--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -59,7 +59,7 @@
             </span>
             <span class="column-half api-notifications-item-time">
               <time class="timeago" datetime="{{ notification.created_at }}">
-                {{ notification.created_at|format_delta }}
+                {{ notification.created_at }}
               </time>
             </span>
           </span>

--- a/app/templates/views/dashboard/_inbox.html
+++ b/app/templates/views/dashboard/_inbox.html
@@ -13,7 +13,10 @@
       }}
       <div class="big-number-meta">
         {% if inbound_sms_summary.most_recent %}
-          latest message {{ inbound_sms_summary.most_recent | format_delta }}
+          {{ _("latest message") }} 
+          <time class="timeago" datetime="{{ inbound_sms_summary.most_recent }}">
+            {{ inbound_sms_summary.most_recent }}
+          </time>
         {% endif %}
       </div>
     </div>

--- a/app/templates/views/dashboard/_inbox_messages.html
+++ b/app/templates/views/dashboard/_inbox_messages.html
@@ -30,7 +30,9 @@
     {% endcall %}
     {% call field(align='right') %}
       <span class="align-with-message-body">
-        {{ item.created_at | format_delta }}
+        <time class="timeago" datetime="{{ item.created_at }}">
+          {{ item.created_at }}
+        </time>
       </span>
     {% endcall %}
   {% endcall %}

--- a/app/templates/views/find-users/user-information.html
+++ b/app/templates/views/find-users/user-information.html
@@ -51,7 +51,7 @@
       {% else %}
       <p>{{ _('Last logged in') }}
         <time class="timeago" datetime="{{ user.logged_in_at }}">
-          {{ user.logged_in_at|format_delta }}
+          {{ user.logged_in_at }}
         </time>
       </p>
       {% endif %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -51,7 +51,7 @@
         {% set last_edited = _('Last edited') %}
         {{ last_edited }}
         <time class="timeago" datetime="{{ template._template.updated_at }}">
-          {{ template._template.updated_at|format_delta }}
+          {{ template._template.updated_at }}
         </time>
       </h2>
 

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -53,7 +53,12 @@
         {% set txt = _('Password') %}
         {% set last_change_txt = _('Last changed ') %}
         {{ text_field(txt) }}
-        {{ text_field(last_change_txt + current_user.password_changed_at|format_delta) }}
+        {% call field(status="") %}
+          {{ last_change_txt }}
+          <time class="timeago" datetime="{{current_user.password_changed_at}}">
+            {{ current_user.password_changed_at }}
+          </time>
+        {% endcall %}
         {{ edit_field(change, url_for('.user_profile_password')) }}
       {% endcall %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,10 +39,11 @@ itsdangerous==0.24  # pyup: <1.0.0
 git+https://github.com/cds-snc/notifier-utils.git@41.0.1#egg=notifications-utils==41.0.1
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.51
+astroid==2.4.0
+awscli==1.18.52
 bleach==3.1.4
 boto3==1.12.13
-botocore==1.16.1
+botocore==1.16.2
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.2
@@ -55,12 +56,15 @@ flask-redis==0.4.0
 future==0.18.2
 greenlet==0.4.15
 idna==2.9
+isort==4.3.21
 jdcal==1.4.1
 Jinja2==2.11.2
 jmespath==0.9.5
+lazy-object-proxy==1.4.3
 lml==0.0.9
 lxml==4.5.0
 MarkupSafe==1.1.1
+mccabe==0.6.1
 mistune==0.8.4
 monotonic==1.5
 openpyxl==3.0.3
@@ -69,6 +73,7 @@ phonenumbers==8.10.13
 pyasn1==0.4.8
 pyexcel-ezodf==0.3.4
 PyJWT==1.7.1
+pylint==2.5.0
 PyPDF2==1.26.0
 python-dateutil==2.8.1
 python-json-logger==0.1.11
@@ -80,8 +85,11 @@ six==1.14.0
 smartypants==2.0.1
 statsd==3.3.0
 texttable==1.6.2
+toml==0.10.0
+typed-ast==1.4.1
 urllib3==1.25.9
 webencodings==0.5.1
 Werkzeug==1.0.1
+wrapt==1.12.1
 xlrd==1.2.0
 xlwt==1.3.0


### PR DESCRIPTION
Working on https://github.com/cds-snc/notification-api/issues/774

I didn't think this was going to be very easy/possible, but it turns out we were already using a jquery plugin called [timeago](https://timeago.yarp.com/) that supports french! It was being used for formatting some of the "x time ago" type strings. So I just replaced the python ago library with that one. Will keep this a draft until I fix the tests. 

Here are the new screens:

User settings:
<img width="1018" alt="Screen Shot 2020-05-04 at 3 40 09 PM" src="https://user-images.githubusercontent.com/5498428/81017626-1f183800-8e20-11ea-8b1b-cb750dea826c.png">

Recent sends:
<img width="751" alt="Screen Shot 2020-05-04 at 3 39 30 PM" src="https://user-images.githubusercontent.com/5498428/81017643-2a6b6380-8e20-11ea-87d6-2ed283e33990.png">

Template preview page for a template that has been edited:
<img width="725" alt="Screen Shot 2020-05-04 at 3 42 36 PM" src="https://user-images.githubusercontent.com/5498428/81017634-23445580-8e20-11ea-8f87-f91a3c462200.png">

@anikbrazeau can you take a look at these and let me know if you see any problems?