### PR TITLE
fix: include image in nav menu item

### DIFF
--- a/app/templates/components/nav_menu_item.html
+++ b/app/templates/components/nav_menu_item.html
@@ -13,14 +13,15 @@
           {% else %}
           aria-label="{{ localised_txt }}"
           {% endif %}
-        >{{ localised_txt }}</a>
-        {% if external_link_img %}
-          <img
-            aria-hidden="true"
-            src="{{ external_link_img }}"
-            alt="{{ _('External link') }}"
-            class="inline w-8 h-8 ml-2 self-center"/>
-        {% endif %}
+        >{{ localised_txt }}
+          {% if external_link_img %}
+            <img
+              aria-hidden="true"
+              src="{{ external_link_img }}"
+              alt="{{ _('External link') }}"
+              class="inline w-8 h-8 ml-2 self-center"/>
+          {% endif %}
+        </a>
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
Broke this feature in #1002, sorry about that!

![Screen Shot 2021-04-27 at 15 07 05](https://user-images.githubusercontent.com/295709/116298281-41f6d700-a76a-11eb-83e0-82cd826bdd07.png)
