### PR TITLE
feat: add flash message when updating service settings

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -350,6 +350,7 @@ def service_switch_live(service_id):
                 message_limit = current_service.message_limit
             else:
                 message_limit = current_app.config["DEFAULT_LIVE_SERVICE_LIMIT"]
+            flash(_("An email has been sent to service users"), "default_with_tick")
 
         current_service.update_status(live=live, message_limit=message_limit)
         return redirect(url_for('.service_settings', service_id=service_id))
@@ -1014,6 +1015,8 @@ def set_message_limit(service_id):
 
     if form.validate_on_submit():
         service_api_client.update_message_limit(service_id, form.message_limit.data)
+        if current_service.live:
+            flash(_("An email has been sent to service users"), "default_with_tick")
         return redirect(url_for('.service_settings', service_id=service_id))
 
     return render_template(

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1388,3 +1388,4 @@
 "The email was rejected because of its attachments","Le courriel a été rejeté à cause des pièces jointes"
 "Opens in a new tab","S’ouvre dans un nouvel onglet"
 "For added security, GC Notify has sent you an email message with a security code to confirm you still control a valid Government email address.","Pour plus de sécurité, GC Notification vous a envoyé un courriel avec un code de sécurité pour confirmer que vous contrôlez toujours une adresse courriel gouvernementale valide."
+"An email has been sent to service users","Un courriel a été envoyé aux membres du service"


### PR DESCRIPTION
Add flash messages when updating service settings as a platform admin to say that service users will receive an email.

- when turning a service live
- when updating the daily limit of a live service