### PR TITLE
Wrap unwrapped string in dashboard

### DIFF
--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -51,7 +51,7 @@
         notifications,
         caption=uploaded_file_name,
         caption_visible=False,
-        empty_message="No messages to show",
+        empty_message=_("No messages to show"),
         field_headings=[
           heading_1,
           heading_2


### PR DESCRIPTION
Closes https://github.com/cds-snc/notification-api/issues/889
(see the comments below - this fixes the "No messages to show" not being wrapped)