### PR TITLE
Retry failed requests to the Notify API

### DIFF
--- a/tests/app/notify_client/test_base.py
+++ b/tests/app/notify_client/test_base.py
@@ -1,0 +1,45 @@
+import pytest
+import requests
+from notifications_python_client.errors import HTTP503Error
+
+from app.notify_client.service_api_client import service_api_client
+
+
+def test_retry_on_server_error_2_failed_tries(mocker):
+    response = requests.Response()
+    response._content = b'{"foo": "bar"}'
+    response.encoding = "utf-8"
+    response.status_code = 200
+
+    # 2 failures, 1 good response, successful on last try
+    mocker.patch(
+        'notifications_python_client.base.requests.request',
+        side_effect=[
+            requests.exceptions.ConnectionError(),
+            requests.exceptions.ConnectionError(),
+            response
+        ]
+    )
+
+    assert service_api_client.get_live_services_data() == {"foo": "bar"}
+
+
+def test_retry_on_server_error_3_failed_tries(mocker):
+    response = requests.Response()
+    response._content = b"{}"
+    response.encoding = "utf-8"
+    response.status_code = 200
+
+    # 3 failures, 1 good response: too many failures
+    mocker.patch(
+        'notifications_python_client.base.requests.request',
+        side_effect=[
+            requests.exceptions.ConnectionError(),
+            requests.exceptions.ConnectionError(),
+            requests.exceptions.ConnectionError(),
+            response
+        ]
+    )
+
+    with pytest.raises(HTTP503Error):
+        service_api_client.get_live_services_data()


### PR DESCRIPTION
Turns out that the Notify API client throws a 503 error when it can’t connect to the API. This means that the API never returned an error, the admin didn’t manage to connect to the API. [Code in charge of this](https://github.com/alphagov/notifications-python-client/blob/8ba2c878d50bae4a4e130614e9bcb06a2018c5da/notifications_python_client/errors.py#L62-L84) and test [proving that a connection error results are converted in a 503 error](https://github.com/alphagov/notifications-python-client/blob/master/tests/notifications_python_client/test_base_api_client.py#L44-L52).

They have a note in the client regarding 503 errors, they even raise a specific exception for these. They say
> Specific instance of HTTPError for 503 errors. Used for detecting whether failed requests should be retried.

But turns out the admin doesn’t retry these requests after such a failure. We don’t and the current GDS codebase doesn’t either. I don’t think it’s a good idea. API requests can temporarily fail (hey, distributed systems) so they are worth retrying if it’s a temporary failure (like a 503 error).

Therefore, this PR retries requests to the Notify API up to 3 times when encountering a 503 error.

Slack discussion: https://gcdigital.slack.com/archives/CNWA63606/p1602853930021500