### PR TITLE
Webpack fix

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,15 +27,12 @@ module.exports = {
         include: [
           path.resolve(__dirname, "app/assets/javascripts")
         ],
-        use: [
-          "css-loader",
-          "postcss-loader"
-        ]
+        use: ["style-loader", "css-loader"]
       },
       {
         test: /\.css$/i,
         include: [
-          path.resolve(__dirname, "app/assets/stylesheets/tailwind")
+          path.resolve(__dirname, "app/assets/stylesheets")
         ],
         use: [
           MiniCssExtractPlugin.loader,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
       {
         test: /\.css$/i,
         include: [
-          path.resolve(__dirname, "app/assets/stylesheets")
+          path.resolve(__dirname, "app/assets/stylesheets/tailwind")
         ],
         use: [
           MiniCssExtractPlugin.loader,


### PR DESCRIPTION
When adding tailwind I had to change up the webpack config. Turns out I didn't quite do it correctly and it was not picking up some styles that go into main.min.js, particularly for the Calendar component.

Closes https://github.com/cds-snc/notification-api/issues/1162

That said, I still would not want to commit main.min.js changes until we remove / fix moment.js (https://github.com/cds-snc/notification-api/issues/1150) as it still adds a lot of garbage to the file. However if it is accidentally committed / updated before that fix happens, it won't break anything this time.

To test:
- Checkout branch locally
- run `npm run webpack`
- verify that main.min.js has been changed
- run the app and see that all styles are still in place, including the calendar component