### PR TITLE
Change line of copy in service accounts

### DIFF
--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -49,13 +49,13 @@
 {% endmacro %}
 
 {% block per_page_title %}
-  {{ _('Choose service') }}
+  {{ _('All services') }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
   <h1 class="heading-large {% if current_user.has_access_to_live_and_trial_mode_services %}visually-hidden{% endif %}">
-    {{ _('Choose service') }}
+    {{ _('All services') }}
   </h1>
 
   <nav class="browse-list {% if current_user.has_access_to_live_and_trial_mode_services %}mt-8 block clear-both contain-floats{% endif %}">

--- a/app/translations/csv/en.csv
+++ b/app/translations/csv/en.csv
@@ -406,7 +406,7 @@
 "Click the link in the email to confirm the change to your email address.",""
 "live service",""
 "Add a new service",""
-"Choose service",""
+"All services",""
 "All organisations",""
 "organisations",""
 "live services",""

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -406,7 +406,7 @@
 "Click the link in the email to confirm the change to your email address.","Cliquez sur le lien pour confirmer le changement à votre adresse courriel."
 "live service","service en fonction"
 "Add a new service","Ajouter un nouveau service"
-"Choose service","Choisissez un service"
+"All services","Tous les services"
 "All organisations","Toutes les organisations"
 "organisations","organisations"
 "live services","services en fonction"

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -90,7 +90,7 @@ def test_choose_account_should_show_choose_accounts_page(
     resp = client_request.get('main.choose_account')
     page = resp.find('div', {'id': 'content'}).main
 
-    assert normalize_spaces(page.h1.text) == 'Choose service'
+    assert normalize_spaces(page.h1.text) == 'All services'
     outer_list_items = page.select('nav ul')[0].select('li')
 
     assert len(outer_list_items) == 7
@@ -149,7 +149,7 @@ def test_choose_account_should_show_choose_accounts_page_if_no_services(
     links = page.findAll('a')
     assert len(links) == 1
     add_service_link = links[0]
-    assert normalize_spaces(page.h1.text) == 'Choose service'
+    assert normalize_spaces(page.h1.text) == 'All services'
     assert normalize_spaces(add_service_link.text) == 'Add a new service'
     assert add_service_link['href'] == url_for('main.add_service')
 
@@ -233,7 +233,7 @@ def test_choose_account_should_not_show_back_to_service_link_if_service_archived
         session['service_id'] = service_one['id']
     page = client_request.get('main.choose_account')
 
-    assert normalize_spaces(page.select_one('h1').text) == 'Choose service'
+    assert normalize_spaces(page.select_one('h1').text) == 'All services'
     assert page.select_one('.navigation-service a') is None
 
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3745,7 +3745,7 @@ def test_archive_service_after_confirm(
     )
 
     mocked_fn.assert_called_once_with('/service/{}/archive'.format(SERVICE_ONE_ID), data=None)
-    assert normalize_spaces(page.select_one('h1').text) == 'Choose service'
+    assert normalize_spaces(page.select_one('h1').text) == 'All services'
     assert normalize_spaces(page.select_one('.banner-default-with-tick').text) == (
         '‘service one’ was deleted'
     )


### PR DESCRIPTION
# Summary | Résumé

Before: `Choose service` heading (even when no service existed)
---

After: `All services`heading
---

<img width="1145" alt="Screen Shot 2021-02-02 at 5 13 53 PM" src="https://user-images.githubusercontent.com/38330843/106670078-92e79c80-657a-11eb-91d4-e4714697ea76.png">
