### PR TITLE
feat: opt out of Google FLoC

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -634,6 +634,7 @@ def useful_headers_after_request(response):
     response.headers.add('X-Frame-Options', 'deny')
     response.headers.add('X-Content-Type-Options', 'nosniff')
     response.headers.add('X-XSS-Protection', '1; mode=block')
+    response.headers.add('Permissions-Policy', 'interest-cohort=()')
     response.headers.add('Content-Security-Policy', (
         "default-src 'self' {asset_domain} 'unsafe-inline';"
         "script-src 'self' {asset_domain} *.google-analytics.com *.googletagmanager.com 'unsafe-inline' 'unsafe-eval' data:;"

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -31,6 +31,7 @@ def test_owasp_useful_headers_set(
     assert response.headers['X-Frame-Options'] == 'deny'
     assert response.headers['X-Content-Type-Options'] == 'nosniff'
     assert response.headers['X-XSS-Protection'] == '1; mode=block'
+    assert response.headers['Permissions-Policy'] == 'interest-cohort=()'
     assert response.headers['Content-Security-Policy'] == (
         "default-src 'self' static.example.com 'unsafe-inline';"
         "script-src 'self' static.example.com *.google-analytics.com *.googletagmanager.com 'unsafe-inline' 'unsafe-eval' data:;"


### PR DESCRIPTION
Opt out of Google’s Federated Learning of Cohorts (FLoC).

See:
- https://scotthelme.co.uk/goodbye-feature-policy-and-hello-permissions-policy/
- https://plausible.io/blog/google-floc
- https://github.com/WICG/floc#opting-out-of-computation
- https://github.blog/changelog/2021-04-27-github-pages-permissions-policy-interest-cohort-header-added-to-all-pages-sites/