### PR TITLE
Add email domains for pen tester

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -50,6 +50,10 @@ with open('{}/email_domains.txt'.format(
 )) as email_domains:
     GOVERNMENT_EMAIL_DOMAIN_NAMES = [line.strip() for line in email_domains]
 
+# --- Delete after penetration testing ---
+if os.environ.get('NOTIFY_ENVIRONMENT', None) == 'development':
+    GOVERNMENT_EMAIL_DOMAIN_NAMES.extend(['gmail.com', 'strivesec.com'])
+# --- Delete after penetration testing ---
 
 user_is_logged_in = login_required
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -51,7 +51,10 @@ with open('{}/email_domains.txt'.format(
     GOVERNMENT_EMAIL_DOMAIN_NAMES = [line.strip() for line in email_domains]
 
 # --- Delete after penetration testing ---
-if os.environ.get('NOTIFY_ENVIRONMENT', None) == 'development':
+is_dev = os.environ.get('NOTIFY_ENVIRONMENT', None) == 'development'
+is_heroku = 'staging' in os.environ.get('API_HOST_NAME', '')
+is_staging = 'staging' in os.environ.get('ADMIN_BASE_URL', '')
+if is_dev or is_heroku or is_staging:
     GOVERNMENT_EMAIL_DOMAIN_NAMES.extend(['gmail.com', 'strivesec.com'])
 # --- Delete after penetration testing ---
 


### PR DESCRIPTION
closes https://github.com/cds-snc/notification-api/issues/960

add gmail.com and strivesec.com domains for pen testing on staging.

changes only applied if `NOTIFY_ENVIRONMENT` is `development`, so production is safe.