### PR TITLE
Remove left submenu from Template Formatting Guide page

### DIFF
--- a/app/templates/views/templates.html
+++ b/app/templates/views/templates.html
@@ -1,5 +1,5 @@
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field, row_heading with context %}
-{% extends "withoutnav_template.html" %}
+{% extends "content_template.html" %}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
 
 {% block per_page_title %}
   {{ _('Template formatting guide') }}

--- a/app/templates/views/templates.html
+++ b/app/templates/views/templates.html
@@ -1,11 +1,12 @@
-{% extends "content_template.html" %}
-{% from "components/table.html" import mapping_table, row, text_field, edit_field, field with context %}
+{% from "components/table.html" import mapping_table, row, text_field, edit_field, field, row_heading with context %}
+{% extends "withoutnav_template.html" %}
 
 {% block per_page_title %}
   {{ _('Template formatting guide') }}
 {% endblock %}
-
-{% block content_column_content %}
+{% block maincolumn_content %}
+<div class="grid-row contain-floats">
+  <div class="md:w-2/3 float-left py-0 px-0 px-gutterHalf box-border">
   <h1 class="heading heading-large">{{ _('Template formatting guide') }}</h1>
   <p>{{ _('Use this guide to write email message templates. Make sure to send yourself a message before sending to recipients to ensure formatting looks good.') }}</p>
 
@@ -16,5 +17,5 @@
   {% if current_service and current_service.has_permission('upload_document') %}
     {% include "partials/templates/guidance-send-a-document.html" %}
   {% endif %}
-
+</div>
 {% endblock %}

--- a/app/templates/views/templates.html
+++ b/app/templates/views/templates.html
@@ -4,18 +4,20 @@
 {% block per_page_title %}
   {{ _('Template formatting guide') }}
 {% endblock %}
+
 {% block maincolumn_content %}
 <div class="grid-row contain-floats">
   <div class="md:w-2/3 float-left py-0 px-0 px-gutterHalf box-border">
-  <h1 class="heading heading-large">{{ _('Template formatting guide') }}</h1>
-  <p>{{ _('Use this guide to write email message templates. Make sure to send yourself a message before sending to recipients to ensure formatting looks good.') }}</p>
+    <h1 class="heading heading-large">{{ _('Template formatting guide') }}</h1>
+    <p>{{ _('Use this guide to write email message templates. Make sure to send yourself a message before sending to recipients to ensure formatting looks good.') }}</p>
 
-  {% include "partials/templates/guidance-formatting.html" %}
-  {% include "partials/templates/guidance-links.html" %}
-  {% include "partials/templates/guidance-personalisation.html" %}
-  {% include "partials/templates/guidance-conditional-text.html" %}
-  {% if current_service and current_service.has_permission('upload_document') %}
-    {% include "partials/templates/guidance-send-a-document.html" %}
-  {% endif %}
+    {% include "partials/templates/guidance-formatting.html" %}
+    {% include "partials/templates/guidance-links.html" %}
+    {% include "partials/templates/guidance-personalisation.html" %}
+    {% include "partials/templates/guidance-conditional-text.html" %}
+    {% if current_service and current_service.has_permission('upload_document') %}
+      {% include "partials/templates/guidance-send-a-document.html" %}
+   {% endif %}
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
# Summary | Résumé

Removed the left side menu that is now only redundant content from the Template Formatting Guide `/templates` for consistency with other pages.

Did this by looking at the structure of the  `/callbacks` and `/messages-status` pages