### PR TITLE
added cron schedule for after hours CI tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,8 @@
-on: push
+on:
+  push:
+  schedule:
+    - cron: '1 0-12,20-23 * * 1-5'
+    - cron: '1 * * * 0,6'
 name: Continuous Integration Testing
 jobs:
   test:


### PR DESCRIPTION
Trello:
https://trello.com/c/WZuI7jWL/312-admin-and-api-tests-suites-should-succeed-at-night

Added identical cron schedule as what API is set for hourly evening and weekend tests.