### PR TITLE
Limit local part of email address to 64 bytes

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -243,14 +243,19 @@ def generate_previous_next_dict(view, service_id, page, title, url_args):
 
 
 def email_safe(string, whitespace='.'):
-    # strips accents, diacritics etc
+    original = string
+    # Strips accents, diacritics etc
     string = ''.join(c for c in unicodedata.normalize('NFD', string) if unicodedata.category(c) != 'Mn')
     string = ''.join(
         word.lower() if word.isalnum() or word == whitespace else ''
         for word in re.sub(r'\s+', whitespace, string.strip())
     )
     string = re.sub(r'\.{2,}', '.', string)
-    return string.strip('.')
+    string = string.strip('.')
+    # Limit to 64 bytes before the @ symbol
+    if len(string) > 64 and '|' in original:
+        return email_safe(original.split('|')[0])
+    return string[:64]
 
 
 def id_safe(string):

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -99,6 +99,8 @@ def _get_notifications_csv_mock(
     ('.leading', 'leading'),
     ('trailing.', 'trailing'),
     ('üńïçödë wördś', 'unicode.words'),
+    ('Health Promotion And Chronic Diseases Prevention Branch HPCDP | Direction générale de la promotion de la santé et de la prévention des maladies chroniques PSPMC', 'health.promotion.and.chronic.diseases.prevention.branch.hpcdp'),
+    ('Health Promotion And Chronic Diseases Prevention Branch HPCDP ~ Direction générale de la promotion de la santé et de la prévention des maladies chroniques PSPMC', 'health.promotion.and.chronic.diseases.prevention.branch.hpcdp.di'),
 ])
 def test_email_safe_return_dot_separated_email_domain(service_name, safe_email):
     assert email_safe(service_name) == safe_email


### PR DESCRIPTION
https://github.com/cds-snc/notification-api/issues/1110
https://trello.com/c/yiFU8McP/44-service-name-can-make-an-email-too-long-restrict-length

If the service name is very long in both languages, separated by a pipe, use only the first part to generate the email address
- _Health Promotion And Chronic Diseases Prevention Branch HPCDP | Direction générale de la promotion de la santé et de la prévention des maladies chroniques PSPMC_ => `health.promotion.and.chronic.diseases.prevention.branch.hpcdp`

If we can't split "nicely" the too long original string, trim to a maximum of 64 bytes