### PR TITLE
feat: move SMS senders to platform admin

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -864,7 +864,7 @@ def service_delete_letter_contact(service_id, letter_contact_id):
 
 
 @main.route("/services/<service_id>/service-settings/sms-sender", methods=['GET'])
-@user_has_permissions('manage_service', 'manage_api_keys')
+@user_is_platform_admin
 def service_sms_senders(service_id):
     return render_template(
         'views/service-settings/sms-senders.html',
@@ -872,7 +872,7 @@ def service_sms_senders(service_id):
 
 
 @main.route("/services/<service_id>/service-settings/sms-sender/add", methods=['GET', 'POST'])
-@user_has_permissions('manage_service')
+@user_is_platform_admin
 def service_add_sms_sender(service_id):
     form = ServiceSmsSenderForm()
     first_sms_sender = current_service.count_sms_senders == 0
@@ -899,7 +899,7 @@ def service_add_sms_sender(service_id):
     methods=['GET'],
     endpoint="service_confirm_delete_sms_sender"
 )
-@user_has_permissions('manage_service')
+@user_is_platform_admin
 def service_edit_sms_sender(service_id, sms_sender_id):
     sms_sender = current_service.get_sms_sender(sms_sender_id)
     is_inbound_number = sms_sender['inbound_number_id']

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -175,28 +175,6 @@
         {% endcall %}
 
         {% call settings_row(if_has_permission='sms') %}
-          {% set txt = _('Text message senders') %}
-          {% set default = _('default') %}
-          {{ text_field(txt) }}
-          {% call field(status=default if current_service.default_sms_sender == "None" else '') %}
-            {{ current_service.default_sms_sender | string | nl2br | safe if current_service.default_sms_sender else 'None'}}
-            {% if current_service.count_sms_senders > 1 %}
-              <div class="hint">
-                {{ current_service.count_sms_senders|get_and_n_more_text }}
-              </div>
-            {% endif %}
-          {% endcall %}
-          {% set txt = _('Manage') %}
-          {{ edit_field(
-              txt,
-              url_for('.service_sms_senders',
-              service_id=current_service.id),
-              permissions=['manage_service','manage_api_keys']
-          )
-          }}
-        {% endcall %}
-
-        {% call settings_row(if_has_permission='sms') %}
           {% set txt = _('Start text messages with service name') %}
           {{ text_field(txt) }}
           {{ boolean_field(current_service.prefix_sms) }}
@@ -216,18 +194,6 @@
           {{ edit_field(
               change_txt,
               url_for('.service_set_international_sms',
-              service_id=current_service.id),
-              permissions=['manage_service']
-          )
-          }}
-        {% endcall %}
-        {% call settings_row(if_has_permission='sms') %}
-          {% set txt = _('Receive text messages') %}
-          {{ text_field(txt) }}
-          {{ boolean_field('inbound_sms' in current_service.permissions) }}
-          {{ edit_field(
-              change_txt,
-              url_for('.service_set_inbound_sms',
               service_id=current_service.id),
               permissions=['manage_service']
           )
@@ -339,6 +305,42 @@
             {{ text_field(current_service.rate_limit | format_number) }}
             {{ text_field('')}}
           {% endcall %}
+
+          {% call row() %}
+            {% set txt = _('Text message senders') %}
+            {% set default = _('default') %}
+            {{ text_field(txt) }}
+            {% call field(status=default if current_service.default_sms_sender == "None" else '') %}
+              {{ current_service.default_sms_sender | string | nl2br | safe if current_service.default_sms_sender else 'None'}}
+              {% if current_service.count_sms_senders > 1 %}
+                <div class="hint">
+                  {{ current_service.count_sms_senders|get_and_n_more_text }}
+                </div>
+              {% endif %}
+            {% endcall %}
+            {% set txt = _('Manage') %}
+            {{ edit_field(
+                txt,
+                url_for('.service_sms_senders',
+                service_id=current_service.id),
+                permissions=['manage_service','manage_api_keys']
+            )
+            }}
+          {% endcall %}
+
+          {% call row() %}
+            {% set txt = _('Receive text messages') %}
+            {{ text_field(txt) }}
+            {{ boolean_field('inbound_sms' in current_service.permissions) }}
+            {{ edit_field(
+                change_txt,
+                url_for('.service_set_inbound_sms',
+                service_id=current_service.id),
+                permissions=['manage_service']
+            )
+            }}
+          {% endcall %}
+
           {% call row() %}
             {% set txt = _('Free text message allowance') %}
             {{ text_field(txt)}}


### PR DESCRIPTION
Move settings
- Receive text messages
- Text message senders

to the Platform admin section and make sure that service owners cannot change these settings themselves.

I've kept tests testing the behaviour of text message senders, just updated those to make sure that the logged-in user was a platform admin to perform these actions.

## Do we need to change the API?
My understanding is no.

SMS sender HTTP endpoints are defined here (just 1 HTTP endpoint, others are present if you search for `sms-sender`)
https://github.com/cds-snc/notification-api/blob/757e94bcec48347663d978e9bd10121f1eaf7b21/app/service/rest.py#L783

And the blueprint that makes sure that requests come from the admin
https://github.com/cds-snc/notification-api/blob/757e94bcec48347663d978e9bd10121f1eaf7b21/app/__init__.py#L134-L135

As a user, you cannot handcraft HTTP requests and ask the admin to do those to the API, so we're safe.

Other "platform admin only" things like inbound numbers don't have a different authentication mechanism.
https://github.com/cds-snc/notification-api/blob/757e94bcec48347663d978e9bd10121f1eaf7b21/app/__init__.py#L158-L159

## How to test this
Use the review app and go to "Service settings" with a Platform admin account/with a normal user account.

## Screenshots
New settings in Platform Admin
![Screen Shot 2021-01-27 at 09 37 22](https://user-images.githubusercontent.com/295709/106006514-4fc19100-6083-11eb-9d41-64f2d0cdf0b1.png)

Fewer settings in "Text message settings"

![Screen Shot 2021-01-27 at 09 36 54](https://user-images.githubusercontent.com/295709/106006522-518b5480-6083-11eb-8ed6-f5743005e179.png)

Trello card: https://trello.com/c/ugFh402K/250-make-text-message-senders-platform-admin-only