### PR TITLE
feat: add create an account on why notify

### DIFF
--- a/app/templates/views/why-notify.html
+++ b/app/templates/views/why-notify.html
@@ -56,6 +56,10 @@
 </div>
 <div class="pl-24">
   <p>{{ _('Try out GC Notify before committing. When you create an account you will start in trial mode allowing you to experiment by sending messages to yourself and other people on your team. Once you’ve updated your settings and added examples of messages you want to send, you can request to go live with your service to send to more recipients.') }}</p>
+
+  {% if not current_user.is_authenticated %}
+    <p><a href="{{ url_for('main.register') }}">{{ _('Create an account and try it for yourself') }}</a></p>
+  {% endif %}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Add a nudge to register "Create an account and try it for yourself" at the bottom of the "Why Notify" page if folks are not logged in.

![Screen Shot 2021-02-05 at 12 58 49](https://user-images.githubusercontent.com/295709/107070887-eabc1880-67b1-11eb-8585-9ce36b35dc53.png)


Something similar is done on the "Features" page as well.