### PR TITLE
Remove blocked attribute on non User models

### DIFF
--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -23,7 +23,6 @@ class Organisation(JSONModel):
         'id',
         'name',
         'active',
-        'blocked',
         'crown',
         'default_branding_is_french',
         'organisation_type',

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -47,7 +47,6 @@ class Service(JSONModel):
         'count_as_live',
         'go_live_user',
         'go_live_at',
-        'blocked',
         'sending_domain',
         'smtp_relay'
     }

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -429,14 +429,12 @@ class InvitedUser(JSONModel):
         'created_at',
         'auth_type',
         'folder_permissions',
-        'blocked'
     }
 
     def __init__(self, _dict):
         super().__init__(_dict)
         self.permissions = _dict.get('permissions') or []
         self._from_user = _dict['from_user']
-        self.blocked = False
 
     @classmethod
     def create(
@@ -523,16 +521,16 @@ class InvitedUser(JSONModel):
                 other.status))
 
     def serialize(self, permissions_as_string=False):
-        data = {'id': self.id,
-                'service': self.service,
-                'from_user': self._from_user,
-                'email_address': self.email_address,
-                'status': self.status,
-                'created_at': str(self.created_at),
-                'auth_type': self.auth_type,
-                'folder_permissions': self.folder_permissions,
-                'blocked': self.blocked
-                }
+        data = {
+            'id': self.id,
+            'service': self.service,
+            'from_user': self._from_user,
+            'email_address': self.email_address,
+            'status': self.status,
+            'created_at': str(self.created_at),
+            'auth_type': self.auth_type,
+            'folder_permissions': self.folder_permissions,
+        }
         if permissions_as_string:
             data['permissions'] = ','.join(self.permissions)
         else:
@@ -552,7 +550,6 @@ class InvitedOrgUser(JSONModel):
         'email_address',
         'status',
         'created_at',
-        'blocked'
     }
 
     def __init__(self, _dict):
@@ -582,15 +579,14 @@ class InvitedOrgUser(JSONModel):
         return cls(invited_org_user) if invited_org_user else None
 
     def serialize(self, permissions_as_string=False):
-        data = {'id': self.id,
-                'organisation': self.organisation,
-                'invited_by': self._invited_by,
-                'email_address': self.email_address,
-                'status': self.status,
-                'created_at': str(self.created_at),
-                'blocked': self.blocked,
-                }
-        return data
+        return {
+            'id': self.id,
+            'organisation': self.organisation,
+            'invited_by': self._invited_by,
+            'email_address': self.email_address,
+            'status': self.status,
+            'created_at': str(self.created_at),
+        }
 
     @property
     def invited_by(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -111,7 +111,6 @@ def invited_user(
         'status': status,
         'created_at': created_at,
         'auth_type': auth_type,
-        'blocked': blocked
     }
     if service:
         data['service'] = service
@@ -146,7 +145,6 @@ def service_json(
     prefix_sms=True,
     contact_link=None,
     organisation_id=None,
-    blocked=False,
     sending_domain=None
 ):
     if users is None:
@@ -184,7 +182,6 @@ def service_json(
         'consent_to_research': True,
         'count_as_live': True,
         'organisation': organisation_id,
-        'blocked': blocked,
         'sending_domain': sending_domain
     }
 
@@ -325,19 +322,17 @@ def invite_json(id_,
         'created_at': created_at,
         'auth_type': auth_type,
         'folder_permissions': folder_permissions,
-        'blocked': False
     }
 
 
-def org_invite_json(id_, invited_by, org_id, email_address, created_at, status, blocked):
+def org_invite_json(id_, invited_by, org_id, email_address, created_at, status):
     return {
         'id': id_,
         'invited_by': invited_by,
         'organisation': org_id,
         'email_address': email_address,
         'status': status,
-        'created_at': created_at,
-        'blocked': blocked
+        'created_at': created_at
     }
 
 

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -264,7 +264,6 @@ def test_registration_from_org_invite_has_different_email_or_organisation(
         'password': 'validPassword!',
         'email_address': session['invited_org_user']['email_address'],
         'organisation': session['invited_org_user']['organisation'],
-        'blocked': False
     })
 
     assert response.status_code == 400
@@ -289,7 +288,6 @@ def test_org_user_registers_with_email_already_in_use(
         'password': 'validPassword!',
         'email_address': session['invited_org_user']['email_address'],
         'organisation': session['invited_org_user']['organisation'],
-        'blocked': False
     })
 
     assert response.status_code == 302
@@ -323,7 +321,6 @@ def test_org_user_registration(
         'mobile_number': '+16502532222',
         'password': 'validPassword!',
         'organisation': session['invited_org_user']['organisation'],
-        'blocked': False
     })
 
     assert response.status_code == 302
@@ -357,7 +354,6 @@ def test_verified_org_user_redirects_to_dashboard(
         session['expiry_date'] = str(datetime.utcnow() + timedelta(hours=1))
         session['user_details'] = {"email": invited_org_user['email_address'], "id": invited_org_user['id']}
         session['organisation_id'] = invited_org_user['organisation']
-        session['blocked'] = invited_org_user['blocked']
 
     response = client.post(url_for('main.verify'), data={'two_factor_code': '12345'})
 

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -488,7 +488,6 @@ def test_new_invited_user_verifies_and_added_to_service(
         'mobile_number': '+447890123456',
         'name': 'Invited User',
         'auth_type': 'sms_auth',
-        'blocked': False
     }
     response = client.post(url_for('main.register_from_invite'), data=data)
     assert response.status_code == 302

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3465,9 +3465,8 @@ def sample_org_invite(mocker, organisation_one, status='pending'):
     email_address = 'invited_user@test.canada.ca'
     organisation = organisation_one['id']
     created_at = str(datetime.utcnow())
-    blocked = False
 
-    return org_invite_json(id_, invited_by, organisation, email_address, created_at, status, blocked)
+    return org_invite_json(id_, invited_by, organisation, email_address, created_at, status)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Fixes https://github.com/cds-snc/notification-api/issues/1154

The `blocked` attribute was added to various models that don't support it: org, service, InvitedUser, InvitedOrgUser. The only model using this attribute is the User model.

This extra attribute was responsible for a bug I encountered while working on another feature. I fixed it at the same time because I already investigated the root cause.
