### PR TITLE
Remove mention of Travis on healthcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 
 .PHONY: generate-version-file
 generate-version-file: ## Generates the app version file
-	printf "__travis_commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"\n__travis_job_number__ = \"0\"\n__travis_job_url__ = \"\"\n" > ${APP_VERSION_FILE}
+	printf "__commit_sha__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"\n" > ${APP_VERSION_FILE}
 
 .PHONY: test
 test:

--- a/app/status/views/healthcheck.py
+++ b/app/status/views/healthcheck.py
@@ -18,6 +18,5 @@ def show_status():
         return jsonify(
             status="ok",
             api=api_status,
-            travis_commit=version.__travis_commit__,
-            travis_build_number=version.__travis_job_number__,
+            commit_sha=version.__commit_sha__,
             build_time=version.__time__), 200


### PR DESCRIPTION
We do not use Travis, remove those fields from the Makefile and the healthcheck page https://notification.canada.ca/_status.

They are creating confusion for developers.

See also https://github.com/cds-snc/notification-api/pull/1264