### PR TITLE
feat: force SMS 2FA users to log in with email every month

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -36,7 +36,8 @@ def two_factor_email_sent():
     return render_template(
         'views/two-factor-email.html',
         title=title,
-        form=form
+        form=form,
+        requires_email_login=user.requires_email_login,
     )
 
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -161,7 +161,7 @@ class User(JSONModel, UserMixin):
 
     @property
     def email_auth(self):
-        return self.auth_type == 'email_auth' or not self.has_recent_email_login()
+        return self.auth_type == 'email_auth' or self.requires_email_login
 
     @property
     def requires_email_login(self):

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -163,6 +163,10 @@ class User(JSONModel, UserMixin):
     def email_auth(self):
         return self.auth_type == 'email_auth' or not self.has_recent_email_login()
 
+    @property
+    def requires_email_login(self):
+        return self.auth_type == 'sms_auth' and not self.has_recent_email_login()
+
     def has_recent_email_login(self):
         date = user_api_client.get_last_email_login_datetime(self.id)
         return date and date >= (datetime.utcnow() - timedelta(days=30))

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 from flask import abort, current_app, request, session
 from flask_login import AnonymousUserMixin, UserMixin, login_user
 from notifications_python_client.errors import HTTPError
@@ -147,6 +149,7 @@ class User(JSONModel, UserMixin):
 
         if self.email_auth and len(self.security_keys) == 0:
             user_api_client.send_verify_code(self.id, 'email', None, request.args.get('next'))
+            user_api_client.register_last_email_login_datetime(self.id)
         if self.sms_auth and len(self.security_keys) == 0:
             user_api_client.send_verify_code(self.id, 'sms', self.mobile_number)
 
@@ -154,11 +157,15 @@ class User(JSONModel, UserMixin):
 
     @property
     def sms_auth(self):
-        return self.auth_type == 'sms_auth'
+        return self.auth_type == 'sms_auth' and self.has_recent_email_login()
 
     @property
     def email_auth(self):
-        return self.auth_type == 'email_auth'
+        return self.auth_type == 'email_auth' or not self.has_recent_email_login()
+
+    def has_recent_email_login(self):
+        date = user_api_client.get_last_email_login_datetime(self.id)
+        return date and date >= (datetime.utcnow() - timedelta(days=30))
 
     def reset_failed_login_count(self):
         user_api_client.reset_failed_login_count(self.id)

--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -15,7 +15,15 @@
     <h1 class="heading-large">{{ _(title) }}</h1>
     {% set continue = _('Continue') %}
     {% set link_txt = _('Not received an email?') %}
-    <p>{{ _('We’ve sent you an email with a security code to sign in to GC Notify.') }}</p>
+    {% if requires_email_login %}
+      <p>
+        {{ _("For added security, GC Notify has sent you an email message with a security code to confirm you still control a valid Government email address.") }}
+      </p>
+    {% else %}
+      <p>
+        {{ _('We’ve sent you an email with a security code to sign in to GC Notify.') }}
+      </p>
+    {% endif %}
     {% call form_wrapper(class="extra-tracking") %}
       {{ textbox(
         form.two_factor_code,

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1376,4 +1376,4 @@
 "The email address is on the GC Notify suppression list","L’adresse courriel est sur la liste de suppression de GC Notification"
 "The email was rejected because of its attachments","Le courriel a été rejeté à cause des pièces jointes"
 "Opens in a new tab","S’ouvre dans un nouvel onglet"
-"For added security, GC Notify has sent you an email message with a security code to confirm you still control a valid Government email address.","Pour plus de sécurité, GC Notification vous a envoyé un courriel avec un code de sécurité pour confirmer que vous contrôlez toujours une adresse e-mail gouvernementale valide."
+"For added security, GC Notify has sent you an email message with a security code to confirm you still control a valid Government email address.","Pour plus de sécurité, GC Notification vous a envoyé un courriel avec un code de sécurité pour confirmer que vous contrôlez toujours une adresse courriel gouvernementale valide."

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1376,3 +1376,4 @@
 "The email address is on the GC Notify suppression list","L’adresse courriel est sur la liste de suppression de GC Notification"
 "The email was rejected because of its attachments","Le courriel a été rejeté à cause des pièces jointes"
 "Opens in a new tab","S’ouvre dans un nouvel onglet"
+"For added security, GC Notify has sent you an email message with a security code to confirm you still control a valid Government email address.","Pour plus de sécurité, GC Notification vous a envoyé un courriel avec un code de sécurité pour confirmer que vous contrôlez toujours une adresse e-mail gouvernementale valide."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1937,6 +1937,11 @@ def mock_login(mocker, mock_get_user, mock_update_user_attribute, mock_events):
 
 
 @pytest.fixture(scope='function')
+def mock_register_email_login(mocker):
+    return mocker.patch('app.user_api_client.register_last_email_login_datetime')
+
+
+@pytest.fixture(scope='function')
 def mock_send_verify_code(mocker):
     return mocker.patch('app.user_api_client.send_verify_code')
 


### PR DESCRIPTION
Some SMS 2FA users use a personal phone number to use Notify. We have no way to remove their access, compared to email addresses, when they leave the Government of Canada or move to another department.

Make sure that SMS 2FA users log in at least once every 30 days with an email 2FA code, proving that they still have access to their inbox.

Trello: https://trello.com/c/l2sS1gRP/487-make-sure-sms-2fa-users-log-in-with-email-every-month