### PR TITLE
fix: update FR translation for sending email address

### DIFF
--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1249,7 +1249,7 @@
 "Please","Veuillez"
 "contact us","nous joindre"
 "Sending email address","Adresse courriel d’envoi"
-"Change your sending email address","Créez votre adresse courriel d’envoi"
+"Change your sending email address","Changez votre adresse courriel d’envoi"
 "Users will see your service email address in the 'From' field of the emails you send.","L’adresse courriel d’envoi apparaîtra dans le champ « De » des courriels que vous envoyez."
 "Your sending email address helps to build trust with recipients. A good email address is bilingual, recognizable, and as concise as possible.","Votre adresse courriel d’envoi aide les destinataires à faire confiance à votre service. Une bonne adresse courriel est bilingue, reconnaissable et aussi concise que possible."
 "For example: renew.passport.renouveler.passeport","Par exemple : renew.passport.renouveler.passeport"


### PR DESCRIPTION
Follow up of https://github.com/cds-snc/notification-admin/pull/874, updating a French translation string