### PR TITLE
use safelist api interface

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -322,11 +322,11 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.get(url='/service/{}/notifications/monthly?year={}'.format(service_id, year))
 
     def get_safelist(self, service_id):
-        return self.get(url='/service/{}/whitelist'.format(service_id))
+        return self.get(url='/service/{}/safelist'.format(service_id))
 
     @cache.delete('service-{service_id}')
     def update_safelist(self, service_id, data):
-        return self.put(url='/service/{}/whitelist'.format(service_id), data=data)
+        return self.put(url='/service/{}/safelist'.format(service_id), data=data)
 
     def get_inbound_sms(self, service_id, user_number=''):
         # POST prevents the user phone number leaking into our logs


### PR DESCRIPTION
re https://github.com/cds-snc/notification-api/issues/962

use the `/service/**/safelist` api route instead of instead of `/service/**/whitelist`

requires https://github.com/cds-snc/notification-api/pull/1056

To test: run both this PR and https://github.com/cds-snc/notification-api/pull/1056 locally and go to `/services/**/api/safelist`. (currently on master we still use the old `/service/**/whitelist` api route)