### PR TITLE
Delete Select template content dropdown and related code

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -564,21 +564,12 @@ def add_service_template(service_id, template_type, template_folder_id=None):
             template_id='0'
         ))
     else:
-        template_select = []
-
-        if(template_type == "email"):
-            templates = template_api_prefill_client.get_template_list()
-            if(templates):
-                for template in templates:
-                    template_select.append({'id': template["id"], 'name': template["name"]})
-
         return render_template(
             'views/edit-{}-template.html'.format(template_type),
             form=form,
             template_type=template_type,
             template_folder_id=template_folder_id,
             service_id=service_id,
-            template_select=template_select,
             heading_action=_l('New'),
         )
 

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -16,21 +16,6 @@ call form_wrapper() %}
         >{{ _('Formatting Guide') }}</a
       >
     </div>
-    <!-- prefill-template -->
-    <div>
-      <hr />
-      <label class="form-label" for="prefill-template"
-        >{{ _('Select template content') }}</label
-      >
-      <select name="prefill-template" id="prefill-template">
-        <option value=""></option>
-        {% for result in template_select %}
-        <option value="{{result.id}}">{{result.name}}</option>
-        {% endfor %}
-      </select>
-      <hr />
-    </div>
-    <!-- end prefill-template -->
 
     {% set hint_txt = _('Your recipients won’t see this:') %} {{
     textbox(form.name, width='1-1', hint=hint_txt, rows=10) }} {{
@@ -62,55 +47,6 @@ call form_wrapper() %}
       }
     });
   };
-
-  $("#prefill-template").on("change", function() {
-    const hasVal = $("#template_content").val();
-    const templateId = $(this)
-      .children("option:selected")
-      .val();
-
-    const clear_text = '{{ _("This will clear existing content") }}';
-    const confirm_text = '{{ _("Are you sure?") }}';
-    const okay_button = '{{ _("Okay") }}';
-    const cancel_button = '{{ _("Cancel") }}';
-
-    if (hasVal === "") {
-      if (templateId) {
-        loadContent(templateId);
-      } else {
-        $("#template_content").val("");
-      }
-      return;
-    }
-
-    Swal.fire({
-      title: `<strong>${confirm_text}</strong>`,
-      icon: "warning",
-      html: clear_text,
-      showCloseButton: false,
-      showCancelButton: true,
-      focusConfirm: true,
-      confirmButtonText: okay_button,
-      cancelButtonText: cancel_button,
-      customClass: {
-        container: "confirm-container-class",
-        confirmButton: "button",
-        cancelButton: "button-secondary",
-        showClass: "",
-        hideClass: ""
-      },
-      buttonsStyling: false
-    }).then(result => {
-      if (result.value) {
-        if (templateId) {
-          loadContent(templateId);
-        } else {
-          $("#template_content").val("");
-        }
-      }
-    });
-  });
-  //template_content
 </script>
 
 <style>

--- a/app/translations/csv/en.csv
+++ b/app/translations/csv/en.csv
@@ -473,7 +473,6 @@
 "Direct connection to API",""
 "email template",""
 "Formatting Guide","How to format your notification"
-"Select template content",""
 "Your recipients won’t see this:","Your recipients will not see this template name."
 "Save",""
 "loading...",""

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -473,7 +473,6 @@
 "Direct connection to API","Connexion directe à l'API"
 "email template","gabarit de courriel"
 "Formatting Guide","Comment mettre en forme votre notification"
-"Select template content","Sélectionner le contenu du gabarit"
 "Your recipients won’t see this:","Vos destinataires ne verront pas le nom du gabarit."
 "Save","Enregistrer"
 "loading...","chargement en cours..."


### PR DESCRIPTION
fixes https://github.com/cds-snc/notification-api/issues/841
fixes https://github.com/cds-snc/notification-api/issues/852

delete the "Select template content" dropdown and related code / translation

Now:

<img width="626" alt="image" src="https://user-images.githubusercontent.com/8228248/83293485-ddc63e80-a1b9-11ea-8d22-8fe787c06308.png">

Note that I have deleted both horizontal rules. I noticed that the "New text message template" has neither the dropdown nor the rules.

<img width="555" alt="image" src="https://user-images.githubusercontent.com/8228248/83293684-09e1bf80-a1ba-11ea-96c2-58f5cdff7d66.png">

