### PR TITLE
Upgrade Flask-Login

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -132,6 +132,7 @@ class User(JSONModel, UserMixin):
 
     def login(self):
         login_user(self)
+        session['user_id'] = self.id
 
     def sign_in(self):
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,7 +4,7 @@
 timeago==1.0.14
 Flask==1.1.2
 Flask-WTF==0.14.3
-Flask-Login==0.4.1
+Flask-Login==0.5.0
 Flask-Caching==1.9.0
 
 blinker==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 timeago==1.0.14
 Flask==1.1.2
 Flask-WTF==0.14.3
-Flask-Login==0.4.1
+Flask-Login==0.5.0
 Flask-Caching==1.9.0
 
 blinker==1.4

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from flask import session as flask_session
 from flask import url_for
 from flask.testing import FlaskClient
 from flask_login import login_user
@@ -27,6 +28,9 @@ class TestClient(FlaskClient):
 
         with patch('app.events_api_client.create_event'):
             login_user(model_user)
+        with self.session_transaction() as test_session:
+            for key, value in flask_session.items():
+                test_session[key] = value
 
     def logout(self, user):
         self.get(url_for("main.sign_out"))

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -181,13 +181,13 @@ def test_api_documentation_page_should_redirect(
 
 def test_should_show_empty_api_keys_page(
     client,
-    api_user_pending,
+    api_user_active,
     mock_login,
     mock_get_no_api_keys,
     mock_get_service,
     mock_has_permissions,
 ):
-    client.login(api_user_pending)
+    client.login(api_user_active)
     service_id = str(uuid.uuid4())
     response = client.get(url_for('main.api_keys', service_id=service_id))
 


### PR DESCRIPTION
Reused code from https://github.com/alphagov/notifications-admin/commit/85f159a25fbeb502e1f42fadb2fe52e2734b3502

Here are their notes:
flask_login sets a bunch of variables in the session object. We only use
one of them, `user_id`. We set that to the user id from the database,
and refer to it all over the place.

However, in flask_login 0.5.0 they prefix this with an underscore to
prevent people accidentally overwriting it etc. So when a user logs in
we need to make sure that we set user_id manually so we can still use
it.

flask_login sets a bunch of variables on the `flask.session` object.
However, this session object isn't the one that gets passed in to the
request context by flask - that one can only be modified outside of
requests from within the session_transaction context manager (see [1]).
So, flask_login populates the normal session and then we need to copy
all of those values across.

We didn't need to do this previously because we already set the
`user_id` value on line 20 of tests/__init__.py, but now that
flask_login is looking for `_user_id` instead we need to do this
properly.

[1] https://flask.palletsprojects.com/en/1.1.x/testing/#accessing-and-modifying-sessions


Trello card https://trello.com/c/vacZWEnH/70-upgrade-flask-login-on-admin