### PR TITLE
feat: update fallback for geolocate service

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -101,7 +101,7 @@ class Config(object):
 
     HIPB_ENABLED = True
 
-    IP_GEOLOCATE_SERVICE = os.environ.get('IP_GEOLOCATE_SERVICE', None)
+    IP_GEOLOCATE_SERVICE = os.environ.get('IP_GEOLOCATE_SERVICE', "").rstrip("/")
 
     BULK_SEND_AWS_BUCKET = os.getenv('BULK_SEND_AWS_BUCKET')
     HC_EN_SERVICE_ID = os.getenv('HC_EN_SERVICE_ID')

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -82,8 +82,9 @@ def sign_in_again():
 
 
 def _geolocate_lookup(ip):
-    url = current_app.config.get('IP_GEOLOCATE_SERVICE', None) + ip
-    request = urllib.request.Request(url=url)
+    request = urllib.request.Request(
+        url=f"{current_app.config['IP_GEOLOCATE_SERVICE']}/{ip}"
+    )
 
     try:
         with urllib.request.urlopen(request) as f:
@@ -96,7 +97,7 @@ def _geolocate_lookup(ip):
 
 
 def _geolocate_ip(ip):
-    if current_app.config.get('IP_GEOLOCATE_SERVICE') is None:
+    if not current_app.config['IP_GEOLOCATE_SERVICE'].startswith('http'):
         return
     resp = _geolocate_lookup(ip)
 

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -265,7 +265,7 @@ def test_sign_in_geolookup_disabled_in_dev(
     mock_get_security_keys,
     mocker
 ):
-    assert current_app.config.get('IP_GEOLOCATE_SERVICE') is None
+    assert current_app.config['IP_GEOLOCATE_SERVICE'] == ""
 
     mocker.patch('app.user_api_client.get_user', return_value=api_user_active_email_auth)
     mocker.patch('app.user_api_client.get_user_by_email', return_value=api_user_active_email_auth)


### PR DESCRIPTION
Update the fallback mechanism for the env `IP_GEOLOCATE_SERVICE`. Previously, in order to deactivate this feature the env variable would need to be absent. Having it present and set to a `""`/`False` would not disable the feature.

This PR makes sure that the feature is only enabled if we put an HTTP-like value. It also removes the required `/` at the end of the domain (it's unsual to be forced to put a base URL ending with a slash)
https://github.com/cds-snc/notification-manifests/blob/23f3bb87a8e4900a5b000b65f26e9237e90bcd07/base/admin-deployment.yaml#L93-L94 and now accepts a value ending with a `/` or not.