### PR TITLE
fix: rework logic for email 2FA logic once a month

### DIFF
--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -56,11 +56,13 @@ def sign_in():
                 abort(403)
             else:
                 invited_user.accept_invite()
+        requires_email_login = user and user.requires_email_login
         if user and user.sign_in():
-            if user.sms_auth:
+            if user.sms_auth and not requires_email_login:
                 return redirect(url_for('.two_factor_sms_sent', next=request.args.get('next')))
-            if user.email_auth:
-                return redirect(url_for('.two_factor_email_sent'))
+            if user.email_auth or requires_email_login:
+                args = {'requires_email_login': True} if requires_email_login else {}
+                return redirect(url_for('.two_factor_email_sent', **args))
 
         # Vague error message for login in case of user not known, inactive or password not verified
         flash(_("The email address or password you entered is incorrect."))

--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -37,7 +37,7 @@ def two_factor_email_sent():
         'views/two-factor-email.html',
         title=title,
         form=form,
-        requires_email_login=user.requires_email_login,
+        requires_email_login=request.args.get('requires_email_login', False),
     )
 
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -150,6 +150,7 @@ class User(JSONModel, UserMixin):
         if self.email_auth and len(self.security_keys) == 0:
             user_api_client.send_verify_code(self.id, 'email', None, request.args.get('next'))
             user_api_client.register_last_email_login_datetime(self.id)
+            return True
         if self.sms_auth and len(self.security_keys) == 0:
             user_api_client.send_verify_code(self.id, 'sms', self.mobile_number)
 

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -91,7 +91,7 @@ def test_should_render_email_two_factor_page_for_sms_user_forced_to_login_with_e
         session['user_details'] = {
             'id': api_user_active['id'],
             'email': api_user_active['email_address']}
-    response = client.get(url_for('main.two_factor_email_sent'))
+    response = client.get(url_for('main.two_factor_email_sent', requires_email_login=True))
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.select_one('main p').text.strip() == (


### PR DESCRIPTION
Follow up of #1014 #1015

This time I'm not relying on the test suite mocking everything to know how it works, I actually tested it multiple times locally on top of changing the logic.

The main problem was that the logic tried to send 2 codes here

https://github.com/cds-snc/notification-admin/blob/048be5a6cf34a608d7d93ff8516a69c6b866c1f5/app/models/user.py#L150-L154

`self.email_auth` is false the first time because we didn't log in recently with an email code but the execution doesn't stop here! `self.sms_auth` is now `true` because we just registered a recent email login.

There was the same problem on the email 2FA page, displaying another message: the state was false before the redirection but is true after the redirection because a code has been sent in the meantime.