### PR TITLE
Move Ready to send heading

### DIFF
--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -13,6 +13,8 @@
     </p>
   {% else %}
     {% if current_user.has_permissions('send_messages', restrict_admin_usage=True) %}
+    <h2 class="heading-medium">{{ _('Ready to send?') }}</h2>
+
     <div class="mb-12">
       <a href="{{ url_for('.set_sender', service_id=current_service.id, template_id=template.id) }}" class="button">
         {{ _('Add recipients') }}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -41,8 +41,6 @@
       root_element='h2',
     ) }}
     {{ page_header(template._template.name) }}
-
-    <h2 class="heading-medium">{{ _('Ready to send?') }}</h2>
   </div>
 
   {% include 'views/templates/_template.html' %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -682,6 +682,25 @@ def test_should_show_logos_on_template_page(
     assert f"https://{app_.config['ASSET_DOMAIN']}/wmms-blk.png" in email_body
 
 
+def test_should_not_show_send_buttons_on_template_page_for_user_without_permission(
+    client_request,
+    fake_uuid,
+    mock_get_service_template,
+    active_user_view_permissions,
+):
+    client_request.login(active_user_view_permissions)
+
+    page = client_request.get(
+        '.view_template',
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _test_page_title=False,
+    )
+
+    assert "Ready to send?" not in str(page)
+    assert "Send test message to yourself" not in str(page)
+
+
 def test_should_show_sms_template_with_downgraded_unicode_characters(
     client_request,
     mocker,


### PR DESCRIPTION
Move the "Ready to send" heading to make sure it's wrapped in the condition "can you send messages".

For templates where you cannot send notifications only the heading was displayed, it was weird.

![Screen Shot 2021-05-26 at 11 47 39](https://user-images.githubusercontent.com/295709/119691045-3e617900-be18-11eb-9e14-4e03c32a28e9.png)

Trello: https://trello.com/c/hNx9JBJR/544-do-not-show-ready-to-send-without-permissions