### PR TITLE
Disable honeypot field on contact page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -862,7 +862,6 @@ class ContactNotifyTeam(StripWhitespaceForm):
         ],
     )
     email_address = email_address(label=_l('Your email'), gov_user=False)
-    phone = StringField(_l('Your phone'))
     feedback = TextAreaField(_l('Message'), validators=[DataRequired(message=not_empty)])
 
 

--- a/app/main/views/contact.py
+++ b/app/main/views/contact.py
@@ -9,10 +9,6 @@ from app.main.forms import ContactNotifyTeam
 def contact():
     form = ContactNotifyTeam()
 
-    # catch with the honeypot field
-    if (form.phone.data):
-        return render_template('views/contact/thanks.html')
-
     if form.validate_on_submit():
         # send email here
         user_api_client.send_contact_email(form.name.data, form.email_address.data, form.feedback.data, form.support_type.data)

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -44,10 +44,6 @@ def index():
 
     form = ContactNotifyTeam()
 
-    # catch with the honeypot field
-    if (form.phone.data):
-        return render_template('views/contact/thanks.html')
-
     if form.validate_on_submit():
         # send email here
         user_api_client.send_contact_email(form.name.data, form.email_address.data, form.feedback.data, form.support_type.data)

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -616,7 +616,7 @@ set description = _('GC Notify lets you send emails and text messages to your us
         {% call form_wrapper() %} {% set name_label = _('Your name') %} {{
         textbox(form.name, label=name_label, width='1-1') }} {% set email_label
         = _('Your email') %} {{ textbox(form.email_address, label=email_label,
-        width='1-1') }} {# honeypot field #} {% set email_label = _('Your phone') %} {{ honeypotfield(form.phone, label=email_label) }}
+        width='1-1') }}
 
         <div class="form-group">
           <label class="form-label" for="support_type">

--- a/tests/app/main/test_contact.py
+++ b/tests/app/main/test_contact.py
@@ -72,29 +72,6 @@ def test_form_validation_fails_with_invalid_support_type_field(app_):
         assert form.errors['support_type'] == ['Not a valid choice']
 
 
-def test_submit_contact_form_with_honeypot(
-    client_request,
-    mocker,
-):
-    mock_send_contact_email = mocker.patch(
-        'app.user_api_client.send_contact_email'
-    )
-
-    client_request.post(
-        '.contact',
-        _expected_status=200,
-        _data={
-            'name': 'John',
-            'support_type': 'Ask a question',
-            'email_address': 'john@example.com',
-            'feedback': 'Awesome',
-            'phone': 'should not fill'
-        }
-    )
-
-    assert not mock_send_contact_email.called
-
-
 def test_submit_contact_form_validates(
     client_request,
     mocker,


### PR DESCRIPTION
The autocomplete of browsers may fill the honeypot `phone` field on the contact form, not on purpose. This has the effect of displaying the "thanks" page without actually sending the contact request. This is unfortunate.

First I thought about setting `autocomplete=off` on the honeypot field but [many browsers ignore this](https://stackoverflow.com/questions/12374442/chrome-ignores-autocomplete-off).

Therefore, I've removed it for now and we'll revisit this if we get some spam.