### PR TITLE
Missing French translation for alt text on homepage

### DIFF
--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -76,12 +76,21 @@
               </div>
             </div>
             <div class="pt-6 pb-6 ml-10 image-content hidden lg:block lg:visible">
+              {% if session["userlang"] == "en" %}
               <img
                 loading="lazy"
                 alt="An illustration of a laptop with a message window on the screen and a cellphone with a message and a callout blurb."
                 src="{{ asset_s3_url('mac-phone.svg') }}"
                 width="350"
               />
+              {% else %}
+              <img
+                loading="lazy"
+                alt="Illustration d'un ordinateur portable dont l'écran affiche une fenêtre avec un message et d'un téléphone cellulaire affichant un message et une bulle de texte."
+                src="{{ asset_s3_url('mac-phone.svg') }}"
+                width="350"
+              />
+            {% endif %}
             </div>
           </div>
         </div>


### PR DESCRIPTION
**Top banner image:**

alt="Illustration d'un ordinateur portable dont l'écran affiche une fenêtre avec un message et d'un téléphone cellulaire affichant un message et une bulle de texte."

> Do we want to fix the non-standard hardcoded localisations in the file using `if.. else.. endif` statements? See Trello for more details: https://trello.com/c/ByGjBswg/346-translate-alternative-text-on-images-in-the-signed-out-view-for-accessibility 

