### PR TITLE
feat: delete user cache when validating Fido key

### DIFF
--- a/app/notify_client/user_api_client.py
+++ b/app/notify_client/user_api_client.py
@@ -230,6 +230,7 @@ class UserApiClient(NotifyAdminAPIClient):
         endpoint = '/user/{}/fido2_keys/authenticate'.format(user_id)
         return self.post(endpoint, {})
 
+    @cache.delete('user-{user_id}')
     def validate_security_keys(self, user_id, payload):
         endpoint = '/user/{}/fido2_keys/validate'.format(user_id)
         data = {'payload': payload}

--- a/tests/app/notify_client/test_user_client.py
+++ b/tests/app/notify_client/test_user_client.py
@@ -194,6 +194,7 @@ def test_returns_value_from_cache(
     (user_api_client, 'update_password', [user_id, 'hunter2'], {}),
     (user_api_client, 'verify_password', [user_id, 'hunter2'], {}),
     (user_api_client, 'check_verify_code', [user_id, '', ''], {}),
+    (user_api_client, 'validate_security_keys', [user_id, {}], {}),
     (user_api_client, 'add_user_to_service', [SERVICE_ONE_ID, user_id, [], []], {}),
     (user_api_client, 'add_user_to_organisation', [sample_uuid(), user_id], {}),
     (user_api_client, 'set_user_permissions', [user_id, SERVICE_ONE_ID, []], {}),


### PR DESCRIPTION
When you log in using a Fido key, this endpoint is called

https://github.com/cds-snc/notification-admin/blob/d6e7b9f62a5242546263579cfd2e106aa3b231fb/app/main/views/user_profile.py#L279-L298

which calls an API endpoint to validate the Fido key, through `validate_security_keys`. This records the login date in `logged_in_at` https://github.com/cds-snc/notification-api/blob/1997ebbee52a63f28f0d73771e832ef5df8f652c/app/user/rest.py#L679-L706

Not clearing the cache means that we will get a stale value displayed when looking at a user profile. Clearing the user's cache after calling this endpoint will make sure that we get a fresh user afterwards.

Checked other code paths for sign in and 2FA using email and SMS and I confirmed that we store login events and update `logged_in_at` properly.

Trello: https://trello.com/c/2KwpmvGk/502-last-login-date-is-not-properly-recorded