### PR TITLE
Clean up message delivery status page with new failure reasons

### DIFF
--- a/app/templates/partials/messages-status-en.html
+++ b/app/templates/partials/messages-status-en.html
@@ -34,32 +34,29 @@
 
 <h3 class="heading-small">Failed</h3>
 <p>
-  If a message fails to be delivered, you can retry after 72 hours or try a different channel. A message may fail to be delivered for several reasons:
+  If a message fails to be delivered, you can retry after 72 hours or try a different channel. If a message fails consistently you should remove these contacts from your database.
+</p>
+<p>
+  A message may fail to be delivered for several reasons:
 </p>
 
-<ul class="list-bullet">
+<ul style="list-style-type: disc; margin-left: 2em; margin-bottom: 20px;">
   <li class="pt-4">
-    <p class="font-bold" style="margin-bottom: 0">The email address or phone number does not exist</p>
-    <p>
-      This means the provider could not deliver the message because the email address or phone number was wrong. You should remove these contacts from your database. You might still be charged for text messages to numbers that do not exist.
-    </p>
+      The email address or phone number does not exist.
   </li>
   <li class="pt-4">
-    <p class="font-bold" style="margin-bottom: 0">The recipient is not accepting messages right now</p>
-    <p>
-      This means the provider could not deliver the message after trying for 72 hours. This can happen when a recipient’s inbox is full or when their phone is off. You can try to send the message again. You might still  be charged for text messages to numbers that do not exist.
-    </p>
+      The recipient is not accepting messages right now.
   </li>
   <li class="pt-4">
-    <p class="font-bold" style="margin-bottom: 0">The email address is on the GC Notify suppression list</p>
-    <p>
-      This means that GC Notify could not deliver the email because an error or complaint was encountered in the past. If you believe this email address should receive emails, please <a href="{{ url_for('.contact') }}">contact us</a>.
-    </p>
+      The message is being blocked by the email or phone carrier.
   </li>
   <li class="pt-4">
-    <p class="font-bold" style="margin-bottom: 0">Technical failure</p>
-    <p>
-      This means there was a connection problem between GC Notify and the email or mobile provider. You’ll have to try sending your messages again. You will not be charged for text messages that are affected by this type of technical failure.
-    </p>
+      The message content is invalid or is being blocked as spam.
+  </li>
+  <li class="pt-4">
+      The destination is on a blocked list.
+  </li>
+  <li class="pt-4">
+      The recipient has opted out of messages.
   </li>
 </ul>

--- a/app/templates/partials/messages-status-fr.html
+++ b/app/templates/partials/messages-status-fr.html
@@ -34,32 +34,28 @@
 
 <h3 class="heading-small">Échec</h3>
 <p>
-  Si un message n’arrive pas à être livré, vous pouvez réessayer après 72 heures ou bien essayer de joindre l’utilisateur par un autre moyen. Un message peut échouer pour plusieurs raisons :
+  Si un message n’arrive pas à être livré, vous pouvez réessayer après 72 heures ou bien essayer de joindre l’utilisateur par un autre moyen.
+</p>
+<p>
+  Un message peut échouer pour plusieurs raisons, nottament :
 </p>
 
-<ul class="list-bullet">
+<ul style="list-style-type: disc; margin-left: 2em; margin-bottom: 20px;">
   <li class="pt-4">
-    <p class="font-bold" style="margin-bottom: 0">L’adresse courriel ou le numéro de téléphone n’existe pas</p>
-    <p>
-      Dans un tel cas, le fournisseur n’a pas pu livrer le message puisque l’adresse courriel ou le numéro de téléphone était erroné. Vous devriez supprimer ce destinataire de votre base de données. Les messages texte envoyés aux numéros qui n’existent pas pourraient tout de même être facturés.
-    </p>
+    L’adresse courriel ou le numéro de téléphone n’existent pas.
   </li>
   <li class="pt-4">
-    <p class="font-bold" style="margin-bottom: 0">Le destinataire n’accepte pas de messages à l’heure actuelle</p>
-    <p>
-      Dans un tel cas, le fournisseur n’a pas réussi à livrer le message après avoir essayé pendant 72 heures. Cela peut se produire si la boîte de réception du destinatiare est pleine ou si le téléphone du destinataire est éteint. Vous pouvez essayer d’envoyer le message de nouveau. Les messages texte qui ont été envoyés aux numéros qui n’acceptent pas de messages pourraient tout de même être facturés.
-    </p>
+    Le destinataire n’accepte pas de messages à l’heure actuelle.
   </li>
   <li class="pt-4">
-    <p class="font-bold" style="margin-bottom: 0">{{ _("The email address is on the GC Notify suppression list") }}</p>
-    <p>
-      Dans un tel cas, GC Notification n’a pas pu envoyer un courriel car nous avons eu des erreurs ou une plainte dans le passé. Si vous pensez que cette adresse courielle devrait recevoir des messages maintenant, <a href="{{ url_for('.contact') }}">contactez-nous</a>.
-    </p>
+    Le message est bloqué par le fournisseur de messagerie ou de téléphonie mobile.
   </li>
   <li class="pt-4">
-    <p class="font-bold" style="margin-bottom: 0">Échec technique</p>
-    <p>
-      Dans un tel cas, un problème de connexion a eu lieu entre GC Notification et le fournisseur de messagerie ou de téléphonie cellulaire. Vous devrez essayer d’envoyer vos messages de nouveau. Les messages texte qui sont affectés par une telle défaillance technique ne vous seront pas facturés.
-    </p>
+    Le contenu du message n’est pas valide ou est bloqué en tant que spam.
   </li>
+  <li class="pt-4">
+    Le destinataire figure sur une liste bloquée
+  </li>
+  <li class="pt-4">
+    Le destinataire a choisi de ne plus recevoir de messages.  </li>
 </ul>


### PR DESCRIPTION
# Summary | Résumé

Including examples of precise reasons for failure to deliver messages in plain language.
https://trello.com/c/HEZcloCO/460-better-error-messages-for-emails-in-case-of-failures