### PR TITLE
fix: convert last email login datetime

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -250,6 +250,8 @@ class UserApiClient(NotifyAdminAPIClient):
         value = redis_client.get(self._last_email_login_key_name(user_id))
         if value is None:
             return None
+        if type(value) == bytes:
+            value = value.decode('utf-8')
         return datetime.fromisoformat(value)
 
     def _last_email_login_key_name(self, user_id):

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -261,6 +261,7 @@ def test_register_last_email_login_datetime(mocker):
 @pytest.mark.parametrize('value, expected_return', [
     [None, None],
     ['2016-01-01T11:09:00.061258', datetime.fromisoformat('2016-01-01T11:09:00.061258')],
+    [b'2016-01-01T11:09:00.061258', datetime.fromisoformat('2016-01-01T11:09:00.061258')],
 ])
 def test_get_last_email_login_datetime(mocker, value, expected_return):
     mock_redis_get = mocker.patch('app.extensions.RedisClient.get', return_value=value)


### PR DESCRIPTION
Follow up of https://github.com/cds-snc/notification-admin/pull/1014

I'm very surprised to discover that `redis.get` returns bytes sometimes and we have to convert it. Looked elsewhere in the codebase and the fetched value is passed to methods that can handle bytes, like `json.loads`.

Did the bytes to string conversion and updated tests.

Sorry for letting this one go through.