### PR TITLE
Adding a service to an org cleans orgs cache

### DIFF
--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -62,6 +62,7 @@ class OrganisationsClient(NotifyAdminAPIClient):
 
     @cache.delete('service-{service_id}')
     @cache.delete('live-service-and-organisation-counts')
+    @cache.delete('organisations')
     def update_service_organisation(self, service_id, org_id):
         data = {
             'service_id': service_id

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -113,6 +113,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.post(endpoint, data)
 
     @cache.delete('live-service-and-organisation-counts')
+    @cache.delete('organisations')
     def update_status(self, service_id, live):
         return self.update_service(
             service_id,
@@ -122,6 +123,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         )
 
     @cache.delete('live-service-and-organisation-counts')
+    @cache.delete('organisations')
     def update_count_as_live(self, service_id, count_as_live):
         return self.update_service(
             service_id,

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -192,3 +192,25 @@ def test_update_organisation_when_updating_org_type_but_org_has_no_services(mock
         call('organisations'),
         call('domains'),
     ]
+
+
+def test_update_service_organisation(mocker, fake_uuid):
+    org_id, service_id = fake_uuid, fake_uuid
+
+    mock_redis_delete = mocker.patch('app.extensions.RedisClient.delete')
+    mock_post = mocker.patch('app.notify_client.organisations_api_client.OrganisationsClient.post')
+
+    organisations_client.update_service_organisation(
+        service_id,
+        org_id,
+    )
+
+    mock_post.assert_called_with(
+        url='/organisations/{}/service'.format(org_id),
+        data={'service_id': service_id}
+    )
+    assert mock_redis_delete.call_args_list == [
+        call('organisations'),
+        call('live-service-and-organisation-counts'),
+        call('service-{}'.format(service_id)),
+    ]


### PR DESCRIPTION
Adding a service to an organisation doesn't clean the organisations cache currently. This has the effect of having a count of live services wrong.

Noticed that yesterday when creating a new org, attaching a service and turning it live.
![Screen Shot 2020-10-21 at 10 38 06](https://user-images.githubusercontent.com/295709/96736332-7e481580-138a-11eb-93ba-f71a9db9f92c.png)

[Link to PHAC org with a live service](https://notification.alpha.canada.ca/organisations/6d5f3682-54ff-4aba-8405-96e71de45bb1)

This PR cleans the `organisations` cache when the count of the live services for an org can be affected:
- turning it live
- changing if the service should be counted as live or not
- attaching a service to an org