### PR TITLE
fix: display custom sending domain in settings if set

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -81,7 +81,6 @@ PLATFORM_ADMIN_SERVICE_PERMISSIONS = OrderedDict([
 @main.route("/services/<service_id>/service-settings")
 @user_has_permissions('manage_service', 'manage_api_keys')
 def service_settings(service_id: str):
-
     limits = {
         'free_yearly_email': current_app.config["FREE_YEARLY_EMAIL_LIMIT"],
         'free_yearly_sms': current_app.config["FREE_YEARLY_SMS_LIMIT"]
@@ -91,7 +90,7 @@ def service_settings(service_id: str):
     return render_template(
         'views/service-settings.html',
         service_permissions=PLATFORM_ADMIN_SERVICE_PERMISSIONS,
-        sending_domain=current_app.config["SENDING_DOMAIN"],
+        sending_domain=current_service.sending_domain or current_app.config["SENDING_DOMAIN"],
         limits=limits
     )
 

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% set change_txt = _('Change') %}
-{% set display_email_from = current_service.email_from +'@' + sending_domain %}
+{% set display_email_from = current_service.email_from + '@' + sending_domain %}
 
 {% block maincolumn_content %}
 
@@ -410,8 +410,7 @@
           {% call row() %}
           {% set txt = _('Sending domain') %}
           {{ text_field(txt) }}
-          {% set txt = _('{}') %}
-          {{ text_field(txt.format(current_service.sending_domain)|safe if current_service.sending_domain else sending_domain) }}
+          {{ text_field(sending_domain) }}
           {{ edit_field(
             change_txt,
             url_for('.service_sending_domain', service_id=current_service.id),

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -56,8 +56,8 @@ def mock_get_service_settings_page_common(
     return
 
 
-@pytest.mark.parametrize('user, expected_rows', [
-    (active_user_with_permissions, [
+@pytest.mark.parametrize('user, sending_domain, expected_rows', [
+    (active_user_with_permissions, None, [
 
         'Label Value Action',
         'Service name Test Service Change',
@@ -78,7 +78,7 @@ def mock_get_service_settings_page_common(
         'Send international text messages Off Change',
         'Yearly free maximum 25,000 text messages',
     ]),
-    (platform_admin_user, [
+    (platform_admin_user, 'test.example.com', [
 
         'Label Value Action',
         'Service name Test Service Change',
@@ -117,23 +117,28 @@ def mock_get_service_settings_page_common(
     ]),
 ])
 def test_should_show_overview(
-        client,
-        mocker,
-        api_user_active,
-        fake_uuid,
-        no_reply_to_email_addresses,
-        no_letter_contact_blocks,
-        mock_get_service_organisation,
-        single_sms_sender,
-        user,
-        expected_rows,
-        mock_get_service_settings_page_common,
+    client,
+    mocker,
+    api_user_active,
+    fake_uuid,
+    no_reply_to_email_addresses,
+    no_letter_contact_blocks,
+    mock_get_service_organisation,
+    single_sms_sender,
+    user,
+    sending_domain,
+    expected_rows,
+    mock_get_service_settings_page_common,
+    app_,
 ):
-    service_one = service_json(SERVICE_ONE_ID,
-                               users=[api_user_active['id']],
-                               permissions=['sms', 'email'],
-                               organisation_id=ORGANISATION_ID,
-                               restricted=False)
+    service_one = service_json(
+        SERVICE_ONE_ID,
+        users=[api_user_active['id']],
+        permissions=['sms', 'email'],
+        organisation_id=ORGANISATION_ID,
+        restricted=False,
+        sending_domain=sending_domain,
+    )
     mocker.patch('app.service_api_client.get_service', return_value={'data': service_one})
 
     client.login(user(fake_uuid), mocker, service_one)
@@ -145,9 +150,9 @@ def test_should_show_overview(
     assert page.find('h1').text == 'Settings'
     rows = page.select('tr')
     for index, row in enumerate(expected_rows):
-        formatted_row = row.format(sending_domain=os.environ.get(
-            'SENDING_DOMAIN', 'notification.alpha.canada.ca'
-        ))
+        formatted_row = row.format(
+            sending_domain=sending_domain or app_.config['SENDING_DOMAIN']
+        )
         assert formatted_row == " ".join(rows[index].text.split())
     app.service_api_client.get_service.assert_called_with(SERVICE_ONE_ID)
 


### PR DESCRIPTION
Use the custom sending domain in service settings, if it set, in the "Sending email address" field in service settings.

At the moment there is a bug where the displayed domain is always the default Notify domain, even if the service uses a custom sending domain.

Fixes https://github.com/cds-snc/notification-admin/commit/366e065e14773d0343f4a346a0a47bd84827515c