### PR TITLE
Fix cache for get_latest_stats

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -55,7 +55,7 @@ with open('{}/email_domains.txt'.format(
 user_is_logged_in = login_required
 
 
-@cache.cached(timeout=300, key_prefix='latest_stats')
+@cache.memoize(timeout=300)
 def get_latest_stats(lang="en"):
     json_data = {}
     email_totals = 0


### PR DESCRIPTION
`get_latest_stats` is cached but the `lang` argument is not taken into account. The function is written to format numbers differently according to the lang parameter, but you can see it's not working in production by switching to "Français", these numbers will be formatted in English.

To take arguments into account, we should use the `memoize` function instead. https://flask-caching.readthedocs.io/en/latest/api.html#flask_caching.Cache.memoize

> Use this to cache the result of a function, taking its arguments into account in the cache key.