### PR TITLE
feat: clarify free limits in service settings

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1119,11 +1119,11 @@ class ServiceOnOffSettingForm(StripWhitespaceForm):
 
 class ServiceSwitchChannelForm(ServiceOnOffSettingForm):
     def __init__(self, channel, *args, **kwargs):
-        name = '{} {}'.format(_l('Send'), {
-            'email': _l('emails'),
-            'sms': _l('text messages'),
-            'letter': _l('letters'),
-        }.get(channel))
+        name = _l('Send {}'.format({
+            'email': 'emails',
+            'sms': 'text messages',
+            'letter': 'letters',
+        }.get(channel)))
 
         super().__init__(name, *args, **kwargs)
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -790,6 +790,10 @@ def service_set_channel(service_id, channel):
     return render_template(
         'views/service-settings/set-{}.html'.format(channel),
         form=form,
+        limits={
+            'free_yearly_email': current_app.config["FREE_YEARLY_EMAIL_LIMIT"],
+            'free_yearly_sms': current_app.config["FREE_YEARLY_SMS_LIMIT"],
+        }
     )
 
 

--- a/app/templates/views/service-settings/set-email.html
+++ b/app/templates/views/service-settings/set-email.html
@@ -17,7 +17,7 @@
         back_link=url_for('main.service_settings', service_id=current_service.id)
       ) }}
       <p>
-        {{ _('It’s free to send emails through GC Notify.') }}
+        {{ _("You can send up to {} million emails per year for free").format((limits.free_yearly_email//1000000) | format_number) }}
       </p>
       {% call form_wrapper() %}
         {% set save_txt = _('Save') %}

--- a/app/templates/views/service-settings/set-email.html
+++ b/app/templates/views/service-settings/set-email.html
@@ -17,7 +17,7 @@
         back_link=url_for('main.service_settings', service_id=current_service.id)
       ) }}
       <p>
-        {{ _("You can send up to {} million emails per year for free").format((limits.free_yearly_email//1000000) | format_number) }}
+        {{ _("You can send up to {} million emails per year for free.").format((limits.free_yearly_email//1000000) | format_number) }}
       </p>
       {% call form_wrapper() %}
         {% set save_txt = _('Save') %}

--- a/app/templates/views/service-settings/set-sms.html
+++ b/app/templates/views/service-settings/set-sms.html
@@ -18,7 +18,7 @@
       ) }}
       <p>
         {{ _('You have a free allowance of') }}
-        {{ '{:,}'.format(current_service.free_sms_fragment_limit) }} {{ _('text messages each financial year.') }}
+        {{ limits.free_yearly_sms | format_number }} {{ _('text messages each financial year.') }}
       </p>
       {% call form_wrapper() %}
         {{ radios(form.enabled) }}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1296,6 +1296,7 @@
 "{} million emails","{} millions de courriels"
 "{} text messages","{} messages texte"
 "Yearly free maximum","Maximum gratuit annuel"
+"You can send up to {} million emails per year for free","Vous pouvez envoyer jusqu’ à {} millions de courriels gratuitement par année"
 "External link","Lien externe"
 "Separator","Séparateur"
 "Trial","Mode d'essai"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1296,7 +1296,7 @@
 "{} million emails","{} millions de courriels"
 "{} text messages","{} messages texte"
 "Yearly free maximum","Maximum gratuit annuel"
-"You can send up to {} million emails per year for free.","Vous pouvez envoyer jusqu’ à {} millions de courriels gratuitement par année."
+"You can send up to {} million emails per year for free.","Vous pouvez envoyer jusqu’à {} millions de courriels gratuitement par année."
 "External link","Lien externe"
 "Separator","Séparateur"
 "Trial","Mode d'essai"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1296,7 +1296,7 @@
 "{} million emails","{} millions de courriels"
 "{} text messages","{} messages texte"
 "Yearly free maximum","Maximum gratuit annuel"
-"You can send up to {} million emails per year for free","Vous pouvez envoyer jusqu’ à {} millions de courriels gratuitement par année"
+"You can send up to {} million emails per year for free.","Vous pouvez envoyer jusqu’ à {} millions de courriels gratuitement par année."
 "External link","Lien externe"
 "Separator","Séparateur"
 "Trial","Mode d'essai"

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3016,7 +3016,7 @@ def test_unknown_channel_404s(
     ),
     (
         'email',
-        'It’s free to send emails through GC Notify.',
+        'You can send up to 10 million emails per year for free.',
         'Send emails',
         [],
         'False', 'True',
@@ -3024,7 +3024,7 @@ def test_unknown_channel_404s(
     ),
     (
         'email',
-        'It’s free to send emails through GC Notify.',
+        'You can send up to 10 million emails per year for free.',
         'Send emails',
         ['email', 'sms', 'letter'],
         'True', 'True',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3008,7 +3008,7 @@ def test_unknown_channel_404s(
     ),
     (
         'sms',
-        'You have a free allowance of 250,000 text messages each financial year.',
+        'You have a free allowance of 25,000 text messages each financial year.',
         'Send text messages',
         [],
         'False', 'True',


### PR DESCRIPTION
Some pages were wrong about the information displayed.

This page was visible from Settings > Send emails

![Screen Shot 2021-04-12 at 11 09 07](https://user-images.githubusercontent.com/295709/114417419-95203580-9b7f-11eb-96a1-b27ea095a087.png)
