### PR TITLE
rename master branch name to main

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,41 +1,41 @@
 name: Build, push to GCR, and deploy
 on:
   push:
-    branches:    
-      - master
+    branches:
+      - main
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Build and push
     steps:
-    - uses: actions/checkout@master
-    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-      with:
-        version: '270.0.0'
-        service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-        service_account_key: ${{ secrets.GCLOUD_AUTH }}
-    - run: |
-        gcloud auth configure-docker
-    - name: Build
-      run: |        
-        docker build --build-arg GIT_SHA=${GITHUB_SHA::7} -t gcr.io/cdssnc/notify/admin:${GITHUB_SHA::7} -t gcr.io/cdssnc/notify/admin:latest -f ci/Dockerfile .
-    - name: Publish
-      run: |
-        docker push gcr.io/cdssnc/notify/admin:latest && docker push gcr.io/cdssnc/notify/admin:${GITHUB_SHA::7}
-    - name: EKS
-      uses: docker://gcr.io/cdssnc/aws:latest
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      with:
-        args: eks --region ca-central-1 update-kubeconfig --name notification-staging-2020-04-01
-    - name: Apply
-      uses: docker://gcr.io/cdssnc/aws-kubectl:latest
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      with:
-        args: set image deployment.apps/admin admin=gcr.io/cdssnc/notify/admin:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=/github/home/.kube/config
-    - uses: cds-snc/notification-pr-bot@master
-      env:
-        TOKEN: ${{ secrets.TOKEN }}
+      - uses: actions/checkout@main
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: "270.0.0"
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCLOUD_AUTH }}
+      - run: |
+          gcloud auth configure-docker
+      - name: Build
+        run: |
+          docker build --build-arg GIT_SHA=${GITHUB_SHA::7} -t gcr.io/cdssnc/notify/admin:${GITHUB_SHA::7} -t gcr.io/cdssnc/notify/admin:latest -f ci/Dockerfile .
+      - name: Publish
+        run: |
+          docker push gcr.io/cdssnc/notify/admin:latest && docker push gcr.io/cdssnc/notify/admin:${GITHUB_SHA::7}
+      - name: EKS
+        uses: docker://gcr.io/cdssnc/aws:latest
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:
+          args: eks --region ca-central-1 update-kubeconfig --name notification-staging-2020-04-01
+      - name: Apply
+        uses: docker://gcr.io/cdssnc/aws-kubectl:latest
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:
+          args: set image deployment.apps/admin admin=gcr.io/cdssnc/notify/admin:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=/github/home/.kube/config
+      - uses: cds-snc/notification-pr-bot@master
+        env:
+          TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/secret.yaml
+++ b/.github/workflows/secret.yaml
@@ -5,6 +5,6 @@ jobs:
     name: seekret-scanning
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: docker://cdssnc/seekret-github-action
-      uses: docker://cdssnc/seekret-github-action
+      - uses: actions/checkout@main
+      - name: docker://cdssnc/seekret-github-action
+        uses: docker://cdssnc/seekret-github-action


### PR DESCRIPTION
re https://github.com/cds-snc/notification-api/issues/1062

similar to https://github.com/cds-snc/covid-alert-portal

This PR doesn't actually rename the default branch, just changes the code to use the `main` branch rather than `master` for building images. See 
https://gist.github.com/ccopsey/9866a0bcb0b39ade04fe
for details on how we'll change the default branch to `main`

Note: Github plans to make this process less manual later this year: https://github.com/github/renaming#later-this-year

Process:
1) copy `master` into new `main` branch
2) add `main` branch to branch protection rules
3) make `main` the name of the default branch in GitHub
4) change this PR so it merges into main rather than master
5) merge the PR
6) check [status](https://staging.notification.cdssandbox.xyz/_status) to ensure that the new `main` was deployed
7) delete `master` branch