### PR TITLE
add npm run tailwind command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "watch": "gulp watch",
     "heroku-postbuild": "gulp && make generate-version-file && export ADMIN_BASE_URL=${HEROKU_APP_NAME}.herokuapp.com",
     "snyk-protect": "snyk protect",
-    "prepare": "npm run snyk-protect"
+    "prepare": "npm run snyk-protect",
+    "tailwind": "webpack --config webpack.config.js && gulp"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   //mode: "development", //development
   mode: "production",
   entry: ["./app/assets/javascripts/index.js", "./app/assets/stylesheets/tailwind/style.css"],
-  watch: true,
+  watch: false,
   output: {
     filename: "javascripts/[name].min.js",
     path: path.resolve(__dirname, "app/assets")


### PR DESCRIPTION
The various "watch" elements of webpack and gulp aren't cooperating, but for now we can add a command to combine `npm run webpack` and `npm run build` so we only need to run one command when we make changes.