### PR TITLE
fix: don't remove brackets when translating template previews

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -387,27 +387,22 @@ def format_delta(_date):
 
 
 def translate_preview_template(_template_str):
-    translate = {
-        "From": _("From"),
-        "To": _("To"),
-        "Subject": _("Subject"),
-        "Reply to": _("Reply to"),
-        "From:": _("From:"),
-        "To:": _("To:"),
-        "phone number": _("phone number"),
-        "email address": _("email address"),
-        "hidden": _("hidden"),
-    }
-
     def translate_brackets(x):
-        g = x.group(0)
-        english = g[1:-1]  # drop brackets
-        if english not in translate:
-            return english
-        return translate[english]
+        match, word = x.group(0), x.group(1)
+        return {
+            "From": _("From"),
+            "To": _("To"),
+            "Subject": _("Subject"),
+            "Reply to": _("Reply to"),
+            "From:": _("From:"),
+            "To:": _("To:"),
+            "phone number": _("phone number"),
+            "email address": _("email address"),
+            "hidden": _("hidden"),
+        }.get(word, match)
 
-    # this regex finds test inside []
-    template_str = re.sub(r"\[[^]]*\]", translate_brackets, _template_str)
+    # This regex finds words inside []
+    template_str = re.sub(r"\[([^]]*)\]", translate_brackets, _template_str)
     return Markup(template_str)
 
 


### PR DESCRIPTION
# Problem

Template previews leverage brackets `[]` to identify text to translate. Previously the logic removed brackets when it didn't match a word, meaning you could write a title like `[Action required] Foo` and it would be displayed as `Action required Foo` afterwards but the real email would include brackets.

This PRs improves this a bit: if a word is in brackets but not in the list, we keep brackets around. It does not solve yet the issue for words we do translate. This means that if you put `[phone number]` in your template, brackets would be removed and it would be translated 🙄 

This will be fixed later on in utils, after shipping #1017 by likely using a more unique sequence than brackets.

Look at https://github.com/cds-snc/notification-utils/blob/1bcce4033ce9957691bd5b530f74801c7489ee1a/notifications_utils/jinja_templates/email_preview_template.jinja2#L15 or https://github.com/cds-snc/notification-utils/blob/1bcce4033ce9957691bd5b530f74801c7489ee1a/notifications_utils/jinja_templates/sms_preview_template.jinja2#L3

## Demo of this bug
https://user-images.githubusercontent.com/295709/117322642-2c656980-ae5c-11eb-8b59-12bb3575a4ea.mov

## Test
- Create a template with `[Action required] Foo`
- Save it
- Look at the preview, see that the subject is not altered

Trello: https://trello.com/c/VpYPyzga/490-dont-remove-brackets-in-template-previews