### PR TITLE
fix: 500 error when going back after sending a notification

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -956,7 +956,7 @@ def get_back_link(service_id, template, step_index):
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['GET'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def check_notification(service_id, template_id):
-    if 'send_step' in session and not 'placeholders' in session:
+    if 'send_step' in session and 'placeholders' not in session:
         session.pop('send_step')
     return render_template(
         'views/notifications/check.html',

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -956,6 +956,8 @@ def get_back_link(service_id, template, step_index):
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['GET'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def check_notification(service_id, template_id):
+    if 'send_step' in session and not 'placeholders' in session:
+        session.pop('send_step')
     return render_template(
         'views/notifications/check.html',
         **_check_notification(service_id, template_id),
@@ -1060,6 +1062,7 @@ def send_notification(service_id, template_id):
     session.pop('placeholders')
     session.pop('recipient')
     session.pop('sender_id', None)
+    session.pop('send_step', None)
 
     return redirect(url_for(
         '.view_notification',

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -956,8 +956,6 @@ def get_back_link(service_id, template, step_index):
 @main.route("/services/<service_id>/template/<template_id>/notification/check", methods=['GET'])
 @user_has_permissions('send_messages', restrict_admin_usage=True)
 def check_notification(service_id, template_id):
-    if 'send_step' in session and 'placeholders' not in session:
-        session.pop('send_step')
     return render_template(
         'views/notifications/check.html',
         **_check_notification(service_id, template_id),

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3039,7 +3039,8 @@ def test_check_messages_shows_over_max_row_error(
 @pytest.mark.parametrize('existing_session_items', [
     {},
     {'recipient': '6502532223'},
-    {'name': 'Jo'}
+    {'name': 'Jo'},
+    {'send_step': 'main.send_test_step'},
 ])
 def test_check_notification_redirects_if_session_not_populated(
     client_request,
@@ -3192,6 +3193,7 @@ def test_send_notification_clears_session(
     with client_request.session_transaction() as session:
         session['recipient'] = '6502532223'
         session['placeholders'] = {'a': 'b'}
+        session['send_step'] = 'main.send_test_step'
 
     client_request.post(
         'main.send_notification',
@@ -3202,6 +3204,7 @@ def test_send_notification_clears_session(
     with client_request.session_transaction() as session:
         assert 'recipient' not in session
         assert 'placeholders' not in session
+        assert 'send_step' not in session
 
 
 def test_send_notification_redirects_if_missing_data(

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3039,8 +3039,7 @@ def test_check_messages_shows_over_max_row_error(
 @pytest.mark.parametrize('existing_session_items', [
     {},
     {'recipient': '6502532223'},
-    {'name': 'Jo'},
-    {'send_step': 'main.send_test_step'},
+    {'name': 'Jo'}
 ])
 def test_check_notification_redirects_if_session_not_populated(
     client_request,


### PR DESCRIPTION
There is a 500 error when you go to the previous page after sending a notification.

To reproduce:
- Go to Templates
- Choose an email template
- Send it to yourself
- On the check `/service/:id/notification/:id/notification/check` page, go back
- Notice the 500 error

## Why?

The session is not properly cleaned up, the relevant code is here

https://github.com/cds-snc/notification-admin/blob/17fdffc716da058b997e63fa8317884e9c4f6f9e/app/main/views/send.py#L1030-L1062


This is a `POST` for `/services/<service_id>/template/<template_id>/notification/check`. If you go back, you reach the same URL but the `GET` endpoint https://github.com/cds-snc/notification-admin/blob/17fdffc716da058b997e63fa8317884e9c4f6f9e/app/main/views/send.py#L956-L962

The error happens in this method https://github.com/cds-snc/notification-admin/blob/17fdffc716da058b997e63fa8317884e9c4f6f9e/app/main/views/send.py#L988, the `send_step` is still present so it tries to prefill stuff but `placeholders` has been cleaned in the session already so it throws an exception.

https://github.com/cds-snc/notification-admin/blob/17fdffc716da058b997e63fa8317884e9c4f6f9e/app/main/views/send.py#L840-L851

Making sure that the `send_step` is cleared out is enough, there is already a test case making sure we're redirected if the session is not populated `test_check_notification_redirects_if_session_not_populated`. Added another defense if someones arrives with a `send_step` in the session but no `placeholders`

## Demo of the fix

https://user-images.githubusercontent.com/295709/117197297-a5f64c80-adb5-11eb-9171-77bb281b0ffa.mov

