### PR TITLE
Small content fixes

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1597,7 +1597,7 @@ class TemplateAndFoldersSelectionForm(Form):
     add_template_by_template_type = RadioFieldWithRequiredMessage(_l('Create template'), validators=[
         required_for_ops('add-new-template'),
         Optional(),
-    ], required_message=_l('Select the type of template you want to add'))
+    ], required_message=_l('Select the type of message you want to create'))
 
 
 class ClearCacheForm(StripWhitespaceForm):

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -103,7 +103,7 @@
 "Text message","Message texte"
 "Choose a folder","Choisissez un dossier"
 "Create template","Créer un gabarit"
-"Select the type of template you want to add","Sélectionnez le type de gabarit que vous voulez ajouter"
+"Select the type of message you want to create","Sélectionnez le type de message que vous voulez créer"
 "What’s their name?","Quel est son nom?"
 "What’s their email address?","Quelle est son adresse courriel?"
 "This password is not allowed. Try a different password.","Ce mot de passe n'est pas autorisé. Essayez un autre mot de passe."

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1250,7 +1250,7 @@
 "This email address is already in use","Cette adresse courriel a déjà été utilisée"
 "You can change your service email address later in Settings.","Vous pourrez changer l'adresse d'envoi de votre service plus tard dans la section Paramètres."
 "What’s your service called?","Quel est le nom de votre service?"
-"A good service name uses words service users will recognize.","Un bon nom de service est facilement reconnaissables par les utilisateurs de votre service."
+"A good service name uses words service users recognize.","Un bon nom de service est facilement reconnaissables par les utilisateurs de votre service."
 "Bilingual service name","Nom bilingue du service"
 "API rate limit per minute","Limite d'appels à l’API par minute"
 "Yes, remove","Oui, retirer"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1250,7 +1250,7 @@
 "This email address is already in use","Cette adresse courriel a déjà été utilisée"
 "You can change your service email address later in Settings.","Vous pourrez changer l'adresse d'envoi de votre service plus tard dans la section Paramètres."
 "What’s your service called?","Quel est le nom de votre service?"
-"A good service name uses words your service users will recognize.","Un bon nom de service est facilement reconnaissables par les utilisateurs de votre service."
+"A good service name uses words service users will recognize.","Un bon nom de service est facilement reconnaissables par les utilisateurs de votre service."
 "Bilingual service name","Nom bilingue du service"
 "API rate limit per minute","Limite d'appels à l’API par minute"
 "Yes, remove","Oui, retirer"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1264,7 +1264,7 @@
 "Add templates with content you plan on sending","Ajouter des gabarits avec du contenu à envoyer"
 "Add a team member who can manage settings","Ajouter un membre d’équipe qui peut gérer les paramètres"
 "Tell us about how you intend to use GC Notify","Expliquer comment vous prévoyez utiliser GC Notification"
-"Accept the terms of use","Acceptez les conditions d’utilisation"
+"Accept the terms of use","Accepter les conditions d’utilisation"
 "Accepting the terms of use","Accepter les conditions d’utilisation"
 "Before going live, review the GC Notify <a href='{}'>terms of use</a>.","Avant d’activer votre service, consultez les <a href='{}'>conditions d’utilisation</a> de GC Notification."
 "What you need to know:","Ce qu’il faut retenir :"

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -1344,7 +1344,7 @@ def test_radio_button_with_no_value_shows_custom_error_message(
     assert mock_move_to_template_folder.called is False
     assert mock_create_template_folder.called is False
 
-    assert page.select_one('span.error-message').text.strip() == 'Select the type of template you want to add'
+    assert page.select_one('span.error-message').text.strip() == 'Select the type of message you want to create'
 
 
 @pytest.mark.parametrize('data, error_msg', [


### PR DESCRIPTION
-- Change verb tense in 'Go Live' checklist for consistency in French
-- Update copy used for error message after changing page copy to 'Create a template' for a cohesive experience
-- Correct a French string that was missing since it did not match English