### PR TITLE
Speed up docker build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -39,7 +39,13 @@ jobs:
         rm /tmp/aws
     - name: Build
       run: |
-        docker build --build-arg GIT_SHA=${GITHUB_SHA::7} -t $DOCKER_SLUG:${GITHUB_SHA::7} -t $DOCKER_SLUG:latest -f ci/Dockerfile .
+        docker pull $DOCKER_SLUG:latest
+        docker build \
+        --cache-from $DOCKER_SLUG:latest \
+        --build-arg GIT_SHA=${GITHUB_SHA::7} \
+        -t $DOCKER_SLUG:${GITHUB_SHA::7} \
+        -t $DOCKER_SLUG:latest \
+        -f ci/Dockerfile .
     - name: Publish
       run: |
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:${GITHUB_SHA::7}

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt /app
 RUN set -ex && pip3 install -r requirements.txt
 
 COPY package.json package-lock.json /app/
-RUN npm install
+RUN npm ci
 
 COPY . /app
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,12 +12,16 @@ RUN set -ex && mkdir /app
 
 WORKDIR /app
 
+COPY requirements.txt /app
+RUN set -ex && pip3 install -r requirements.txt
+
+COPY package.json package-lock.json /app/
+RUN npm install
+
 COPY . /app
 
-RUN set -ex && pip3 install -r requirements.txt
 RUN make babel
 
-RUN npm install
 RUN npm run build
 
 RUN make generate-version-file


### PR DESCRIPTION
Rewrite Docker file to leverage Docker layer caching. The idea is to be able to reuse an intermediate layer if Python or npm dependencies did not change.

Previously, the whole source code was copied and dependencies were installed. This has the effect of busting the cache for `npm install` or `pip install` as soon as another unrelated file is updated (say a Python file). By copying lock files, running installation instructions and then copying the whole folder, we will be able to reuse an intermediate layer on the next (making the install step almost instantaneous).

The final work is to pull up a base image to work with in CI. Here we pull the latest version of the container, built before. By doing this, GitHub Actions will be able to reuse the previously built intermediate layers.

Already did this mechanism with great success on the documentation:
- https://github.com/cds-snc/notification-documentation/blob/ca42a63db78624a5ef7d7926e46cc9398145a841/.github/workflows/docker.yml#L40-L47
- https://github.com/cds-snc/notification-documentation/blob/ca42a63db78624a5ef7d7926e46cc9398145a841/Dockerfile#L9-L12

More about this: https://medium.com/condenastengineering/speedy-builds-with-docker-layer-caching-7ed590ac2fd1

---

Made the same PR on the API https://github.com/cds-snc/notification-api/pull/1203