### PR TITLE
feat: display attachments on notification page

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -148,7 +148,8 @@ def view_notification(service_id, notification_id):
             notification.get('key_type') == KEY_TYPE_TEST
         ),
         back_link=back_link,
-        just_sent=request.args.get('just_sent')
+        just_sent=request.args.get('just_sent'),
+        attachments=get_attachments(notification),
     )
 
 
@@ -218,6 +219,15 @@ def get_single_notification_partials(notification):
             ),
         ),
     }
+
+
+def get_attachments(notification):
+    return [
+        v['document'] for k, v in (notification['personalisation'] or {}).items()
+        if isinstance(v, dict)
+        and 'document' in v
+        and v["document"].get('sending_method') == 'attach'
+    ]
 
 
 def get_all_personalisation_from_notification(notification):

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -149,7 +149,7 @@ def view_notification(service_id, notification_id):
         ),
         back_link=back_link,
         just_sent=request.args.get('just_sent'),
-        attachments=get_attachments(notification),
+        attachments=get_attachments(notification, 'attach').values(),
     )
 
 
@@ -221,13 +221,16 @@ def get_single_notification_partials(notification):
     }
 
 
-def get_attachments(notification):
-    return [
-        v['document'] for k, v in (notification['personalisation'] or {}).items()
+def get_attachments(notification, sending_method):
+    if sending_method not in ['attach', 'link']:
+        raise NotImplementedError
+    return {
+        k: v['document']
+        for k, v in (notification.get('personalisation', {})).items()
         if isinstance(v, dict)
         and 'document' in v
-        and v["document"].get('sending_method') == 'attach'
-    ]
+        and v["document"].get('sending_method') == sending_method
+    }
 
 
 def get_all_personalisation_from_notification(notification):
@@ -241,15 +244,10 @@ def get_all_personalisation_from_notification(notification):
     if notification['template']['template_type'] == 'sms':
         notification['personalisation']['phone_number'] = notification['to']
 
-    # Extract any file objects from the personalization
-    file_keys = [
-        k for k, v in (notification['personalisation'] or {}).items() if isinstance(v, dict) and 'document' in v
-    ]
-
     personalisation_data = notification['personalisation'].copy()
 
-    for key in file_keys:
-        personalisation_data[key] = personalisation_data[key]['document']['url']
+    for key, attachment in get_attachments(notification, 'link').items():
+        personalisation_data[key] = attachment['url']
 
     return personalisation_data
 

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -109,7 +109,7 @@
     {% endif %}
 
     {% if attachments %}
-      <h3 class="heading-small">{{ _("Attachments") }}</h3>
+      <h2 class="heading-small">{{ _("Attachments") }}</h2>
 
       <ul class="list list-bullet">
         {% for attachment in attachments %}

--- a/app/templates/views/notifications/notification.html
+++ b/app/templates/views/notifications/notification.html
@@ -108,4 +108,16 @@
       {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
     {% endif %}
 
+    {% if attachments %}
+      <h3 class="heading-small">{{ _("Attachments") }}</h3>
+
+      <ul class="list list-bullet">
+        {% for attachment in attachments %}
+          <li>
+            {{ attachment['filename'] }} &mdash; {{ attachment['file_size'] | filesizeformat }}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+
 {% endblock %}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1409,3 +1409,4 @@
 "Review before sending","Réviser avant l’envoi"
 "Ready to go live?","Prêt à activer votre service?"
 "You must complete these steps before submitting the request:","Vous devez compléter ces étapes avant de soumettre la demande :"
+"Attachments","Pièces jointes"

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -187,12 +187,12 @@ def test_notification_status_page_shows_attachments(
     )
 
     if expected_attachments:
-        assert "Attachments" in [h3.text for h3 in page.select('h3')]
+        assert "Attachments" in [h2.text for h2 in page.select('h2')]
         assert "poster.pdf — 694.8 kB" in str(page)
         assert "poster2.pdf — 1.3 MB" in str(page)
         assert "test.pdf" not in str(page)
     else:
-        assert "Attachments" not in [h3.text for h3 in page.select('h3')]
+        assert "Attachments" not in [h2.text for h2 in page.select('h2')]
 
 
 @pytest.mark.parametrize('extra_args, expected_back_link', [

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -195,6 +195,36 @@ def test_notification_status_page_shows_attachments(
         assert "Attachments" not in [h2.text for h2 in page.select('h2')]
 
 
+def test_notification_status_page_shows_attachments_with_links(
+    client_request,
+    mocker,
+    service_one,
+    fake_uuid,
+):
+    mock_get_notification(
+        mocker,
+        fake_uuid,
+        content='Download it ((poster_link))',
+        template_type='email',
+        personalisation={
+            'poster_link': {
+                'document': {
+                    'sending_method': 'link',
+                    'url': 'https://example.com/test.pdf',
+                }
+            },
+        },
+    )
+
+    page = client_request.get(
+        'main.view_notification',
+        service_id=service_one['id'],
+        notification_id=fake_uuid
+    )
+
+    assert "Download it https://example.com/test.pdf" in page.select_one('.email-message-body').text
+
+
 @pytest.mark.parametrize('extra_args, expected_back_link', [
     (
         {},

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -129,6 +129,72 @@ def test_notification_status_page_respects_redaction(
     )
 
 
+@pytest.mark.parametrize('with_attachments, expected_attachments', [
+    (True, True),
+    (False, False),
+])
+def test_notification_status_page_shows_attachments(
+    client_request,
+    mocker,
+    service_one,
+    fake_uuid,
+    with_attachments,
+    expected_attachments,
+):
+    personalisation = {
+        'name': 'Jo',
+        'poster_link': {
+            'document': {
+                'sending_method': 'link',
+                'filename': 'test.pdf',
+                'file_size': 694807,
+                'url': 'https://example.com/test.pdf',
+            }
+        },
+        'poster': {
+            'document': {
+                'sending_method': 'attach',
+                'filename': 'poster.pdf',
+                'file_size': 694807,
+                'url': 'https://example.com/poster.pdf',
+            }
+        },
+        'poster2': {
+            'document': {
+                'sending_method': 'attach',
+                'filename': 'poster2.pdf',
+                'file_size': 1305213,
+                'url': 'https://example.com/poster2.pdf',
+            }
+        },
+
+    }
+    if not with_attachments:
+        del personalisation['poster']
+        del personalisation['poster2']
+
+    mock_get_notification(
+        mocker,
+        fake_uuid,
+        template_type='email',
+        personalisation=personalisation,
+    )
+
+    page = client_request.get(
+        'main.view_notification',
+        service_id=service_one['id'],
+        notification_id=fake_uuid
+    )
+
+    if expected_attachments:
+        assert "Attachments" in [h3.text for h3 in page.select('h3')]
+        assert "poster.pdf — 694.8 kB" in str(page)
+        assert "poster2.pdf — 1.3 MB" in str(page)
+        assert "test.pdf" not in str(page)
+    else:
+        assert "Attachments" not in [h3.text for h3 in page.select('h3')]
+
+
 @pytest.mark.parametrize('extra_args, expected_back_link', [
     (
         {},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2927,6 +2927,7 @@ def mock_get_notification(
     notification_id=fake_uuid,
     notification_status='delivered',
     notification_provider_response=None,
+    personalisation=None,
     redact_personalisation=False,
     template_type=None,
     template_name='sample template',
@@ -2955,7 +2956,7 @@ def mock_get_notification(
                 'name': 'Test User',
                 'email_address': 'test@user.canada.ca'
             }
-        noti['personalisation'] = {'name': 'Jo'}
+        noti['personalisation'] = personalisation or {'name': 'Jo'}
         noti['template'] = template_json(
             service_id,
             '5407f4db-51c7-4150-8758-35412d42186a',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2927,6 +2927,7 @@ def mock_get_notification(
     notification_id=fake_uuid,
     notification_status='delivered',
     notification_provider_response=None,
+    content=None,
     personalisation=None,
     redact_personalisation=False,
     template_type=None,
@@ -2960,7 +2961,7 @@ def mock_get_notification(
         noti['template'] = template_json(
             service_id,
             '5407f4db-51c7-4150-8758-35412d42186a',
-            content='hello ((name))',
+            content=content or 'hello ((name))',
             subject='blah',
             redact_personalisation=redact_personalisation,
             type_=template_type,


### PR DESCRIPTION
Display attachments sent on the notification status page if the email contained attachments.


![Screen Shot 2021-05-28 at 14 17 52](https://user-images.githubusercontent.com/295709/120029035-88d32900-bfc3-11eb-828e-4e427a619c8f.png)

Trello: https://trello.com/c/9ByM9kFm/545-display-attachments-on-the-notification-page-if-the-email-had-attachements