### PR TITLE
Remove line in logo page

### DIFF
--- a/app/templates/partials/add-service/step-choose-logo.html
+++ b/app/templates/partials/add-service/step-choose-logo.html
@@ -1,5 +1,3 @@
-<p>{{ _('The default logo use in email messages is the English Government of Canada signature.') }}</p>
-
 <div class="form-wrap">
     {% call form_wrapper() %}
     {{ radios(form.default_branding) }}

--- a/app/translations/csv/en.csv
+++ b/app/translations/csv/en.csv
@@ -1201,7 +1201,6 @@
 "hidden",""
 "Key removed",""
 "Add a security key",""
-"The default logo use in email messages is the English Government of Canada signature.",""
 "You can also upload a new custom logo later in Settings.",""
 "Sending method: services sending via API vs. User Interface",""
 "Download trial services csv report",""

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1198,7 +1198,6 @@
 "hidden","masqué"
 "Key removed","Clé de sécurité retirée"
 "Add a security key","Ajouter une clé de sécurité"
-"The default logo use in email messages is the English Government of Canada signature.","Le logo par défaut utilisé dans vos messages courriel est la signature du gouvernement du Canada en anglais d'abord."
 "You can also upload a new custom logo later in Settings.","Vous pourrez téléverser un nouveau logo personnalisé plus tard dans la section Paramètres."
 "English GC logo","Logo du GC en anglais"
 "French GC logo","Logo du GC en français"


### PR DESCRIPTION
# Summary | Résumé

Remove redundant content on logo page, as per suggestion on https://github.com/cds-snc/notification-admin/pull/874

Removed top sentence from `/add-service?current_step=choose_logo` page and both csv translation files:
"The default logo use in email messages is the English Government of Canada signature." 
"Le logo par défaut utilisé dans vos messages courriel est la signature du gouvernement du Canada en anglais d'abord."