### PR TITLE
Bump utils to 43.11.0

### DIFF
--- a/app/assets/stylesheets/tailwind/components/email_sms_message.css
+++ b/app/assets/stylesheets/tailwind/components/email_sms_message.css
@@ -20,7 +20,7 @@
   .sms-message-sender, .sms-message-recipient {
     padding-top: 2px;
     padding-bottom: 8px;
-    
+
     @apply text-smaller leading-tight font-normal text-gray-grey1 m-0 pb-2;
   }
 
@@ -31,10 +31,6 @@
   .email-message-meta td {
     width: 99%;
     @apply pr-doubleGutter break-words;
-  }
-
-  .email-message-body a {
-    word-break: break-all;
   }
 
   /*

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -38,6 +38,6 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@43.10.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@45000447b53a0abdebea3f1c47801b6f5d1ac8ea#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -38,6 +38,6 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@45000447b53a0abdebea3f1c47801b6f5d1ac8ea#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@a16353baf072d111ef5620c221ba0f7859980e0d#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@43.10.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@45000447b53a0abdebea3f1c47801b6f5d1ac8ea#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@45000447b53a0abdebea3f1c47801b6f5d1ac8ea#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@a16353baf072d111ef5620c221ba0f7859980e0d#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -678,8 +678,8 @@ def test_should_show_logos_on_template_page(
     assert service_one['email_branding'] is None
 
     email_body = str(page.select_one('.email-message-body'))
-    assert f"https://{app_.config['ASSET_DOMAIN']}/gov-canada-en.png" in email_body
-    assert f"https://{app_.config['ASSET_DOMAIN']}/wmms-blk.png" in email_body
+    assert f"https://{app_.config['ASSET_DOMAIN']}/gc-logo-en.png" in email_body
+    assert f"https://{app_.config['ASSET_DOMAIN']}/canada-logo.png" in email_body
 
 
 def test_should_not_show_send_buttons_on_template_page_for_user_without_permission(


### PR DESCRIPTION
Dark mode improvements for emails https://github.com/cds-snc/notification-utils/pull/86

This PR bumps utils and pull in changes for email template previews, making sure that the new style for email templates matches what's actually sent.