### PR TITLE
Add assistance link to menu header

### DIFF
--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -122,7 +122,7 @@ Canada Notification service') %} {% set meta_title = _('GC Notify | GC notificat
             class="text-small text-blue mr-10 font-bold no-underline hover:underline"
             >{{ _("Technical documentation") }}</a>
           <a
-            href="{{ _('url.freshdesk.home') }}"
+            href="{{ _('https://notification.assistance.cds-snc.ca/en/support/home') }}"
             class="text-small text-blue mr-10 font-bold no-underline hover:underline"
             >{{ _("FAQs & Assistance") }}</a>
           <a

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -122,6 +122,10 @@ Canada Notification service') %} {% set meta_title = _('GC Notify | GC notificat
             class="text-small text-blue mr-10 font-bold no-underline hover:underline"
             >{{ _("Technical documentation") }}</a>
           <a
+            href="{{ _('url.freshdesk.home') }}"
+            class="text-small text-blue mr-10 font-bold no-underline hover:underline"
+            >{{ _("FAQs & Assistance") }}</a>
+          <a
             href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}"
             class="text-small text-blue mr-10 font-bold no-underline hover:underline"
             >{{ _("Contact us") }}

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -153,6 +153,12 @@ Canada Notification service') %} {% set meta_title = _('GC Notify | GC notificat
           <li>
             <a
               class="block text-small mb-5 no-underline hover:underline"
+              href="{{ _('https://notification.assistance.cds-snc.ca/en/support/home') }}"
+              >{{ _("FAQs & Assistance") }}</a>
+          </li>
+          <li>
+            <a
+              class="block text-small mb-5 no-underline hover:underline"
               href="{{ url_for('.feedback', ticket_type='ask-question-give-feedback') }}"
               >{{ _("Contact us") }}</a>
           </li>

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -154,7 +154,7 @@ Canada Notification service') %} {% set meta_title = _('GC Notify | GC notificat
             <a
               class="block text-small mb-5 no-underline hover:underline"
               href="{{ _('https://notification.assistance.cds-snc.ca/en/support/home') }}"
-              >{{ _("FAQs & Assistance") }}</a>
+              >{{ _("FAQ & Assistance") }}</a>
           </li>
           <li>
             <a


### PR DESCRIPTION
We're often answering the same questions in the support channel which takes a lot of time away from being able to build the application. We want to let users have the best experience possible and to do so we should allow them to find answers to their questions and get the support they need.

This is a first pass at adding a link to Freshdesk's Knowledge Base.

Another thing that we should probably do in a future PR is change the Technical Documentation link to point directly to https://notification.assistance.cds-snc.ca/en/support/solutions/folders/61000161438 since this answers another of the most frequently asked questions which is regarding the base API url.


French content:
https://notification.assistance.cds-snc.ca/en/support/home => 
https://notification.assistance.cds-snc.ca/fr/support/home

FAQs & Assistance = > Assistance et FAQ
