### PR TITLE
Fix overlapping FR text on template page

### DIFF
--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -32,8 +32,16 @@ $sticky-padding: $gutter * 2 / 3;
     }
 
   }
-
+  .template-list-selected-counter {
+    position: relative;
+    top: 0px;
+    margin-top: 15px;
+    margin-bottom: 15px;
+    right: 0px;
+  }
 }
+
+
 
 .js-stick-at-top-when-scrolling {
 

--- a/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/components/stick-at-top-when-scrolling.scss
@@ -41,8 +41,6 @@ $sticky-padding: $gutter * 2 / 3;
   }
 }
 
-
-
 .js-stick-at-top-when-scrolling {
 
   margin-top: -10px;


### PR DESCRIPTION
Closes https://github.com/cds-snc/notification-api/issues/753

FR nothing selected:
<img width="853" alt="Screen Shot 2020-05-14 at 2 32 57 PM" src="https://user-images.githubusercontent.com/5498428/81983213-3c06f500-95f0-11ea-9ebc-1e6e55397e05.png">

FR something selected:
<img width="818" alt="Screen Shot 2020-05-14 at 2 33 21 PM" src="https://user-images.githubusercontent.com/5498428/81983223-40331280-95f0-11ea-9d24-042e1738969f.png">

EN nothing selected: 
<img width="1067" alt="Screen Shot 2020-05-14 at 2 34 06 PM" src="https://user-images.githubusercontent.com/5498428/81983278-58a32d00-95f0-11ea-858f-39bd191eb783.png">

