### PR TITLE
fix reference to months so french strings appear when expected

### DIFF
--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -14,7 +14,7 @@
 
   <div class="dashboard">
     {% for month in months %}
-      <h2>{{ month.name }}</h2>
+      <h2>{{ _(month.name) }}</h2>
       {% if not month.templates_used %}
         <p class="table-no-data">
           {{ _('No messages sent') }}


### PR DESCRIPTION
# Summary | Résumé

Fixing month string reference so French months appear when expected.

Trello: https://trello.com/c/ms7DKi9n/135-missing-french-strings-months-in-template-usage