### PR TITLE
Add the send button to dashboard, linked to a "sending" view of the templates page

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -154,6 +154,7 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
         template_list=template_list,
         show_search_box=current_service.count_of_templates_and_folders > 7,
         show_template_nav=(current_service.has_multiple_template_types and (len(current_service.all_templates) > 2)),
+        sending_view=request.args.get("view") == "sending",
         template_nav_items=get_template_nav_items(template_folder_id),
         template_type=template_type,
         search_form=SearchByNameForm(),

--- a/app/templates/views/dashboard/task-shortcuts.html
+++ b/app/templates/views/dashboard/task-shortcuts.html
@@ -10,13 +10,15 @@
         _("Create a template"),
       )
     }}
-    {# {{ task_shortcut(
-      _("Send"),
-      asset_url('images/dashboard/paper-plane-solid.svg'),
-      _("Send existing messages to specific recipients."),
-      url_for('.choose_template', service_id=current_service.id),
-      _("Choose a template"),
-    )
-  }} #}
+  {% endif %}
+  {% if current_user.has_permissions('send_messages') %}
+    {{ task_shortcut(
+        _("Send"),
+        asset_url('images/dashboard/paper-plane-solid.svg'),
+        _("Send existing messages to specific recipients."),
+        url_for('.choose_template', service_id=current_service.id, view="sending"),
+        _("Choose a template"),
+      )
+    }}
   {% endif %}
 </div>

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -21,10 +21,11 @@
     {% endif %}
   </p>
 {% else %}
+  {% set display_checkboxes = current_user.has_permissions('manage_templates') and not sending_view %}
   <nav id="template-list" class="{{ 'top-gutter-5px contain-floats' if (not show_template_nav and not show_search_box) else '' }}">
     {% for item in template_list %}
-      <div class="template-list-item {% if current_user.has_permissions('manage_templates') %}template-list-item-with-checkbox{% endif %} {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
-        {% if current_user.has_permissions('manage_templates') %}
+      <div class="template-list-item {% if display_checkboxes %}template-list-item-with-checkbox{% endif %} {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}">
+        {% if display_checkboxes %}
           {{ unlabelled_checkbox(
             id='templates-or-folder-{}'.format(item.id),
             name='templates_and_folders',

--- a/app/templates/views/templates/choose.html
+++ b/app/templates/views/templates/choose.html
@@ -63,6 +63,9 @@
       {% endif %}
     </div>
   {% endif %}
+    {% if sending_view %}
+      <p>{{ _('Select template to send.') }}
+    {% endif %}
     {% if show_template_nav %}
       <div class="mb-12 clear-both contain-floats">
         {{ pill(template_nav_items, current_value=template_type, show_count=False) }}
@@ -71,7 +74,7 @@
 
     {{ live_search(target_selector='#template-list .template-list-item', show=show_search_box, form=search_form) }}
 
-    {% if current_user.has_permissions('manage_templates') and user_has_template_folder_permission %}
+    {% if not sending_view and current_user.has_permissions('manage_templates') and user_has_template_folder_permission %}
       {% call form_wrapper(
           class='sticky-scroll-area',
           module='template-folder-form',

--- a/app/templates/views/templates/create.html
+++ b/app/templates/views/templates/create.html
@@ -3,13 +3,13 @@
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/radios.html" import radios %}
 {% from "components/form.html" import form_wrapper %}
+{% set header_txt = _('Create template') %}
 
 {% block service_page_title %}
-  {{ _('Create template') }}
+  {{ header_txt }}
 {% endblock %}
 
 {% block maincolumn_content %}
-  {% set header_txt = _('Create template') %}
   {% set choose_url = url_for('main.choose_template', service_id=service_id, template_type=template_type, template_folder_id=template_folder_id) %}
   {% set dashboard_url = url_for('main.service_dashboard', service_id=service_id) %}
   {% set back_url = dashboard_url if request.args.get('source') == 'dashboard' else choose_url %}
@@ -17,13 +17,11 @@
     header_txt,
     back_link=back_url
   ) }}
- 
-  {% set label_txt = _('Name for this key') %}
-  {% set button_txt = _('Continue') %}
-    {% call form_wrapper() %}
+  
+  <p>{{ _('Create a template to start writing a message.') }}</p>
+  {% call form_wrapper() %}
     {{ radios(form.what_type, disable=disabled_options, option_hints=option_hints) }}
-    {{ page_footer(button_txt) }}
+    {{ page_footer(_('Continue')) }}
   {% endcall %}
-
 
 {% endblock %}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1427,3 +1427,7 @@
 "Prepare to send messages by creating your own templates.","Préparer l’envoi de messages en créant vos propres gabarits."
 "Create a template","Créer un gabarit"
 "Write","Rédaction"
+"Create a template to start writing a message.","Créez un gabarit pour rédiger un message."
+"Send existing messages to specific recipients.","Envoyer un message à des destinataires spécifiques."
+"Choose a template","Choisir un gabarit"
+"Select template to send.","Sélectionnez un gabarit à envoyer."

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -202,6 +202,31 @@ def test_task_shortcuts_are_visible_based_on_permissions(
         assert text not in page.text
 
 
+def test_sending_link_has_query_param(
+    client_request: ClientRequest,
+    active_user_with_permissions,
+    mocker,
+    mock_get_service_templates,
+    mock_get_jobs,
+    mock_get_service_statistics,
+    mock_get_usage,
+    mock_get_inbound_sms_summary,
+):
+    mocker.patch(
+        "app.template_statistics_client.get_template_statistics_for_service",
+        return_value=copy.deepcopy(stub_template_stats),
+    )
+    active_user_with_permissions["permissions"][SERVICE_ONE_ID] = ["view_activity", "send_messages"]
+    client_request.login(active_user_with_permissions)
+
+    page = client_request.get(
+        "main.service_dashboard",
+        service_id=SERVICE_ONE_ID,
+    )
+    sending_url = url_for("main.choose_template", service_id=SERVICE_ONE_ID, view="sending")
+    assert sending_url == page.select_one("a.button").attrs["href"]
+
+
 def test_should_show_recent_templates_on_dashboard(
     client_request,
     mocker,

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -161,27 +161,16 @@ def test_redirect_caseworkers_to_templates(
     )
 
 
-def test_task_shortcuts(
-    client_request: ClientRequest,
-    mocker,
-    mock_get_jobs,
-    mock_get_service_statistics,
-    mock_get_usage,
-):
-    mocker.patch(
-        "app.template_statistics_client.get_template_statistics_for_service",
-        return_value=copy.deepcopy(stub_template_stats),
-    )
-
-    page = client_request.get(
-        "main.service_dashboard",
-        service_id=SERVICE_ONE_ID,
-    )
-
-    assert "Create a template" in page.text
-
-
-def test_task_shortcut_is_hidden_if_no_permissions(
+@pytest.mark.parametrize(
+    "permissions,text_in_page,text_not_in_page",
+    [
+        (["view_activity", "manage_templates"], ["Create a template"], ["Choose a template"]),
+        (["view_activity", "send_messages"], ["Choose a template"], ["Create a template"]),
+        (["view_activity"], [], ["Create a template", "Choose a template"]),
+        (["view_activity", "manage_templates", "send_messages"], ["Create a template", "Choose a template"], []),
+    ],
+)
+def test_task_shortcuts_are_visible_based_on_permissions(
     client_request: ClientRequest,
     active_user_with_permissions,
     mocker,
@@ -190,12 +179,15 @@ def test_task_shortcut_is_hidden_if_no_permissions(
     mock_get_service_statistics,
     mock_get_usage,
     mock_get_inbound_sms_summary,
+    permissions: list,
+    text_in_page: list,
+    text_not_in_page: list,
 ):
     mocker.patch(
         "app.template_statistics_client.get_template_statistics_for_service",
         return_value=copy.deepcopy(stub_template_stats),
     )
-    active_user_with_permissions["permissions"][SERVICE_ONE_ID] = ["view_activity"]
+    active_user_with_permissions["permissions"][SERVICE_ONE_ID] = permissions
     client_request.login(active_user_with_permissions)
 
     page = client_request.get(
@@ -203,7 +195,11 @@ def test_task_shortcut_is_hidden_if_no_permissions(
         service_id=SERVICE_ONE_ID,
     )
 
-    assert "Create a template" not in page.text
+    for text in text_in_page:
+        assert text in page.text
+
+    for text in text_not_in_page:
+        assert text not in page.text
 
 
 def test_should_show_recent_templates_on_dashboard(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -204,6 +204,28 @@ def test_should_not_show_template_nav_if_only_one_type_of_template(
     assert not page.select(".pill")
 
 
+def test_should_not_show_checkboxes_if_sending(
+    client_request: ClientRequest,
+    mock_get_template_folders,
+    mock_get_service_templates_with_only_one_template,
+):
+    page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID, view="sending")
+    assert "Create template" not in page.text
+    assert "Select template to send" in page.text
+    assert not page.select("input[type=checkbox]")
+
+
+def test_should_show_checkboxes_if_not_sending(
+    client_request: ClientRequest,
+    mock_get_template_folders,
+    mock_get_service_templates_with_only_one_template,
+):
+    page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
+    assert "Create template" in page.text
+    assert "Select template to send" not in page.text
+    assert page.select("input[type=checkbox]")
+
+
 def test_should_not_show_live_search_if_list_of_templates_fits_onscreen(
     client_request, mock_get_template_folders, mock_get_service_templates
 ):


### PR DESCRIPTION
# Summary | Résumé

~Will convert from draft once I have written some tests.~ (Done!) I added a new "sending view" of the template list that is really just the view that someone without the "manage_templates" permissions sees, plus the text "Select template to send.".

Dashboard:
<img width="1197" alt="Screen Shot 2021-06-09 at 3 46 53 PM" src="https://user-images.githubusercontent.com/5498428/121435094-92ea1580-c93b-11eb-926d-f6c782df4543.png">

Select a template to send:
<img width="1191" alt="Screen Shot 2021-06-09 at 3 46 36 PM" src="https://user-images.githubusercontent.com/5498428/121435139-a1d0c800-c93b-11eb-8964-eec7d7e44cef.png">
