### PR TITLE
Extra margin top on service settings

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -248,7 +248,7 @@
       </p>
       <p>
         {{ _('Problems or comments?') }}
-        <a href="{{ url_for('.contact') }}">{{ _('Give feedback') }}</a>.
+        <a href="{{ url_for('.contact') }}">{{ _('Contact us') }}</a>.
       </p>
 
     {% endif %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -223,7 +223,7 @@
       {% endcall %}
 
     {% if current_service.trial_mode %}
-      <h2 class="heading-medium mt-0 contain-floats">{{ _('Your service is in trial mode') }}</h2>
+      <h2 class="heading-medium mt-10 contain-floats">{{ _('Your service is in trial mode') }}</h2>
 
       <ul class='list list-bullet'>
         <li>{{ _('you can only send messages to yourself') }}</li>
@@ -240,7 +240,7 @@
         </p>
 
     {% else %}
-      <h2 class="heading-medium mt-0 contain-floats">{{ _('Your service is live') }}</h2>
+      <h2 class="heading-medium mt-10 contain-floats">{{ _('Your service is live') }}</h2>
 
       <p>
         {{ _('You can send up to') }}


### PR DESCRIPTION
Trello card: https://trello.com/c/euHouaKM/220-css-bug-with-spacing

Pushed down the "Your service is live" and "Your service is in trial mode" section

Before
![Screen Shot 2021-01-05 at 13 46 10](https://user-images.githubusercontent.com/295709/103686162-65e4a180-4f5c-11eb-8e39-12cce5825847.png)

After
![Screen Shot 2021-01-05 at 13 36 22](https://user-images.githubusercontent.com/295709/103686108-4cdbf080-4f5c-11eb-9460-82647557cadb.png)