### PR TITLE
Upgrade WTForms

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -22,7 +22,9 @@ from wtforms import (
     HiddenField,
     IntegerField,
     PasswordField,
-    RadioField,
+)
+from wtforms import RadioField as WTFormsRadioField
+from wtforms import (
     SelectField,
     SelectMultipleField,
     StringField,
@@ -104,6 +106,21 @@ def get_next_days_until(until):
         )
         for i in range(0, days + 1)
     ]
+
+
+class RadioField(WTFormsRadioField):
+    def __init__(
+        self,
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.validate_choice = False
+
+    def pre_validate(self, form):
+        super().pre_validate(form)
+        if self.data not in dict(self.choices).keys():
+            raise ValidationError(_l('You need to choose an option'))
 
 
 class MultiCheckboxField(SelectMultipleField):
@@ -262,7 +279,7 @@ class OrganisationTypeField(RadioField):
                 (value, label) for value, label in Organisation.TYPES
                 if not include_only or value in include_only
             ],
-            validators=[DataRequired()] + (validators or []),
+            validators=validators or [],
             **kwargs
         )
 
@@ -455,7 +472,6 @@ class PermissionsForm(PermissionsAbstract):
             ('sms_auth', _l('Text message code')),
             ('email_auth', _l('Email code')),
         ],
-        validators=[DataRequired()]
     )
 
     @property
@@ -572,9 +588,6 @@ class OrganisationCrownStatusForm(StripWhitespaceForm):
             ('non-crown', 'No'),
             ('unknown', 'Not sure'),
         ],
-        validators=[
-            DataRequired(message=_l('This cannot be empty'))
-        ],
     )
 
 
@@ -587,9 +600,6 @@ class OrganisationAgreementSignedForm(StripWhitespaceForm):
             ('yes', 'Yes'),
             ('no', 'No'),
             ('unknown', 'No (but we have some service-specific agreements in place)'),
-        ],
-        validators=[
-            DataRequired(message=_l('This cannot be empty'))
         ],
     )
 
@@ -697,7 +707,6 @@ class BaseTemplateForm(StripWhitespaceForm):
             ('priority', _l('Yes')),
             ('normal', _l('No')),
         ],
-        validators=[DataRequired()],
         default='normal'
     )
 
@@ -734,7 +743,6 @@ class LetterTemplatePostageForm(StripWhitespaceForm):
             ('first', 'First class'),
             ('second', 'Second class'),
         ],
-        validators=[DataRequired()]
     )
 
 
@@ -803,9 +811,6 @@ class ChooseTimeForm(StripWhitespaceForm):
     scheduled_for = RadioField(
         _l('When should we send these messages?'),
         default='',
-        validators=[
-            DataRequired()
-        ]
     )
 
 
@@ -819,9 +824,6 @@ class CreateKeyForm(StripWhitespaceForm):
 
     key_type = RadioField(
         _l('Type of key'),
-        validators=[
-            DataRequired()
-        ]
     )
 
     key_name = StringField(u'Description of key', validators=[
@@ -858,7 +860,6 @@ class ContactNotifyTeam(StripWhitespaceForm):
             (_l('Set up a demo'), _l('Set up a demo')),
             (_l('Other'), _l('Other')),
         ],
-        validators=[DataRequired()]
     )
     email_address = email_address(label=_l('Your email'), gov_user=False)
     phone = StringField(_l('Your phone'))
@@ -883,7 +884,6 @@ class Triage(StripWhitespaceForm):
             ('yes', 'Yes'),
             ('no', 'No'),
         ],
-        validators=[DataRequired()]
     )
 
 
@@ -910,7 +910,6 @@ class EstimateUsageForm(StripWhitespaceForm):
             ('yes', 'Yes'),
             ('no', 'No'),
         ],
-        validators=[DataRequired()]
     )
 
     at_least_one_volume_filled = True
@@ -936,7 +935,6 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
             ('email_address', 'Email address'),
             ('phone_number', 'Phone number'),
         ],
-        validators=[DataRequired()]
     )
 
     url = StringField("URL")
@@ -1062,9 +1060,6 @@ class SetEmailBranding(StripWhitespaceForm):
 
     branding_style = RadioFieldWithNoneOption(
         'Branding style',
-        validators=[
-            DataRequired()
-        ]
     )
 
     DEFAULT_EN = (FieldWithLanguageOptions.ENGLISH_OPTION_VALUE, 'English Government of Canada signature')
@@ -1259,9 +1254,6 @@ class ServiceInboundNumberForm(StripWhitespaceForm):
 
     inbound_number = RadioField(
         "Select your inbound number",
-        validators=[
-            DataRequired("Option must be selected")
-        ]
     )
 
 
@@ -1378,12 +1370,7 @@ class LinkOrganisationsForm(StripWhitespaceForm):
         super().__init__(*args, **kwargs)
         self.organisations.choices = kwargs['choices']
 
-    organisations = RadioField(
-        'Select an organisation',
-        validators=[
-            DataRequired()
-        ]
-    )
+    organisations = RadioField('Select an organisation')
 
 
 branding_options = (
@@ -1402,9 +1389,6 @@ class BrandingOptionsEmail(StripWhitespaceForm):
     options = RadioField(
         'Branding options',
         choices=branding_options,
-        validators=[
-            DataRequired()
-        ],
     )
 
 
@@ -1417,7 +1401,6 @@ class ServiceDataRetentionForm(StripWhitespaceForm):
             ('sms', 'SMS'),
             ('letter', 'Letter'),
         ],
-        validators=[DataRequired()],
     )
     days_of_retention = IntegerField(label="Days of retention",
                                      validators=[validators.NumberRange(min=3, max=90,
@@ -1563,7 +1546,6 @@ class TemplateAndFoldersSelectionForm(Form):
 class ClearCacheForm(StripWhitespaceForm):
     model_type = RadioField(
         'What do you want to clear today',
-        validators=[DataRequired()]
     )
 
 
@@ -1609,7 +1591,6 @@ class AcceptAgreementForm(StripWhitespaceForm):
                 'Someone else',
             ),
         ),
-        validators=[DataRequired()],
     )
 
     on_behalf_of_name = StringField(

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -897,7 +897,7 @@
 "The text message sender tells your users who the message is from.","L’expéditeur de message texte fait savoir à vos utilisateurs d’où vient le message."
 "Change email branding","Changer l'image de marque du courriel"
 "Choose the branding you’d like on your emails.","Choisir l'image de marque que vous souhaitez pour vos courriels."
-"You need to choose an option","Vous devez sélectionner une option"
+"You need to choose an option","Veuillez sélectionner une option"
 "We’ll email you once your branding’s ready to use, or if we need any more information.","Nous vous enverrons un courriel dès que votre image de marque sera prête à être utilisé, ou bien si nous avons besoin plus d'informations."
 "Request new branding","Demander une nouvelle image de marque"
 "Update email branding","Mettre à jour l'image de marque du courriel"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -28,7 +28,7 @@ PyYAML==5.3.1
 translate-toolkit==3.1.1
 ua-parser==0.10.0
 user-agents==2.2.0
-WTForms==2.2.1  # Pinned because of breaking change in 2.3.0
+WTForms==2.3.3
 email-validator==1.1.1
 
 # PaaS

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ PyYAML==5.3.1
 translate-toolkit==3.1.1
 ua-parser==0.10.0
 user-agents==2.2.0
-WTForms==2.2.1  # Pinned because of breaking change in 2.3.0
+WTForms==2.3.3
 email-validator==1.1.1
 
 # PaaS

--- a/tests/app/main/test_create_api_key_form.py
+++ b/tests/app/main/test_create_api_key_form.py
@@ -36,8 +36,8 @@ def test_return_validation_error_when_key_name_exists(
 
 @pytest.mark.parametrize(
     'key_type, expected_error', [
-        ('', 'This field is required.'),
-        ('invalid', 'Not a valid choice')
+        ('', 'You need to choose an option'),
+        ('invalid', 'You need to choose an option')
     ]
 )
 def test_return_validation_error_when_key_type_not_chosen(client, key_type, expected_error):

--- a/tests/app/main/test_service_contact_details_form.py
+++ b/tests/app/main/test_service_contact_details_form.py
@@ -9,7 +9,7 @@ def test_form_fails_validation_with_no_radio_buttons_selected(app_):
 
         assert not form.validate_on_submit()
         assert len(form.errors) == 1
-        assert form.errors['contact_details_type'] == ['Not a valid choice']
+        assert form.errors['contact_details_type'] == ['You need to choose an option']
 
 
 @pytest.mark.parametrize('selected_radio_button, selected_text_box, text_box_data', [

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -155,8 +155,8 @@ def test_create_new_organisation_validates(
         for error in page.select('.error-message')
     ] == [
         ('name', 'This cannot be empty'),
-        ('organisation_type', 'Not a valid choice'),
-        ('crown_status', 'Not a valid choice'),
+        ('organisation_type', 'You need to choose an option'),
+        ('crown_status', 'You need to choose an option'),
     ]
     assert mock_create_organisation.called is False
 

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -156,7 +156,7 @@ def test_add_service_has_to_choose_org_type(
         _expected_status=200,
     )
     assert normalize_spaces(page.select_one('.error-message').text) == (
-        'Not a valid choice'
+        'You need to choose an option'
     )
     assert mock_create_service.called is False
     assert mock_create_service_template.called is False

--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -252,7 +252,7 @@ def test_accept_agreement_page_populates(
             'on_behalf_of_email': '',
         },
         [
-            'This field is required.',
+            'You need to choose an option',
             'Must be a number',
         ],
     ),

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -964,7 +964,7 @@ def test_clear_cache_requires_option(client_request, platform_admin_user, mocker
 
     page = client_request.post('main.clear_cache', _data={}, _expected_status=200)
 
-    assert normalize_spaces(page.find('span', class_='error-message').text) == 'Not a valid choice'
+    assert normalize_spaces(page.find('span', class_='error-message').text) == 'You need to choose an option'
     assert not redis.delete_cache_keys_by_pattern.called
 
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1224,7 +1224,7 @@ def test_should_show_persist_estimated_volumes(
             'consent_to_research': '',
         },
         '[data-error-label="consent_to_research"]',
-        'This field is required.'
+        'You need to choose an option'
     ),
 ))
 def test_should_error_if_bad_estimations_given(
@@ -3931,7 +3931,7 @@ def test_service_set_contact_link_displays_error_message_when_no_radio_button_se
         },
         _follow_redirects=True
     )
-    assert normalize_spaces(page.find('span', class_='error-message').text) == 'Not a valid choice'
+    assert normalize_spaces(page.find('span', class_='error-message').text) == 'You need to choose an option'
     assert normalize_spaces(page.h1.text) == "Add contact details for ‘Download your document’ page"
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1120,7 +1120,7 @@ def test_load_edit_template_with_copy_of_template(
         expected_name
     )
     assert page.select_one('textarea').text == (
-        'Your ((thing)) is due soon'
+        '\r\nYour ((thing)) is due soon'
     )
     mock_get_service_email_template.assert_called_once_with(
         SERVICE_TWO_ID,


### PR DESCRIPTION
Trello Card https://trello.com/c/uoeGGVUE/71-upgrade-wtforms-on-admin.

The biggest change is regarding error messages, a breaking change WTForms for radio fields. Changed to a single message: "You need to choose an option" instead of required/invalid choice.

See GDS https://github.com/alphagov/notifications-admin/commit/65bb72ef2fe750546e69f1d298569eb4c63f6226