### PR TITLE
add french translation to csv and localization func for string

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1432,7 +1432,7 @@ class TemplateFolderForm(StripWhitespaceForm):
                 (item.id, item.name) for item in all_service_users
             ]
 
-    users_with_permission = MultiCheckboxField('Team members who can see this folder')
+    users_with_permission = MultiCheckboxField(_l('Team members who can see this folder'))
     name = StringField(_l('Folder name'), validators=[DataRequired(message=_l('This cannot be empty'))])
 
 

--- a/app/translations/csv/en.csv
+++ b/app/translations/csv/en.csv
@@ -1197,3 +1197,4 @@
 "Download data as CSV",""
 "Updated daily",""
 "Total",""
+"Team members who can see this folder",""

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1197,3 +1197,4 @@
 "Updated daily","Mis à jour quotidiennement"
 "Total","Total"
 "Learn more in the Activity Dashboard","En savoir plus dans le Tableau de bord<br>d'activité"
+"Team members who can see this folder","Les membres de votre équipe qui peuvent voir ce dossier"


### PR DESCRIPTION
https://trello.com/c/HH5enoW3/134-missing-french-strings-team-members-who-can-see-folders

EN: "Team members who can see this folder"
FR: "Les membres de votre équipe qui peuvent voir ce dossier"

Before
<img width="913" alt="Screen_Shot_2020-11-19_at_12 57 37_AM" src="https://user-images.githubusercontent.com/11636275/100417036-29f51d00-303d-11eb-8390-f11c76b4d6e3.png">

After
<img width="1084" alt="Screen Shot 2020-11-26 at 11 13 51 PM" src="https://user-images.githubusercontent.com/11636275/100417064-38dbcf80-303d-11eb-9115-330e0a1d572e.png">
