### PR TITLE
feat: add years switches for months and templates

### DIFF
--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -12,6 +12,14 @@
 
   <h1 class="heading-large">{{ _('Templates used') }}</h1>
 
+  <div class="mb-6">
+    {{ pill(
+      items=years,
+      current_value=selected_year,
+      big_number_args={'smallest': True},
+    ) }}
+  </div>
+
   <div class="dashboard">
     {% for month in months %}
       <h2>{{ _(month.name) }}</h2>
@@ -30,7 +38,7 @@
             empty_message='',
             field_headings=[
                 template_txt,
-                messages_txt 
+                messages_txt
             ],
             field_headings_visible=False
           ) %}

--- a/app/templates/views/dashboard/all-template-statistics.html
+++ b/app/templates/views/dashboard/all-template-statistics.html
@@ -55,4 +55,8 @@
     {% endfor %}
   </div>
 
+  <p class="align-with-heading-copy">
+    {{ _('Fiscal year ends 31 March.') }}
+  </p>
+
 {% endblock %}

--- a/app/templates/views/dashboard/monthly.html
+++ b/app/templates/views/dashboard/monthly.html
@@ -75,7 +75,6 @@
     </div>
   {% endif %}
 
-
   <p class="align-with-heading-copy">
     {{ _('Fiscal year ends 31 March.') }}
   </p>

--- a/app/templates/views/dashboard/monthly.html
+++ b/app/templates/views/dashboard/monthly.html
@@ -15,14 +15,20 @@
   <h1 class="heading-large">
     {{ _('Messages sent') }}
   </h1>
-  
-  <!-- @todo -> in 2020 add monthly?year=2020 + /monthly?year=2019 -->
-  
+
+  <div class="mb-6">
+    {{ pill(
+      items=years,
+      current_value=selected_year,
+      big_number_args={'smallest': True},
+    ) }}
+  </div>
+
   {% if months %}
-   {% set spend_txt = _('Total spend') %} 
-   {% set heading_1 = _('Month') %} 
-   {% set heading_2 = _('Emails') %} 
-   {% set heading_3 = _('Text messages') %} 
+   {% set spend_txt = _('Total spend') %}
+   {% set heading_1 = _('Month') %}
+   {% set heading_2 = _('Emails') %}
+   {% set heading_3 = _('Text messages') %}
     <div class="body-copy-table" id='pill-selected-item'>
       {% call(month, row_index) list_table(
         months,
@@ -69,11 +75,9 @@
     </div>
   {% endif %}
 
-  
-<!--
+
   <p class="align-with-heading-copy">
     {{ _('Fiscal year ends 31 March.') }}
   </p>
-  -->
 
 {% endblock %}

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -329,6 +329,29 @@ def test_monthly_shows_letters_in_breakdown(
     assert normalize_spaces(columns[1].text) == 'text messages'
 
 
+@pytest.mark.parametrize('endpoint', [
+    'main.monthly',
+    'main.template_usage',
+])
+@freeze_time("2015-01-01 15:15:15.000000")
+def test_stats_pages_show_last_3_years(
+    client_request,
+    endpoint,
+    mock_get_monthly_notification_stats,
+    mock_get_monthly_template_usage,
+):
+    page = client_request.get(
+        endpoint,
+        service_id=SERVICE_ONE_ID,
+    )
+
+    assert normalize_spaces(page.select_one('.pill').text) == (
+        '2012 to 2013 financial year '
+        '2013 to 2014 financial year '
+        '2014 to 2015 financial year'
+    )
+
+
 def test_monthly_has_equal_length_tables(
     client_request,
     service_one,


### PR DESCRIPTION
Reverting https://github.com/cds-snc/notification-admin/pull/291 basically. You can check the new UI on the review app.

![Screen Shot 2021-04-20 at 14 11 40](https://user-images.githubusercontent.com/295709/115444288-5d9a3480-a1e2-11eb-8133-7cec1df5c1bb.png)

Trello: https://trello.com/c/Ymv2IWnn/455-be-able-to-switch-years-when-viewing-stats-on-the-dashboard