### PR TITLE
Update logo and assets domain

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -89,7 +89,7 @@ from app.notify_client.template_statistics_api_client import (
     template_statistics_client,
 )
 from app.notify_client.user_api_client import user_api_client
-from app.utils import get_logo_cdn_domain, id_safe
+from app.utils import id_safe
 
 login_manager = LoginManager()
 csrf = CSRFProtect()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -133,6 +133,7 @@ def create_app(application):
     notify_environment = os.environ['NOTIFY_ENVIRONMENT']
 
     application.config.from_object(configs[notify_environment])
+    asset_fingerprinter._cdn_domain = application.config['ASSET_DOMAIN']
     asset_fingerprinter._asset_root = application.config['ASSET_PATH']
 
     application.config["BABEL_DEFAULT_LOCALE"] = "en"
@@ -625,10 +626,9 @@ def useful_headers_after_request(response):
         "object-src 'self';"
         "style-src 'self' *.googleapis.com 'unsafe-inline';"
         "font-src 'self' {asset_domain} *.googleapis.com *.gstatic.com data:;"
-        "img-src 'self' {asset_domain} *.google-analytics.com *.notifications.service.gov.uk {logo_domain} notification-alpha-canada-ca-cdn.s3.amazonaws.com data:;"  # noqa: E501
+        "img-src 'self' {asset_domain} *.google-analytics.com *.notifications.service.gov.uk data:;"  # noqa: E501
         "frame-src 'self' www.youtube.com;".format(
             asset_domain=current_app.config['ASSET_DOMAIN'],
-            logo_domain=get_logo_cdn_domain(),
         )
     ))
     if 'Cache-Control' in response.headers:

--- a/app/asset_fingerprinter.py
+++ b/app/asset_fingerprinter.py
@@ -19,8 +19,9 @@ class AssetFingerprinter(object):
         * 'app/static' is assumed to be the root for all asset files
     """
 
-    def __init__(self, asset_root='/static/', filesystem_path='app/static/'):
+    def __init__(self, asset_root='/static/', filesystem_path='app/static/', cdn_domain=None):
         self._cache = {}
+        self._cdn_domain = cdn_domain
         self._asset_root = asset_root
         self._filesystem_path = filesystem_path
 
@@ -37,8 +38,7 @@ class AssetFingerprinter(object):
     def get_s3_url(self, asset_path):
         if asset_path not in self._cache:
             self._cache[asset_path] = (
-                "https://notification-alpha-canada-ca-cdn.s3.amazonaws.com/" +
-                asset_path
+                f"https://{self._cdn_domain}/static/{asset_path}"
             )
         return self._cache[asset_path]
 

--- a/app/config.py
+++ b/app/config.py
@@ -83,7 +83,7 @@ class Config(object):
     TEST_MESSAGE_FILENAME = 'Report'
     NOTIFY_ENVIRONMENT = 'development'
     LOGO_UPLOAD_BUCKET_NAME = os.getenv('ASSET_UPLOAD_BUCKET_NAME', 'notification-alpha-canada-ca-asset-upload')
-    ASSET_DOMAIN = os.getenv('ASSET_DOMAIN', 's3.amazonaws.com')
+    ASSET_DOMAIN = os.getenv('ASSET_DOMAIN', 'assets.notification.canada.ca')
     MOU_BUCKET_NAME = os.getenv('MOU_BUCKET_NAME', '')
     ROUTE_SECRET_KEY_1 = os.environ.get('ROUTE_SECRET_KEY_1', '')
     ROUTE_SECRET_KEY_2 = os.environ.get('ROUTE_SECRET_KEY_2', '')

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -59,6 +59,7 @@ def index():
             'views/signedout.html',
             form=form,
             scrollTo="true",
+            admin_base_url=current_app.config['ADMIN_BASE_URL'],
             stats=get_latest_stats(get_current_locale(current_app)),
         )
 
@@ -66,6 +67,7 @@ def index():
         'views/signedout.html',
         form=form,
         scrollTo="false",
+        admin_base_url=current_app.config['ADMIN_BASE_URL'],
         stats=get_latest_stats(get_current_locale(current_app)),
     )
 

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -13,9 +13,9 @@ set description = _('GC Notify lets you send emails and text messages to your us
 <meta property="og:description" content="{{description}}" />
 <meta
   property="og:image"
-  content="https://notification.alpha.canada.ca/static/images/product/notify-main.jpg"
+  content="{{ admin_base_url }}/static/images/product/notify-main.jpg"
 />
-<meta property="og:url" content="https://notification.alpha.canada.ca" />
+<meta property="og:url" content="{{ admin_base_url }}" />
 
 <link
   rel="stylesheet"

--- a/app/utils.py
+++ b/app/utils.py
@@ -460,7 +460,7 @@ def email_or_sms_not_enabled(template_type, permissions):
 
 
 def get_logo_cdn_domain():
-    return "{}.{}".format(current_app.config['LOGO_UPLOAD_BUCKET_NAME'], current_app.config['ASSET_DOMAIN'])
+    return current_app.config['ASSET_DOMAIN']
 
 
 def parse_filter_args(filter_dict):

--- a/tests/app/main/test_asset_fingerprinter.py
+++ b/tests/app/main/test_asset_fingerprinter.py
@@ -89,6 +89,11 @@ class TestAssetFingerprint(object):
             'app/static/application.css'
         )
 
+    def test_s3_url(self):
+        fingerprinter = AssetFingerprinter(cdn_domain='assets.example.com')
+
+        assert fingerprinter.get_s3_url('foo.png') == 'https://assets.example.com/static/foo.png'
+
 
 class TestAssetFingerprintWithUnicode(object):
     def test_can_read_self(self):

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -13,7 +13,6 @@ def test_owasp_useful_headers_set(
     mocker,
     mock_get_service_and_organisation_counts,
 ):
-    mocker.patch('app.get_logo_cdn_domain', return_value='static-logos.test.com')
     mocker.patch(
         'app.service_api_client.get_live_services_data',
         return_value={'data': service}
@@ -36,7 +35,7 @@ def test_owasp_useful_headers_set(
         "style-src 'self' *.googleapis.com 'unsafe-inline';"
         "font-src 'self' static.example.com *.googleapis.com *.gstatic.com data:;"
         "img-src "
-        "'self' static.example.com *.google-analytics.com *.notifications.service.gov.uk static-logos.test.com notification-alpha-canada-ca-cdn.s3.amazonaws.com data:;"  # noqa: E501
+        "'self' static.example.com *.google-analytics.com *.notifications.service.gov.uk data:;"  # noqa: E501
         "frame-src 'self' www.youtube.com;"
     )
 
@@ -46,7 +45,6 @@ def test_headers_non_ascii_characters_are_replaced(
     mocker,
     mock_get_service_and_organisation_counts,
 ):
-    mocker.patch('app.get_logo_cdn_domain', return_value='static-logos€æ.test.com')
     mocker.patch('app.service_api_client.get_live_services_data', return_value={'data': service})
     mocker.patch(
         'app.service_api_client.get_stats_by_month',
@@ -63,6 +61,6 @@ def test_headers_non_ascii_characters_are_replaced(
         "style-src 'self' *.googleapis.com 'unsafe-inline';"
         "font-src 'self' static.example.com *.googleapis.com *.gstatic.com data:;"
         "img-src "
-        "'self' static.example.com *.google-analytics.com *.notifications.service.gov.uk static-logos??.test.com notification-alpha-canada-ca-cdn.s3.amazonaws.com data:;"  # noqa: E501
+        "'self' static.example.com *.google-analytics.com *.notifications.service.gov.uk data:;"  # noqa: E501
         "frame-src 'self' www.youtube.com;"
     )

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -301,7 +301,7 @@ def test_generate_notifications_csv_calls_twice_if_next_link(
 def test_get_cdn_domain_on_localhost(client, mocker):
     mocker.patch.dict('app.current_app.config', values={'ADMIN_BASE_URL': 'http://localhost:6012'})
     domain = get_logo_cdn_domain()
-    assert domain == "{}.{}".format(current_app.config['LOGO_UPLOAD_BUCKET_NAME'], current_app.config['ASSET_DOMAIN'])
+    assert domain == current_app.config['ASSET_DOMAIN']
 
 
 @pytest.mark.parametrize('time, human_readable_datetime', [


### PR DESCRIPTION
- Serve assets on the homepage from `https://assets.notification.canada.ca/static/{path}`
- Serve logos from `https://assets.notification.canada.ca/{path}`

Logos uploaded to `LOGO_UPLOAD_BUCKET_NAME` will be served from the root of assets.notification.canada.ca 

Demo: https://assets.notification.canada.ca/gov-canada-en.svg

You can see on the Heroku deployments that images are served from assets.notification.canada.ca