### PR TITLE
added prefixes for nav views to fix missing context on 404 results

### DIFF
--- a/app/templates/partials/nav/gc_header.html
+++ b/app/templates/partials/nav/gc_header.html
@@ -89,7 +89,7 @@
             aria-label="{{ _('Switch services') }}"
             class="inline"
             id="choose_account"
-            href="{{ url_for('.choose_account') }}"
+            href="{{ url_for('main.choose_account') }}"
             role="button">
             {{ _('Switch services') }}
           </a>

--- a/app/templates/partials/nav/gc_header_nav.html
+++ b/app/templates/partials/nav/gc_header_nav.html
@@ -65,35 +65,35 @@
           {% if not current_user.platform_admin %}
             {% if current_user.has_permissions() %}
               {% if current_user.has_permissions('view_activity') %}
-                {{ nav_menu_item(url_for('.service_dashboard', service_id=current_service.id),_('Dashboard'),'pl-0 header--'+header_navigation.is_selected('dashboard')) }}
+                {{ nav_menu_item(url_for('main.service_dashboard', service_id=current_service.id),_('Dashboard'),'pl-0 header--'+header_navigation.is_selected('dashboard')) }}
               {% endif %}
-              {{ nav_menu_item( url_for('.choose_template', service_id=current_service.id),_('Templates'),'header--'+header_navigation.is_selected('templates')) }}
+              {{ nav_menu_item( url_for('main.choose_template', service_id=current_service.id),_('Templates'),'header--'+header_navigation.is_selected('templates')) }}
               {% if not current_user.has_permissions('view_activity') %}
-                {{ nav_menu_item(url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed'),_('Sent messages'),'header--'+header_navigation.is_selected('sent-messages')) }}
+                {{ nav_menu_item(url_for('main.view_notifications', service_id=current_service.id, status='sending,delivered,failed'),_('Sent messages'),'header--'+header_navigation.is_selected('sent-messages')) }}
                 {% if current_service.has_jobs %}
-                  {{ nav_menu_item(url_for('.view_jobs', service_id=current_service.id),_('Uploaded files'),'header--'+header_navigation.is_selected('uploaded-files')) }}
+                  {{ nav_menu_item(url_for('main.view_jobs', service_id=current_service.id),_('Uploaded files'),'header--'+header_navigation.is_selected('uploaded-files')) }}
                 {% endif %}
               {% endif %}
               {% if current_user.has_permissions('manage_api_keys') %}
-                {{ nav_menu_item(url_for('.api_integration', service_id=current_service.id),_('API integration'),'header--'+header_navigation.is_selected('api-integration')) }}
+                {{ nav_menu_item(url_for('main.api_integration', service_id=current_service.id),_('API integration'),'header--'+header_navigation.is_selected('api-integration')) }}
               {% endif %}
-              {{ nav_menu_item(url_for('.manage_users', service_id=current_service.id),_('Team members'),'header--'+header_navigation.is_selected('team-members')) }}
+              {{ nav_menu_item(url_for('main.manage_users', service_id=current_service.id),_('Team members'),'header--'+header_navigation.is_selected('team-members')) }}
               {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
-                {{ nav_menu_item(url_for('.service_settings', service_id=current_service.id),_('Settings'),'header--'+header_navigation.is_selected('settings')) }}
+                {{ nav_menu_item(url_for('main.service_settings', service_id=current_service.id),_('Settings'),'header--'+header_navigation.is_selected('settings')) }}
               {% endif %}
             {% else %} {# not current_user.has_permissions, i.e. services not in context #}
-              {{ nav_menu_item(url_for('.choose_account'),_('Your services'),'header--'+header_navigation.is_selected('choose_account'),id_key='choose_account') }}
+              {{ nav_menu_item(url_for('main.choose_account'),_('Your services'),'header--'+header_navigation.is_selected('choose_account'),id_key='choose_account') }}
               {{ nav_menu_item(url_for('main.contact', service_id=current_service.id),_('Contact us'),'header--'+header_navigation.is_selected('contact')) }}
             {% endif %}
           {% else %} {# current_user.platform_admin #}
             {% if not platform_admin_view_ind %}
               {% if current_user.has_permissions() %}
-                {{ nav_menu_item(url_for('.live_services', service_id=current_service.id), _('Platform admin'), 'pl-0') }}
-                {{ nav_menu_item(url_for('.service_dashboard', service_id=current_service.id),_('Dashboard'),'header--'+header_navigation.is_selected('dashboard')) }}
-                {{ nav_menu_item( url_for('.choose_template', service_id=current_service.id),_('Templates'),'header--'+header_navigation.is_selected('templates')) }}
-                {{ nav_menu_item(url_for('.api_integration', service_id=current_service.id),_('API integration'),'header--'+header_navigation.is_selected('api-integration')) }}
-                {{ nav_menu_item(url_for('.manage_users', service_id=current_service.id),_('Team members'),'header--'+header_navigation.is_selected('team-members')) }}
-                {{ nav_menu_item(url_for('.service_settings', service_id=current_service.id),_('Settings'),'header--'+header_navigation.is_selected('settings')) }}
+                {{ nav_menu_item(url_for('main.live_services', service_id=current_service.id), _('Platform admin'), 'pl-0') }}
+                {{ nav_menu_item(url_for('main.service_dashboard', service_id=current_service.id),_('Dashboard'),'header--'+header_navigation.is_selected('dashboard')) }}
+                {{ nav_menu_item( url_for('main.choose_template', service_id=current_service.id),_('Templates'),'header--'+header_navigation.is_selected('templates')) }}
+                {{ nav_menu_item(url_for('main.api_integration', service_id=current_service.id),_('API integration'),'header--'+header_navigation.is_selected('api-integration')) }}
+                {{ nav_menu_item(url_for('main.manage_users', service_id=current_service.id),_('Team members'),'header--'+header_navigation.is_selected('team-members')) }}
+                {{ nav_menu_item(url_for('main.service_settings', service_id=current_service.id),_('Settings'),'header--'+header_navigation.is_selected('settings')) }}
                 {{ nav_menu_item(url_for('main.smtp_integration', service_id=current_service.id),_('SMTP'),'header--'+header_navigation.is_selected('smtp-integration')) }}
               {% else %} {# not current_user.has_permissions, i.e. services not in context #}
                 {{ nav_menu_item(url_for('main.choose_account'),_('Your services'),'pl-0 header--'+header_navigation.is_selected('choose_account'),id_key='choose_account') }}

--- a/app/templates/partials/nav/gc_header_nav_mobile.html
+++ b/app/templates/partials/nav/gc_header_nav_mobile.html
@@ -30,21 +30,21 @@
           <!-- service menu dropdown / signed in / mobile -->
           {% if current_user.has_permissions() %} {# service in the context #}
             {% if current_user.has_permissions('view_activity') %}
-              {{ nav_menu_item_mobile(url_for('.service_dashboard', service_id=current_service.id),_('Dashboard'),'menu--'+header_navigation.is_selected('dashboard')) }}
+              {{ nav_menu_item_mobile(url_for('main.service_dashboard', service_id=current_service.id),_('Dashboard'),'menu--'+header_navigation.is_selected('dashboard')) }}
             {% endif %}
-            {{ nav_menu_item_mobile( url_for('.choose_template', service_id=current_service.id),_('Templates'),'menu--'+header_navigation.is_selected('templates')) }}
+            {{ nav_menu_item_mobile( url_for('main.choose_template', service_id=current_service.id),_('Templates'),'menu--'+header_navigation.is_selected('templates')) }}
             {% if not current_user.has_permissions('view_activity') %}
-              {{ nav_menu_item_mobile(url_for('.view_notifications', service_id=current_service.id, status='sending,delivered,failed'),_('Sent messages'),'menu--'+header_navigation.is_selected('sent-messages')) }}
+              {{ nav_menu_item_mobile(url_for('main.view_notifications', service_id=current_service.id, status='sending,delivered,failed'),_('Sent messages'),'menu--'+header_navigation.is_selected('sent-messages')) }}
               {% if current_service.has_jobs %}
-                {{ nav_menu_item_mobile(url_for('.view_jobs', service_id=current_service.id),_('Uploaded files'),'menu--'+header_navigation.is_selected('uploaded-files')) }}
+                {{ nav_menu_item_mobile(url_for('main.view_jobs', service_id=current_service.id),_('Uploaded files'),'menu--'+header_navigation.is_selected('uploaded-files')) }}
               {% endif %}
             {% endif %}
             {% if current_user.has_permissions('manage_api_keys') %}
-              {{ nav_menu_item_mobile(url_for('.api_integration', service_id=current_service.id),_('API integration'),'menu--'+header_navigation.is_selected('api-integration')) }}
+              {{ nav_menu_item_mobile(url_for('main.api_integration', service_id=current_service.id),_('API integration'),'menu--'+header_navigation.is_selected('api-integration')) }}
             {% endif %}
-            {{ nav_menu_item_mobile(url_for('.manage_users', service_id=current_service.id),_('Team members'),'menu--'+header_navigation.is_selected('team-members')) }}
+            {{ nav_menu_item_mobile(url_for('main.manage_users', service_id=current_service.id),_('Team members'),'menu--'+header_navigation.is_selected('team-members')) }}
             {% if current_user.has_permissions('manage_api_keys', 'manage_service') %}
-              {{ nav_menu_item_mobile(url_for('.service_settings', service_id=current_service.id),_('Settings'),'menu--'+header_navigation.is_selected('settings')) }}
+              {{ nav_menu_item_mobile(url_for('main.service_settings', service_id=current_service.id),_('Settings'),'menu--'+header_navigation.is_selected('settings')) }}
             {% endif %}
           {% else %} {# not current_user.has_permissions() / no service in context #}
             {{ nav_menu_item_mobile(url_for('main.choose_account', service_id=current_service.id),_('Your services'),'menu--'+header_navigation.is_selected('choose_account')) }}
@@ -54,7 +54,7 @@
         {% else %} {# current_user.platform_admin #}
           <!-- service menu dropdown / signed in / admin / mobile -->
           {% if platform_admin_view_ind %}
-            {{ nav_menu_item_mobile(url_for('.choose_account', service_id=current_service.id),_('Your services'),'menu--'+header_navigation.is_selected('choose_account')) }}
+            {{ nav_menu_item_mobile(url_for('main.choose_account', service_id=current_service.id),_('Your services'),'menu--'+header_navigation.is_selected('choose_account')) }}
             {% for link_text, view in [
             ('Live services', 'live_services'),
             ('Trial mode services', 'trial_services'),
@@ -73,12 +73,12 @@
             {% endfor %}
           {% else %} {# not platform_admin_view_ind #}
             {% if current_user.has_permissions() %} {# Service in context #}
-              {{ nav_menu_item_mobile(url_for('.live_services', service_id=current_service.id),_('Platform admin')) }}
-              {{ nav_menu_item_mobile(url_for('.service_dashboard', service_id=current_service.id),_('Dashboard'),'menu--'+header_navigation.is_selected('dashboard')) }}
-              {{ nav_menu_item_mobile( url_for('.choose_template', service_id=current_service.id),_('Templates'),'menu--'+header_navigation.is_selected('templates')) }}
-              {{ nav_menu_item_mobile(url_for('.api_integration', service_id=current_service.id),_('API integration'),'menu--'+header_navigation.is_selected('api-integration')) }}
-              {{ nav_menu_item_mobile(url_for('.manage_users', service_id=current_service.id),_('Team members'),'menu--'+header_navigation.is_selected('team-members')) }}
-              {{ nav_menu_item_mobile(url_for('.service_settings', service_id=current_service.id),_('Settings'),'menu--'+header_navigation.is_selected('settings')) }}
+              {{ nav_menu_item_mobile(url_for('main.live_services', service_id=current_service.id),_('Platform admin')) }}
+              {{ nav_menu_item_mobile(url_for('main.service_dashboard', service_id=current_service.id),_('Dashboard'),'menu--'+header_navigation.is_selected('dashboard')) }}
+              {{ nav_menu_item_mobile( url_for('main.choose_template', service_id=current_service.id),_('Templates'),'menu--'+header_navigation.is_selected('templates')) }}
+              {{ nav_menu_item_mobile(url_for('main.api_integration', service_id=current_service.id),_('API integration'),'menu--'+header_navigation.is_selected('api-integration')) }}
+              {{ nav_menu_item_mobile(url_for('main.manage_users', service_id=current_service.id),_('Team members'),'menu--'+header_navigation.is_selected('team-members')) }}
+              {{ nav_menu_item_mobile(url_for('main.service_settings', service_id=current_service.id),_('Settings'),'menu--'+header_navigation.is_selected('settings')) }}
               {{ nav_menu_item_mobile(url_for('main.smtp_integration', service_id=current_service.id),_('SMTP'),'menu--'+header_navigation.is_selected('smtp-integration')) }}
             {% else %} {# current_user.has_permissions() #}
               {{ nav_menu_item_mobile(url_for('main.choose_account', service_id=current_service.id),_('Your services'),'menu--'+header_navigation.is_selected('choose_account')) }}


### PR DESCRIPTION
Fixes additional user contexts for issue on PR #922 

When a user hits the 404, the prefix for url mapping is required due to how the user context is populated combined with how flask resolves the url.

**Reproduce in staging:**
Login as regular user (not platform admin), try a URL without being in a service context such as:
[https://staging.notification.cdssandbox.xyz/NOTHINGHERE](https://staging.notification.cdssandbox.xyz/NOTHINGHERE)
_Current result is a public facing 500 internal server error_

_Expected result after fix should be a regular 404 page_


Example error when a user is not in a service context but reaches 404.
`
404 Not Found: The requested URL was not found on the server.
During handling of the above exception, another exception occurred:
Could not build url for endpoint 'choose_account'. Did you mean 'main.choose_account' instead?
raise value.with_traceback(tb
File \"/app/app/templates/error/500.html\", line 1, in top-level template code
{% extends  \"admin_template.html\" %
File \"/app/app/templates/admin_template.html\", line 9, in top-level template code
{% set extra_title = ' - ' + current_service.name if current_service.name and current_user.has_permissions() else ''  %
File \"/app/app/templates/main_template.html\", line 110, in top-level template code
{% block gc_header %
File \"/app/app/templates/main_template.html\", line 114, in block \"gc_header
{% include 'partials/nav/gc_header_nav.html' %
File \"/app/app/templates/partials/nav/gc_header_nav.html\", line 85, in top-level template code
{{ nav_menu_item(url_for('.choose_account'),_('Your services'),'header--'+header_navigation.is_selected('choose_account'),id_key='choose_account') }
File \"/usr/local/lib/python3.9/site-packages/flask/helpers.py\", line 370, in url_for
return appctx.app.handle_url_build_error(error, endpoint, values
File \"/usr/local/lib/python3.9/site-packages/flask/app.py\", line 2216, in handle_url_build_error
reraise(exc_type, exc_value, tb
File \"/usr/local/lib/python3.9/site-packages/flask/_compat.py\", line 39, in reraise
raise value
File \"/usr/local/lib/python3.9/site-packages/flask/helpers.py\", line 357, in url_for
rv = url_adapter.build(\n
File \"/usr/local/lib/python3.9/site-packages/werkzeug/routing.py\", line 2179, in build
raise BuildError(endpoint, values, method, self)
`