### PR TITLE
Fix the label display for send-test.html

### DIFF
--- a/app/templates/views/send-test.html
+++ b/app/templates/views/send-test.html
@@ -9,11 +9,18 @@ class='js-stick-at-top-when-scrolling send-one-off-form' if
 template.template_type != 'sms' else 'send-one-off-form', module="autofocus",
 data_kwargs={'force-focus': True} ) %}
 <div class="grid-row">
+  {% set form_label = form.placeholder_value.label.text %}
   <div
-    class="column-two-thirds {% if form.placeholder_value.label.text == 'phone number' %}extra-tracking{% endif %}"
+    class="column-two-thirds {% if form_label == 'phone number' %}extra-tracking{% endif %}"
   >
-    {% set hint_txt = _('Optional') %} {{ textbox( form.placeholder_value,
-    hint=hint_txt if optional_placeholder else None, width='1-1', ) }}
+    {% set hint_txt = _('Optional') %}
+    {% if form_label == 'phone number' %}
+      {{ textbox( form.placeholder_value,
+    label=_(form.placeholder_value.label.text)|capitalize, hint=hint_txt if optional_placeholder else None, width='1-1', ) }}
+    {% else %}
+      {{ textbox( form.placeholder_value,
+      label=form.placeholder_value.label.text|capitalize, hint=hint_txt if optional_placeholder else None, width='1-1', ) }}
+  {% endif %}
   </div>
   {% if skip_link %}
   <div class="column-one-third">

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -1136,31 +1136,31 @@ def test_send_one_off_or_test_has_correct_page_titles(
         'main.send_test_step',
         0,
         {'phone number': '6502532222'},
-        'one',
+        'One',
     ),
     (
         'main.send_test_step',
         1,
         {'phone number': '6502532222', 'one': 'one'},
-        'two',
+        'Two',
     ),
     (
         'main.send_one_off_step',
         0,
         {},
-        'phone number',
+        'Phone number',
     ),
     (
         'main.send_one_off_step',
         1,
         {'phone number': '6502532222'},
-        'one',
+        'One',
     ),
     (
         'main.send_one_off_step',
         2,
         {'phone number': '6502532222', 'one': 'one'},
-        'two',
+        'Two',
     ),
 ])
 def test_send_one_off_or_test_shows_placeholders_in_correct_order(
@@ -1394,7 +1394,7 @@ def test_link_to_upload_not_offered_when_entering_personalisation(
 
     # We’re entering personalisation
     assert page.select_one('input[type=text]')['name'] == 'placeholder_value'
-    assert page.select_one('label[for=placeholder_value]').text.strip() == 'name'
+    assert page.select_one('label[for=placeholder_value]').text.strip() == 'Name'
     # …but first link on the page is ‘Back’, so not preceeded by ‘Upload’
     assert page.select_one('main a').text == 'Back'
     assert 'Upload' not in page.select_one('main').text
@@ -1641,7 +1641,7 @@ def test_send_test_sms_message_with_placeholders_shows_first_field(
         _follow_redirects=True,
     )
 
-    assert page.select('label')[0].text.strip() == 'name'
+    assert page.select('label')[0].text.strip() == 'Name'
     assert page.select('input')[0]['name'] == 'placeholder_value'
     assert page.select('.govuk-back-link')[0]['href'] == url_for(
         expected_back_link_endpoint,
@@ -1854,7 +1854,7 @@ def test_send_test_indicates_optional_address_columns(
     )
 
     assert normalize_spaces(page.select('label')[0].text) == (
-        'address line 4 '
+        'Address line 4 '
         'Optional'
     )
     assert page.select('.govuk-back-link')[0]['href'] == url_for(


### PR DESCRIPTION
Fixes part of https://github.com/cds-snc/notification-api/issues/782

<img width="711" alt="Screen Shot 2020-05-08 at 3 12 25 PM" src="https://user-images.githubusercontent.com/5498428/81452248-a4169080-9143-11ea-8ee9-821a5f741d54.png">
<img width="737" alt="Screen Shot 2020-05-08 at 3 11 57 PM" src="https://user-images.githubusercontent.com/5498428/81452256-a678ea80-9143-11ea-9413-4354a3bfef0d.png">


I'm not sure how to fix the yellow placeholder text yet, so that will be a separate pr. 