### PR TITLE
Reset failed login attempts when unblocking users

### DIFF
--- a/app/main/views/find_users.py
+++ b/app/main/views/find_users.py
@@ -51,6 +51,7 @@ def unblock_user(user_id):
     if request.method == 'POST':
         user = User.from_id(user_id)
         user.update(blocked=False, updated_by=current_user.id)
+        user.reset_failed_login_count()
         return redirect(url_for('.user_information', user_id=user_id))
     else:
         flash([_('Are you sure you want to unblock this user?')], 'unblock')

--- a/tests/app/main/views/test_find_users.py
+++ b/tests/app/main/views/test_find_users.py
@@ -228,6 +228,23 @@ def test_archive_user_prompts_for_confirmation(
     assert 'Are you sure you want to archive this user?' in page.find('div', class_='banner-dangerous').text
 
 
+def test_unblock_user_resets_failed_login_count(
+    platform_admin_client,
+    api_user_active,
+    mocker,
+):
+    mock_user_client = mocker.patch('app.user_api_client.post')
+
+    response = platform_admin_client.post(
+        url_for('main.unblock_user', user_id=api_user_active['id'])
+    )
+    assert response.status_code == 302
+    assert response.location == url_for('main.user_information', user_id=api_user_active['id'], _external=True)
+    mock_user_client.assert_called_once_with(
+        '/user/{}/reset-failed-login-count'.format(api_user_active['id']), data={}
+    )
+
+
 def test_archive_user_posts_to_user_client(
     platform_admin_client,
     api_user_active,


### PR DESCRIPTION
This PR fixes https://github.com/cds-snc/notification-api/issues/1044

There is no sufficient test coverage for blocking/unblocking users in the existing test suite. Did my best to add a test proving that when unblocking a user, the failed login attempts counter is reset as well.