### PR TITLE
Remove extra character in template

### DIFF
--- a/app/templates/views/service-settings/sms-senders.html
+++ b/app/templates/views/service-settings/sms-senders.html
@@ -52,6 +52,6 @@
     </div>
   {% endif %}
   <p>
-    {{ _('The text message sender tells your users who the message is from.') }}'
+    {{ _('The text message sender tells your users who the message is from.') }}
   </p>
 {% endblock %}


### PR DESCRIPTION
There is an extra character (`'`) at the end of the translated string in the template, removing it.

> The text message sender tells your users who the message is from.'

![Screen Shot 2020-09-14 at 11 22 12](https://user-images.githubusercontent.com/295709/93105072-9edeca80-f67c-11ea-9d4a-93123881d73b.png)
