### PR TITLE
Blocked users can't reset password

### DIFF
--- a/app/main/views/forgot_password.py
+++ b/app/main/views/forgot_password.py
@@ -14,7 +14,7 @@ def forgot_password():
         try:
             user_api_client.send_reset_password_url(form.email_address.data)
         except HTTPError as e:
-            if e.status_code == 400:
+            if e.status_code == 400 and 'user blocked' in str(e.response.content):
                 flash(_("You cannot reset your password as your account has been blocked. Please email us at assistance@cds-snc.ca"))
                 abort(400)
             elif e.status_code == 404:

--- a/app/main/views/forgot_password.py
+++ b/app/main/views/forgot_password.py
@@ -1,4 +1,5 @@
-from flask import render_template
+from flask import abort, flash, render_template, flash
+from flask_babel import _
 from notifications_python_client.errors import HTTPError
 
 from app import user_api_client
@@ -13,7 +14,10 @@ def forgot_password():
         try:
             user_api_client.send_reset_password_url(form.email_address.data)
         except HTTPError as e:
-            if e.status_code == 404:
+            if e.status_code == 400:
+                flash(_("You cannot reset your password as your account has been blocked. Please email us at assistance@cds-snc.ca"))
+                abort(400)
+            elif e.status_code == 404:
                 return render_template('views/password-reset-sent.html')
             else:
                 raise e

--- a/app/main/views/forgot_password.py
+++ b/app/main/views/forgot_password.py
@@ -1,4 +1,4 @@
-from flask import abort, flash, render_template, flash
+from flask import abort, flash, render_template
 from flask_babel import _
 from notifications_python_client.errors import HTTPError
 
@@ -15,7 +15,8 @@ def forgot_password():
             user_api_client.send_reset_password_url(form.email_address.data)
         except HTTPError as e:
             if e.status_code == 400 and 'user blocked' in str(e.response.content):
-                flash(_("You cannot reset your password as your account has been blocked. Please email us at assistance@cds-snc.ca"))
+                flash(_('You cannot reset your password as your account has been blocked. '
+                        + 'Please email us at assistance@cds-snc.ca'))
                 abort(400)
             elif e.status_code == 404:
                 return render_template('views/password-reset-sent.html')

--- a/app/translations/csv/en.csv
+++ b/app/translations/csv/en.csv
@@ -548,6 +548,7 @@
 "Data available for",""
 "days",""
 "Click the link in the email to reset your password.",""
+"You cannot reset your password as your account has been blocked. Please email us at assistance@cds-snc.ca",""
 "Privacy notice: how we use your data",""
 "Your account will be created with this email address:",""
 "We’ll send you a security code by text message",""

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -547,6 +547,7 @@
 "Data available for","Données disponibles pendant"
 "days","jours"
 "Click the link in the email to reset your password.","Cliquez sur le lien dans le courriel pour réinitialiser votre mot de passe."
+"You cannot reset your password as your account has been blocked. Please email us at assistance@cds-snc.ca","Vous ne pouvez pas réinitialiser votre mot de passe car votre compte a été bloqué. Veuillez nous contacter par courriel : assistance@cds-snc.ca"
 "Privacy notice: how we use your data","Avis de confidentialité : comment nous utilisons vos données"
 "Your account will be created with this email address:","Votre compte sera créé avec cette adresse courriel :"
 "We’ll send you a security code by text message","Nous vous enverrons un code de sécurité par message texte."


### PR DESCRIPTION
deal with api not allowing blocked users to reset password

blocked users trying to reset their password get an error

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/8228248/86799983-8fba1b80-c040-11ea-9709-fceccda0105c.png">
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/8228248/86800039-9ea0ce00-c040-11ea-93d0-a423cfb4e0a8.png">

Corresponding api PR: https://github.com/cds-snc/notification-api/pull/1013