### PR TITLE
Build the correct endpoint for the feedback confirmation page

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -14,15 +14,13 @@ def feedback(ticket_type):
 
     # catch with the honeypot field
     if(form.phone.data):
-        return redirect(url_for('.thanks', auto="true"))
+        return redirect(url_for('.feedback', ticket_type='thanks'))
 
     if form.validate_on_submit():
         # send email here
         user_api_client.send_contact_email(form.name.data, form.email_address.data, form.feedback.data, form.support_type.data)
 
-        return redirect(url_for(
-            '.thanks',
-        ))
+        return redirect(url_for('.feedback', ticket_type='thanks'))
 
     types = [
         'ask-question-give-feedback',

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -44,15 +44,13 @@ def index():
 
     # catch with the honeypot field
     if(form.phone.data):
-        return redirect(url_for('.thanks', auto="true"))
+        return redirect(url_for('.feedback', ticket_type='thanks'))
 
     if form.validate_on_submit():
         # send email here
         user_api_client.send_contact_email(form.name.data, form.email_address.data, form.feedback.data, form.support_type.data)
 
-        return redirect(url_for(
-            '.thanks',
-        ))
+        return redirect(url_for('.feedback', ticket_type='thanks'))
 
     stats = get_latest_stats(lang)
 


### PR DESCRIPTION
Likely broke here: https://github.com/cds-snc/notification-admin/commit/9f74324fc3a9ff490c8d41fd6054d0202d52da2b

> tl:dr is that the thanks route actually doesn’t exist anymore post that /support removal PR i mentioned - instead we just have to point to .feedback and pass in the “thanks” ticket type to get the correct page render