### PR TITLE
Remove pricing link from homepage

### DIFF
--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -554,14 +554,6 @@ set description = _('Notify lets you send emails and text messages to your users
                 {{ _("<i>Notify</i> is a service managed by the Canadian Digital Service — no external procurement." )}}
               </li>
             </ul>
-
-            <div class="pt-10">
-              <a
-                class="line-under text-blue text-base underline hover:no-underline"
-                href="{{ url_for('main.pricing') }}"
-                >{{ _("Learn more about pricing") }}</a
-              >
-            </div>
           </div>
         </div>
       </div>

--- a/app/translations/csv/en.csv
+++ b/app/translations/csv/en.csv
@@ -678,7 +678,6 @@
 "Use <i>Notify</i> for free and replace paper letters or costly third-party messaging services.",""
 "Send unlimited emails, completely free.",""
 "<i>Notify</i> is a service managed by the Canadian Digital Service — no external procurement.",""
-"Learn more about pricing",""
 "Notify by the numbers",""
 "Since November 2019",""
 "services using Notify",""

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -674,7 +674,6 @@
 "Use <i>Notify</i> for free and replace paper letters or costly third-party messaging services.","Vous pouvez utiliser <i>Notification</i> afin de remplacer vos lettres papier ou vos services de messagerie tiers coûteux."
 "Send unlimited emails, completely free.","Envoyer un nombre illimité de courriels, tout à fait gratuitement."
 "<i>Notify</i> is a service managed by the Canadian Digital Service — no external procurement.","<i>Notification</i> est un service géré par le Service numérique canadien, sans autres achats externes."
-"Learn more about pricing","En savoir plus sur les coûts"
 "Notify by the numbers","Notification en chiffres"
 "Since November 2019","Depuis novembre 2019"
 "services using Notify","services qui utilisent Notification"


### PR DESCRIPTION
Removing the link to the pricing page, which adds no additional information.

Same info (about it being free) is found on Emails/Text message pages in features and on homepage.