### PR TITLE
feat: add a11y tracking to staging env

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -68,5 +68,5 @@ jobs:
         run: |
           curl -s https://api.a11y.cdssandbox.xyz/v1/reports\?recent\=true > /dev/null
           sleep 60
-          json='{"product": "cds-snc/notification", "revision": "${{github.sha}}", "urls":["https://staging.notification.cdssandbox.xyz"], "spider": 1}'
+          json='{"product": "cds-snc/notification", "revision": "${{github.sha}}", "urls":["https://staging.notification.cdssandbox.xyz"], "spider": 1, "ci": 1}'
           curl -X POST -H 'X-API-KEY: ${{ secrets.A11Y_TRACKER_KEY }}' --data "$json" https://api.a11y.cdssandbox.xyz/v1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -61,12 +61,12 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
         kubectl set image deployment.apps/admin admin=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+    - uses: cds-snc/notification-pr-bot@master
+      env:
+        TOKEN: ${{ secrets.TOKEN }}
     - name: Run a11y tracker
         run: |
           curl -s https://api.a11y.cdssandbox.xyz/v1/reports\?recent\=true > /dev/null
           sleep 60
           json='{"product": "cds-snc/notification", "revision": "${{github.sha}}", "urls":["https://staging.notification.cdssandbox.xyz"], "spider": 1}'
           curl -X POST -H 'X-API-KEY: ${{ secrets.A11Y_TRACKER_KEY }}' --data "$json" https://api.a11y.cdssandbox.xyz/v1
-    - uses: cds-snc/notification-pr-bot@master
-      env:
-        TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -61,6 +61,12 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
         kubectl set image deployment.apps/admin admin=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+    - name: Run a11y tracker
+        run: |
+          curl -s https://api.a11y.cdssandbox.xyz/v1/reports\?recent\=true > /dev/null
+          sleep 60
+          json='{"product": "cds-snc/notification", "revision": "${{github.sha}}", "urls":["https://staging.notification.cdssandbox.xyz"], "spider": 1}'
+          curl -X POST -H 'X-API-KEY: ${{ secrets.A11Y_TRACKER_KEY }}' --data "$json" https://api.a11y.cdssandbox.xyz/v1
     - uses: cds-snc/notification-pr-bot@master
       env:
         TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
This PR adds a call to the a11y tracking tools into the CI pipeline. After the admin component has been deployed it will make an API call to the a11y tracking tools API that request a spidering of the public facing pages of notify's staging environment.