### PR TITLE
Fix missing bullet on homepage

### DIFF
--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -286,7 +286,7 @@ set description = _('Notify lets you send emails and text messages to your users
          {% endif %}
          </div>
           <ul class="list-disc ml-5">
-            <li class="pt-10 lg:pt-0 flex">
+            <li class="pt-4">
               {{ _("Staff who regularly write and send service updates wishing to upgrade the tools used to communicate with the public") }}
             </li>
             <li class="pt-4">


### PR DESCRIPTION
Closes https://github.com/cds-snc/notification-api/issues/927

This looks like it was just a typo in the markdown.

![Screen Shot 2020-06-11 at 2 16 47 PM](https://user-images.githubusercontent.com/5498428/84434982-351ed280-abee-11ea-868c-329bcac0e4ca.png)
