### PR TITLE
return 400 rather than 500 for newline in params

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -732,7 +732,10 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
         # We want the Flask in browser stacktrace
         if current_app.config.get('DEBUG', None):
             raise error
-        return _error_response(500)
+        if "Detected newline in header value" in str(error):
+            return _error_response(400)
+        else:
+            return _error_response(500)
 
 
 def setup_event_handlers():


### PR DESCRIPTION
We were returning 500 (Internal Server Error) for requests containing newlines in param values, when we should return 400 (Bad Request).

Why? The server is behaving properly in rejecting the request (as if it was accepted it could lead to a header injection if we weren't careful in how we handled the param values). So the problem isn't that the server had an error, but rather that the request was malformed.

To test: go to `/set-lang?from=%0Aid&from=%2f` You should get a 500 on staging and a 400 in the review app.

Note that locally we actually raise the error instead of handling it, so will get a 500 regardless.