### PR TITLE
Script to search translation csvs for keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ notify.code-workspace
 schedule-message.html
 
 jinja_templates/
+scripts/searchresults.csv

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ babel:
 	csv2po app/translations/csv/fr.csv app/translations/fr/LC_MESSAGES/messages.po
 	pybabel compile -d app/translations
 
+.PHONY: search-csv
+search-csv:
+	python scripts/search_csv.py
+
 .PHONY: freeze-requirements
 freeze-requirements:
 	rm -rf venv-freeze

--- a/scripts/search_csv.py
+++ b/scripts/search_csv.py
@@ -15,7 +15,7 @@ def search_single_file(filename):
             for keyword in keywords:
                 # lower case everything to make matches easier to find
                 if keyword in row['source'].lower() or keyword in row['target'].lower():
-                    # append the translated string
+                    # append the translated string if it exists
                     d.append({"keyword": keyword, "found_string": row['source'] if row['target'] == '' else row['target']})
                     continue
     return d

--- a/scripts/search_csv.py
+++ b/scripts/search_csv.py
@@ -1,0 +1,43 @@
+import csv
+import os
+
+# input keywords here, lowercase
+keywords = []
+# example
+# keywords = ["can't","can’t","cannot","can not"]
+
+
+def search_single_file(filename):
+    d = []
+    with open(filename, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            for keyword in keywords:
+                # lower case everything to make matches easier to find
+                if keyword in row['source'].lower() or keyword in row['target'].lower():
+                    # append the translated string
+                    d.append({"keyword": keyword, "found_string": row['source'] if row['target'] == '' else row['target']})
+                    continue
+    return d
+
+
+def search_translation_strings():
+    cwd = os.getcwd()
+
+    d = []
+
+    # english
+    d = d + search_single_file(cwd + "/app/translations/csv/en.csv")
+
+    # french
+    d = d + search_single_file(cwd + "/app/translations/csv/fr.csv")
+
+    # write results
+    with open(cwd + '/scripts/searchresults.csv', 'w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=["keyword", "found_string"])
+        writer.writeheader()
+        for row in d:
+            writer.writerow({"keyword": row["keyword"], "found_string": row["found_string"]})
+
+
+search_translation_strings()


### PR DESCRIPTION
To use:
1. In line 5 of `/scripts/search-csv.py`, input the keywords you want to search for.
2. run `make search-csv`
3. The results will appear in the scripts folder in a file named `searchresults.csv`. The generated csv shows which keyword was found, and then prints the translated string (if it exists). If it doesn't have a translated string, the source string is used instead. This allows both English and French csvs to be searched in one run.

Note: This file is not deleted after running the script, so that the results can be viewed. You'll have to manually get rid of it once you're done with it.

Closes https://github.com/cds-snc/notification-api/issues/982 