### PR TITLE
Fix method to get the real IP address

### DIFF
--- a/app/event_handlers.py
+++ b/app/event_handlers.py
@@ -1,6 +1,7 @@
 from flask import request
 
 from app import events_api_client
+from app.utils import get_remote_addr
 
 
 def on_user_logged_in(_sender, user):
@@ -40,16 +41,8 @@ def _send_event(event_type, **kwargs):
 
 
 def _construct_event_data(request):
-    return {'ip_address': _get_remote_addr(request),
+    return {'ip_address': get_remote_addr(request),
             'browser_fingerprint': _get_browser_fingerprint(request)}
-
-
-# This might not be totally correct depending on proxy setup
-def _get_remote_addr(request):
-    if request.headers.getlist("X-Forwarded-For"):
-        return request.headers.getlist("X-Forwarded-For")[0]
-    else:
-        return request.remote_addr
 
 
 def _get_browser_fingerprint(request):

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -19,7 +19,7 @@ from app import login_manager
 from app.main import main
 from app.main.forms import LoginForm
 from app.models.user import InvitedUser, User
-from app.utils import report_security_finding
+from app.utils import get_remote_addr, report_security_finding
 
 
 @main.route('/sign-in', methods=(['GET', 'POST']))
@@ -33,7 +33,7 @@ def sign_in():
 
         login_data = {
             "user-agent": request.headers["User-Agent"],
-            "location": _geolocate_ip(request.remote_addr)
+            "location": _geolocate_ip(get_remote_addr(request))
         }
 
         user = User.from_email_address_and_password_or_none(

--- a/app/utils.py
+++ b/app/utils.py
@@ -260,6 +260,8 @@ def id_safe(string):
 def get_remote_addr(request):
     try:
         return request.access_route[0]
+    # This except block is here to prevent to fail when the env `REMOTE_ADDR`
+    # is not set. This only happens when running tests
     except IndexError:
         return None
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -257,6 +257,10 @@ def id_safe(string):
     return email_safe(string, whitespace='-')
 
 
+def get_remote_addr(request):
+    return request.access_route[0]
+
+
 class Spreadsheet():
 
     allowed_file_extensions = ['csv', 'xlsx', 'xls', 'ods', 'xlsm', 'tsv']

--- a/app/utils.py
+++ b/app/utils.py
@@ -258,7 +258,10 @@ def id_safe(string):
 
 
 def get_remote_addr(request):
-    return request.access_route[0]
+    try:
+        return request.access_route[0]
+    except IndexError:
+        return None
 
 
 class Spreadsheet():

--- a/tests/app/test_event_handlers.py
+++ b/tests/app/test_event_handlers.py
@@ -12,25 +12,25 @@ from app.models.user import User
 
 def test_on_user_logged_in_calls_events_api(app_, api_user_active, mock_events):
 
-    with app_.test_request_context():
+    with app_.test_request_context(environ_base={'REMOTE_ADDR': '1.2.3.4'}):
         on_user_logged_in(app_, User(api_user_active))
         mock_events.assert_called_with('sucessful_login',
                                        {'browser_fingerprint':
                                         {'browser': ANY, 'version': ANY, 'platform': ANY, 'user_agent_string': ''},
-                                        'ip_address': ANY, 'user_id': str(api_user_active['id'])})
+                                        'ip_address': '1.2.3.4', 'user_id': str(api_user_active['id'])})
 
 
 def test_create_email_change_event_calls_events_api(app_, mock_events):
     user_id = str(uuid.uuid4())
     updated_by_id = str(uuid.uuid4())
 
-    with app_.test_request_context():
+    with app_.test_request_context(environ_base={'REMOTE_ADDR': '1.2.3.4'}):
         create_email_change_event(user_id, updated_by_id, 'original@example.com', 'new@example.com')
 
         mock_events.assert_called_with('update_user_email',
                                        {'browser_fingerprint':
                                         {'browser': ANY, 'version': ANY, 'platform': ANY, 'user_agent_string': ''},
-                                        'ip_address': ANY,
+                                        'ip_address': '1.2.3.4',
                                         'user_id': user_id,
                                         'updated_by_id': updated_by_id,
                                         'original_email_address': 'original@example.com',
@@ -41,13 +41,13 @@ def test_create_mobile_number_change_event_calls_events_api(app_, mock_events):
     user_id = str(uuid.uuid4())
     updated_by_id = str(uuid.uuid4())
 
-    with app_.test_request_context():
+    with app_.test_request_context(environ_base={'REMOTE_ADDR': '1.2.3.4'}):
         create_mobile_number_change_event(user_id, updated_by_id, '07700900000', '07700900999')
 
         mock_events.assert_called_with('update_user_mobile_number',
                                        {'browser_fingerprint':
                                         {'browser': ANY, 'version': ANY, 'platform': ANY, 'user_agent_string': ''},
-                                        'ip_address': ANY,
+                                        'ip_address': '1.2.3.4',
                                         'user_id': user_id,
                                         'updated_by_id': updated_by_id,
                                         'original_mobile_number': '07700900000',
@@ -58,12 +58,12 @@ def test_create_archive_user_event_calls_events_api(app_, mock_events):
     user_id = str(uuid.uuid4())
     archived_by_id = str(uuid.uuid4())
 
-    with app_.test_request_context():
+    with app_.test_request_context(environ_base={'REMOTE_ADDR': '1.2.3.4'}):
         create_archive_user_event(user_id, archived_by_id)
 
         mock_events.assert_called_with('archive_user',
                                        {'browser_fingerprint':
                                         {'browser': ANY, 'version': ANY, 'platform': ANY, 'user_agent_string': ''},
-                                        'ip_address': ANY,
+                                        'ip_address': '1.2.3.4',
                                         'user_id': user_id,
                                         'archived_by_id': archived_by_id})


### PR DESCRIPTION
`request.remote_addr` is not accurate when requests go through proxies as they do in our production environment. This commit introduces a util method to get the real IP address, no matter if it went through a proxy or not. It uses the [`access_route` method](https://werkzeug.palletsprojects.com/en/1.0.x/wrappers/#werkzeug.wrappers.BaseRequest.access_route) to do the heavy work. The original IP address is at the beginning of the list of the `X-Forwarded-For` header if it is set ([see on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)).

Trello card https://trello.com/c/sg03A4Mt/150-repair-ip-geolocation-service