### PR TITLE
Fix broken 'remove team members' feature

### DIFF
--- a/app/templates/views/edit-user-permissions.html
+++ b/app/templates/views/edit-user-permissions.html
@@ -39,7 +39,7 @@
 
         {{ page_footer(
           _('Save'),
-          delete_link=url_for('.delete_smtp', service_id=current_service.id, user_id=user.id, delete='yes'),
+          delete_link=url_for('.edit_user_permissions', service_id=current_service.id, user_id=user.id, delete='yes'),
           delete_link_text=_('Remove this team member')
         ) }}
 


### PR DESCRIPTION
The delete user from service link was hooked up to deleting an SMTP server here:
https://github.com/cds-snc/notification-admin/commit/284835ed4366d546266c1878eca3382c3d1bdd83#diff-da2d347c80668a389e2bce8685bd290e

I am unsure if this was a mistake or not. It may be worth checking with @timarney , and checking that SMTP hasn't been affected, but unless this page was also being used to manage SMTP users (which I don't see evidence of in the code), I can't see how this would break it.

Fixes: https://github.com/cds-snc/notification-api/issues/893