### PR TITLE
skip template tutorial

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -66,16 +66,15 @@ def add_service():
         )
         if error:
             return render_template('views/add-service.html', form=form, heading=heading)
-        if len(service_api_client.get_active_services({'user_id': session['user_id']}).get('data', [])) > 1:
-            return redirect(url_for('main.service_dashboard', service_id=service_id))
 
-        example_email_template = _create_example_template(service_id)
+        return redirect(url_for('main.service_dashboard', service_id=service_id))
 
-        return redirect(url_for(
-            'main.start_tour',
-            service_id=service_id,
-            template_id=example_email_template['data']['id']
-        ))
+        # example_email_template = _create_example_template(service_id)
+        # return redirect(url_for(
+        #     'main.start_tour',
+        #     service_id=service_id,
+        #     template_id=example_email_template['data']['id']
+        # ))
     else:
         return render_template(
             'views/add-service.html',

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -33,17 +33,6 @@ def _create_service(service_name, organisation_type, email_from, form):
             raise e
 
 
-def _create_example_template(service_id):
-    example_email_template = service_api_client.create_service_template(
-        'Example email template',
-        'email',
-        'Hey ((name)), I’m trying out Notify. Today is ((day of week)) and my favourite colour is ((colour)).',
-        service_id,
-        subject='Example email template'
-    )
-    return example_email_template
-
-
 @main.route("/add-service", methods=['GET', 'POST'])
 @user_is_logged_in
 @user_is_gov_user

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -69,12 +69,6 @@ def add_service():
 
         return redirect(url_for('main.service_dashboard', service_id=service_id))
 
-        # example_email_template = _create_example_template(service_id)
-        # return redirect(url_for(
-        #     'main.start_tour',
-        #     service_id=service_id,
-        #     template_id=example_email_template['data']['id']
-        # ))
     else:
         return render_template(
             'views/add-service.html',

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -203,7 +203,6 @@ def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
     client_request,
     mock_create_service,
     mock_create_service_template,
-    mock_get_services,
     mock_get_organisation_by_domain,
     api_user_active,
     organisation_type,
@@ -224,7 +223,6 @@ def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
             _external=True,
         )
     )
-    assert mock_get_services.called
     mock_create_service.assert_called_once_with(
         service_name='testing the post',
         organisation_type=organisation_type,


### PR DESCRIPTION
resolves https://github.com/cds-snc/notification-api/issues/901

New users are prompted to create a service, then instead of going to the example template they go directly to the service dashboard:

![image](https://user-images.githubusercontent.com/8228248/84678731-5dfcdb80-aefe-11ea-9449-801c0f319b89.png)
