### PR TITLE
Making part of the dashboard visible to all users

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -57,9 +57,6 @@ def service_dashboard(service_id):
         session.pop("invited_user", None)
         session["service_id"] = service_id
 
-    if not current_user.has_permissions("view_activity"):
-        return redirect(url_for("main.choose_template", service_id=service_id))
-
     return render_template(
         "views/dashboard/dashboard.html",
         updates_url=url_for(".service_dashboard_updates", service_id=service_id),

--- a/app/templates/partials/nav/gc_header_nav.html
+++ b/app/templates/partials/nav/gc_header_nav.html
@@ -72,15 +72,10 @@
         {% else %}
           {% if not current_user.platform_admin %}
             {% if current_user.has_permissions() %}
-              {% if current_user.has_permissions('view_activity') %}
-                {{ nav_menu_item(url_for('main.service_dashboard', service_id=current_service.id),_('Dashboard'),'pl-0 header--'+header_navigation.is_selected('dashboard')) }}
-              {% endif %}
+              {{ nav_menu_item(url_for('main.service_dashboard', service_id=current_service.id),_('Dashboard'),'pl-0 header--'+header_navigation.is_selected('dashboard')) }}
               {{ nav_menu_item( url_for('main.choose_template', service_id=current_service.id),_('Templates'),'header--'+header_navigation.is_selected('templates')) }}
               {% if not current_user.has_permissions('view_activity') %}
                 {{ nav_menu_item(url_for('main.view_notifications', service_id=current_service.id, status='sending,delivered,failed'),_('Sent messages'),'header--'+header_navigation.is_selected('sent-messages')) }}
-                {% if current_service.has_jobs %}
-                  {{ nav_menu_item(url_for('main.view_jobs', service_id=current_service.id),_('Uploaded files'),'header--'+header_navigation.is_selected('uploaded-files')) }}
-                {% endif %}
               {% endif %}
               {% if current_user.has_permissions('manage_api_keys') %}
                 {{ nav_menu_item(url_for('main.api_integration', service_id=current_service.id),_('API integration'),'header--'+header_navigation.is_selected('api-integration')) }}

--- a/app/templates/partials/nav/gc_header_nav.html
+++ b/app/templates/partials/nav/gc_header_nav.html
@@ -76,6 +76,9 @@
               {{ nav_menu_item( url_for('main.choose_template', service_id=current_service.id),_('Templates'),'header--'+header_navigation.is_selected('templates')) }}
               {% if not current_user.has_permissions('view_activity') %}
                 {{ nav_menu_item(url_for('main.view_notifications', service_id=current_service.id, status='sending,delivered,failed'),_('Sent messages'),'header--'+header_navigation.is_selected('sent-messages')) }}
+                {% if current_service.has_jobs %}
+                  {{ nav_menu_item(url_for('main.view_jobs', service_id=current_service.id),_('Uploaded files'),'header--'+header_navigation.is_selected('uploaded-files')) }}
+                {% endif %}
               {% endif %}
               {% if current_user.has_permissions('manage_api_keys') %}
                 {{ nav_menu_item(url_for('main.api_integration', service_id=current_service.id),_('API integration'),'header--'+header_navigation.is_selected('api-integration')) }}

--- a/app/templates/partials/nav/gc_header_nav_mobile.html
+++ b/app/templates/partials/nav/gc_header_nav_mobile.html
@@ -40,15 +40,10 @@
           {% if not current_user.platform_admin %}
             <!-- service menu dropdown / signed in / mobile -->
             {% if current_user.has_permissions() %} {# service in the context #}
-              {% if current_user.has_permissions('view_activity') %}
                 {{ nav_menu_item_mobile(url_for('main.service_dashboard', service_id=current_service.id),_('Dashboard'),header_navigation.is_selected('dashboard')) }}
-              {% endif %}
               {{ nav_menu_item_mobile( url_for('main.choose_template', service_id=current_service.id),_('Templates'),header_navigation.is_selected('templates')) }}
               {% if not current_user.has_permissions('view_activity') %}
                 {{ nav_menu_item_mobile(url_for('main.view_notifications', service_id=current_service.id, status='sending,delivered,failed'),_('Sent messages'),header_navigation.is_selected('sent-messages')) }}
-                {% if current_service.has_jobs %}
-                  {{ nav_menu_item_mobile(url_for('main.view_jobs', service_id=current_service.id),_('Uploaded files'),header_navigation.is_selected('uploaded-files')) }}
-                {% endif %}
               {% endif %}
               {% if current_user.has_permissions('manage_api_keys') %}
                 {{ nav_menu_item_mobile(url_for('main.api_integration', service_id=current_service.id),_('API integration'),header_navigation.is_selected('api-integration')) }}

--- a/app/templates/partials/nav/gc_header_nav_mobile.html
+++ b/app/templates/partials/nav/gc_header_nav_mobile.html
@@ -44,6 +44,9 @@
               {{ nav_menu_item_mobile( url_for('main.choose_template', service_id=current_service.id),_('Templates'),header_navigation.is_selected('templates')) }}
               {% if not current_user.has_permissions('view_activity') %}
                 {{ nav_menu_item_mobile(url_for('main.view_notifications', service_id=current_service.id, status='sending,delivered,failed'),_('Sent messages'),header_navigation.is_selected('sent-messages')) }}
+                {% if current_service.has_jobs %}
+                  {{ nav_menu_item_mobile(url_for('main.view_jobs', service_id=current_service.id),_('Uploaded files'),header_navigation.is_selected('uploaded-files')) }}
+                {% endif %}
               {% endif %}
               {% if current_user.has_permissions('manage_api_keys') %}
                 {{ nav_menu_item_mobile(url_for('main.api_integration', service_id=current_service.id),_('API integration'),header_navigation.is_selected('api-integration')) }}

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -18,27 +18,28 @@
     {% if current_user.has_permissions('manage_templates') or current_user.has_permissions('send_messages') %}
       {% include 'views/dashboard/task-shortcuts.html' %}
     {% endif %}
+    {% if current_user.has_permissions('view_activity') %}
+      {{ ajax_block(partials, updates_url, 'upcoming', interval=5) }}
 
-    {{ ajax_block(partials, updates_url, 'upcoming', interval=5) }}
+      <h2 class="heading-medium mt-8">
+        {{ _('In the last 7 days') }}
+      </h2>
 
-    <h2 class="heading-medium mt-8">
-      {{ _('In the last 7 days') }}
-    </h2>
-
-    {{ ajax_block(partials, updates_url, 'totals', interval=5) }}
-    {% set msg_txt = _('Check messages sent per month') %}
-    {{ show_more(
-      url_for('.monthly', service_id=current_service.id),
-      msg_txt
-    ) }}
-
-    {% if partials['has_template_statistics'] %}
-      {{ ajax_block(partials, updates_url, 'template-statistics', interval=5) }}
-      {% set template_txt = _('Check templates used by month') %}
+      {{ ajax_block(partials, updates_url, 'totals', interval=5) }}
+      {% set msg_txt = _('Check messages sent per month') %}
       {{ show_more(
-        url_for('.template_usage', service_id=current_service.id),
-        template_txt
+        url_for('.monthly', service_id=current_service.id),
+        msg_txt
       ) }}
+
+      {% if partials['has_template_statistics'] %}
+        {{ ajax_block(partials, updates_url, 'template-statistics', interval=5) }}
+        {% set template_txt = _('Check templates used by month') %}
+        {{ show_more(
+          url_for('.template_usage', service_id=current_service.id),
+          template_txt
+        ) }}
+      {% endif %}
     {% endif %}
 
     {% if partials['has_jobs'] %}
@@ -49,7 +50,6 @@
         more_txt
       ) }}
     {% endif %}
-
   </div>
 
 {% endblock %}

--- a/app/templates/views/dashboard/dashboard.html
+++ b/app/templates/views/dashboard/dashboard.html
@@ -40,16 +40,17 @@
           template_txt
         ) }}
       {% endif %}
+
+      {% if partials['has_jobs'] %}
+        {{ ajax_block(partials, updates_url, 'jobs', interval=5) }}
+        {% set more_txt = _('See all uploaded files') %}
+        {{ show_more(
+          url_for('.view_jobs', service_id=current_service.id),
+          more_txt
+        ) }}
+      {% endif %}
     {% endif %}
 
-    {% if partials['has_jobs'] %}
-      {{ ajax_block(partials, updates_url, 'jobs', interval=5) }}
-      {% set more_txt = _('See all uploaded files') %}
-      {{ show_more(
-        url_for('.view_jobs', service_id=current_service.id),
-        more_txt
-      ) }}
-    {% endif %}
   </div>
 
 {% endblock %}


### PR DESCRIPTION
# Summary | Résumé

Here is an idea for how we could make the write and send links available for all users who have those permissions but not the "view_activity" permission. We are describing this permission as "See dashboard statistics":
<img width="458" alt="Screen Shot 2021-06-11 at 12 03 07 PM" src="https://user-images.githubusercontent.com/5498428/121734054-7a037080-cab1-11eb-9a56-1d999570581e.png">

Maybe it is okay if users without this permission can see the dashboard but not the statistics?

This PR is a draft since a lot of tests need to be fixed if we merge this. Feel free to close and I can pick it up again in 3 weeks.