### PR TITLE
feat: set cache headers for static assets

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -651,7 +651,7 @@ def useful_headers_after_request(response):
     # Cache static assets (CSS, JS, images) for a long time
     # as they have unique hashes thanks to the asset
     # fingerprinter
-    if request.url.startswith(asset_fingerprinter._asset_root):
+    if asset_fingerprinter.is_static_asset(request.url):
         response.headers.add('Cache-Control', 'public, max-age=31536000, immutable')
     else:
         response.headers.add('Cache-Control', 'no-store, no-cache, private, must-revalidate')

--- a/app/asset_fingerprinter.py
+++ b/app/asset_fingerprinter.py
@@ -52,5 +52,8 @@ class AssetFingerprinter(object):
             contents = asset_file.read()
         return contents
 
+    def is_static_asset(self, url):
+        return url and url.startswith(self._asset_root)
+
 
 asset_fingerprinter = AssetFingerprinter()

--- a/app/config.py
+++ b/app/config.py
@@ -143,7 +143,6 @@ class Test(Development):
     ANTIVIRUS_API_HOST = 'https://test-antivirus'
     ANTIVIRUS_API_KEY = 'test-antivirus-secret'
     ASSET_DOMAIN = 'static.example.com'
-    ASSET_PATH = 'https://static.example.com/'
 
 
 class Production(Config):

--- a/app/templates/main_template.html
+++ b/app/templates/main_template.html
@@ -12,13 +12,13 @@
   <link
     rel="stylesheet"
     media="screen"
-    href="{{ asset_path }}stylesheets/index.css"
+    href="{{ asset_url('stylesheets/index.css') }}"
   />
 
 
   <link
     rel="shortcut icon"
-    href="{{ asset_path }}images/favicon.ico?0.24.2"
+    href="{{ asset_url('images/favicon.ico') }}"
     type="image/x-icon"
   />
 
@@ -34,7 +34,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta
     property="og:image"
-    content="{{ admin_base_url }}/static/images/product/notify-main.jpg"
+    content="{{ asset_url('images/product/notify-main.jpg') }}"
   />
   <script>
     window.APP_LANG = "{{ current_lang }}"

--- a/app/templates/notify_template.html
+++ b/app/templates/notify_template.html
@@ -6,7 +6,7 @@
     <title>{% block page_title %}Notify{% endblock %}</title>
     <link
       rel="shortcut icon"
-      href="{{ asset_path }}images/favicon.ico?0.24.2"
+      href="{{ asset_url('images/favicon.ico') }}"
       type="image/x-icon"
     />
     <link

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -11,14 +11,14 @@
   <meta property="og:description" content="{{ description }}"/>
   <meta
     property="og:image"
-    content="{{ admin_base_url }}/static/images/product/notify-main.jpg"
+    content="{{ asset_url('images/product/notify-main.jpg') }}"
   />
   <meta property="og:url" content="{{ admin_base_url }}"/>
 
   <link
     rel="stylesheet"
     media="screen"
-    href="{{ asset_path }}stylesheets/index.css"
+    href="{{ asset_url('stylesheets/index.css') }}"
   />
 
 {% endblock %}

--- a/tests/app/main/test_asset_fingerprinter.py
+++ b/tests/app/main/test_asset_fingerprinter.py
@@ -94,6 +94,16 @@ class TestAssetFingerprint(object):
 
         assert fingerprinter.get_s3_url('foo.png') == 'https://assets.example.com/static/foo.png'
 
+    def test_is_static_asset(self):
+        fingerprinter = AssetFingerprinter(
+            asset_root='https://example.com/static/',
+            cdn_domain='assets.example.com',
+        )
+
+        assert fingerprinter.is_static_asset('https://example.com/static/image.png')
+        assert not fingerprinter.is_static_asset('https://assets.example.com/image.png')
+        assert not fingerprinter.is_static_asset('https://example.com/robots.txt')
+
 
 class TestAssetFingerprintWithUnicode(object):
     def test_can_read_self(self):

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -189,12 +189,11 @@ def test_css_is_served_from_correct_path(client_request):
     for index, link in enumerate(
         page.select('link[rel=stylesheet]')
     ):
-
         assert link['href'].startswith([
-            'https://static.example.com/stylesheets/index.css',
+            'http://localhost:6012/static/stylesheets/index.css',
             'https://fonts.googleapis.com/css?family=Lato:400,700,900&display=swap',
             'https://fonts.googleapis.com/css?',
-            'https://static.example.com/stylesheets/main.css?',
+            'http://localhost:6012/static/stylesheets/main.css?',
         ][index])
 
 


### PR DESCRIPTION
Fixes https://github.com/cds-snc/notification-api/issues/1152

This PR adds appropriate `Cache-Control` headers for static assets (JS, CSS, images) served by the admin. This will improve the user experience for users, reduce the number of requests we have to handle and our costs.

Cache invalidation is done thanks to an [asset fingerprinter](https://github.com/cds-snc/notification-admin/blob/master/app/asset_fingerprinter.py). I've made sure that templates don't use hardcoded paths anymore by looking for thinks like `static/`, `asset_path` and `admin_base_url` in the codebase.
