### PR TITLE
translate landmark aria-labels

### DIFF
--- a/app/templates/components/sub-navigation.html
+++ b/app/templates/components/sub-navigation.html
@@ -13,7 +13,7 @@
 {% macro sub_navigation(
   item_set
 ) %}
-  <nav aria-label="sub-navigation" id="sub-navigation" class="sub-navigation">
+  <nav aria-label="{{ _('sub-navigation') }}" id="sub-navigation" class="sub-navigation">
     <ol itemscope itemtype="http://schema.org/ItemList">
       {% for item in item_set %}
         {{ sub_navigation_item(item) }}

--- a/app/templates/main_template.html
+++ b/app/templates/main_template.html
@@ -182,7 +182,7 @@
           </a>
           </div>
           <!-- start sub nav -->
-          <nav aria-label="Language & Login" class="flex pt-4 mb-10 lg:mb-0">
+          <nav aria-label="{{ _('language and login') }}" class="flex pt-4 mb-10 lg:mb-0">
             <a
               class="mr-10 line-under leading-none inline-block text-blue text-small underline hover:no-underline"
               href="{{ url_for('main.set_lang')}}?from={{request.path}}"
@@ -221,7 +221,7 @@
       </div>
 
       <!-- start main nav -->
-      <nav class="bg-gray py-5" aria-label="main navigation">
+      <nav class="bg-gray py-5" aria-label="{{ _('main navigation') }}">
         <div class="container px-10">
           <div class="lg:hidden">
             <a
@@ -311,7 +311,7 @@
     <div id="global-app-error" class="app-error hidden"></div>
 
     <!-- start section 9 -->
-    <footer aria-label="footer menu">
+    <footer aria-label="{{ _('footer menu') }}">
       <div class="bg-blue">
         <div class="container px-10 py-24">
           <nav class="flex aria-label="footer links">

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -84,7 +84,7 @@ set description = _('Notify lets you send emails and text messages to your users
           </div>
         </div>
         <!-- start sub nav -->
-        <nav aria-label="Language & Login" class="flex pt-4 mb-10 lg:mb-0">
+        <nav aria-label="{{ _('language and login') }}" class="flex pt-4 mb-10 lg:mb-0">
           <a
             class="line-under leading-none inline-block text-blue text-small underline hover:no-underline"
             href="{{ url_for('main.set_lang')}}?from={{request.path}}"

--- a/app/translations/csv/en.csv
+++ b/app/translations/csv/en.csv
@@ -1,4 +1,8 @@
 "source","target"
+"language and login",""
+"main navigation",""
+"sub-navigation",""
+"footer menu",""
 "From",""
 "To",""
 "Subject",""

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1,4 +1,8 @@
 "source","target"
+"language and login","langue et connexion"
+"main navigation","navigation principale"
+"sub-navigation","sous-navigation"
+"footer menu","menu de bas de page"
 "From","De"
 "To","À"
 "Subject","Objet"


### PR DESCRIPTION
resolves https://github.com/cds-snc/notification-api/issues/936

translate some landmark aria-labels.

"banner", "main", etc are HTML roles and I assume we should let the a11y software deal with them as is standard.

![image](https://user-images.githubusercontent.com/8228248/85155518-d927ff80-b226-11ea-9c6d-62da1d030933.png)

![image](https://user-images.githubusercontent.com/8228248/85155563-e644ee80-b226-11ea-817d-0669d8665c91.png)
