### PR TITLE
feat: use utils tag instead of hash for 43.11.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -38,6 +38,6 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@a16353baf072d111ef5620c221ba0f7859980e0d#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@43.11.0#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@a16353baf072d111ef5620c221ba0f7859980e0d#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@43.11.0#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 


### PR DESCRIPTION
Merged https://github.com/cds-snc/notification-admin/pull/1043 too soon and didn't switch to the tag version.

Sorry about that!