### PR TITLE
translate entire trial mode error message

### DIFF
--- a/app/templates/partials/check/not-allowed-to-send-to.html
+++ b/app/templates/partials/check/not-allowed-to-send-to.html
@@ -1,10 +1,9 @@
 <h1 class='banner-title' data-module="track-error" data-error-type="Trial mode: bad recipients" data-error-label="{{ upload_id }}">
-  {{ _('You can’t send to') }}
-  {{ _('this') if count_of_recipients == 1 else _('these') }}
+  {{ _('You can’t send to') + ' ' }}
   {%- if count_of_recipients == 1 -%}
-    {{ ' ' + _(template_type_label) }}
+    {{ _('this email address') if template_type_label == 'email address' else _('this phone number') }}
   {% else %}
-    {{ _('email addresses') if 'email address' == template_type_label else _('phone numbers') }}
+    {{ _('these email addresses') if template_type_label == 'email address' else _('these phone numbers') }}
   {%- endif %}
 </h1>
 <p>

--- a/app/templates/partials/check/not-allowed-to-send-to.html
+++ b/app/templates/partials/check/not-allowed-to-send-to.html
@@ -1,9 +1,10 @@
 <h1 class='banner-title' data-module="track-error" data-error-type="Trial mode: bad recipients" data-error-label="{{ upload_id }}">
   {{ _('You can’t send to') }}
-  {{ 'this' if count_of_recipients == 1 else 'these' }}
-  {{ template_type_label }}
-  {%- if count_of_recipients != 1 -%}
-    {{ 'es' if 'email address' == template_type_label else 's' }}
+  {{ _('this') if count_of_recipients == 1 else _('these') }}
+  {%- if count_of_recipients == 1 -%}
+    {{ ' ' + _(template_type_label) }}
+  {% else %}
+    {{ _('email addresses') if 'email address' == template_type_label else _('phone numbers') }}
   {%- endif %}
 </h1>
 <p>

--- a/app/translations/csv/en.csv
+++ b/app/translations/csv/en.csv
@@ -322,6 +322,8 @@
 "characters.",""
 "Your message is",""
 "You can’t send to",""
+"this",""
+"these",""
 "In",""
 "you can only
   send to yourself and members of your team",""

--- a/app/translations/csv/en.csv
+++ b/app/translations/csv/en.csv
@@ -322,8 +322,10 @@
 "characters.",""
 "Your message is",""
 "You can’t send to",""
-"this",""
-"these",""
+"this email address",""
+"this phone number",""
+"these email addresses",""
+"these phone numbers",""
 "In",""
 "you can only
   send to yourself and members of your team",""

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -322,8 +322,10 @@
 "characters.","caractères."
 "Your message is","Votre message est"
 "You can’t send to","Vous ne pouvez pas faire d'envoi à"
-"this","cette"
-"these","ces"
+"this email address","cette adresse courriel"
+"this phone number","cette numéro de téléphone"
+"these email addresses","ces adresses courriel"
+"these phone numbers","ces numéros de téléphone"
 "In","En"
 "you can only
   send to yourself and members of your team","les envois sont limités à vous et aux membres de votre équipe."

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -322,6 +322,8 @@
 "characters.","caractères."
 "Your message is","Votre message est"
 "You can’t send to","Vous ne pouvez pas faire d'envoi à"
+"this","cette"
+"these","ces"
 "In","En"
 "you can only
   send to yourself and members of your team","les envois sont limités à vous et aux membres de votre équipe."


### PR DESCRIPTION
Closes https://github.com/cds-snc/notification-api/issues/842

We weren’t translating “email address” or “phone number” before.

To test: in trial mode service, check English and French error messages when sending to outside team:
- 1 phone number, 2+ phone numbers, 1 sms, 2+ sms 