### PR TITLE
feat: redirect to your services as a platform admin

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -97,7 +97,7 @@ def redirect_when_logged_in(user, platform_admin):
     if next_url and _is_safe_redirect_url(next_url):
         url = next_url
     elif platform_admin:
-        url = url_for('main.platform_admin')
+        url = url_for('main.choose_account')
     else:
         url = url_for('main.show_accounts_or_dashboard')
 

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -133,7 +133,7 @@ def test_sms_should_login_user_and_should_redirect_to_next_url(
 
 
 @pytest.mark.parametrize('method', ['email', 'sms'])
-def test_should_login_platform_admin_user_and_should_redirect_to_next_url(
+def test_should_login_platform_admin_user_and_redirect_to_your_services(
     client,
     platform_admin_user,
     mocker,


### PR DESCRIPTION
Go to 'Your services' rather than Admin panel from the Sign-in history

Trello card: https://trello.com/c/fkVvilbg/362-go-to-your-services-rather-than-admin-panel-from-the-sign-in-history

---

## Testing

Use the review app and log in as a Platform Admin