### PR TITLE
Wrap unwrapped hint string in text message sender

### DIFF
--- a/app/templates/views/service-settings/sms-sender/add.html
+++ b/app/templates/views/service-settings/sms-sender/add.html
@@ -20,7 +20,7 @@
     {{ textbox(
       form.sms_sender,
       width='w-full md:w-1/4',
-      hint='Up to 11 characters, letters, numbers and spaces only'
+      hint=_('Up to 11 characters, letters, numbers and spaces only')
     ) }}
     {% if not first_sms_sender %}
       <div class="form-group contain-floats box-border mb-gutterHalf md:mb-gutter">


### PR DESCRIPTION
# Summary

Fix issue in Trello card: https://trello.com/c/bUWCe5vP/136-missing-french-string-add-text-message-sender

Missing translation wrapping:
String was already used elsewhere in en.csv and fr. csv

