### PR TITLE
fix: include sending view in templates pill links

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -147,6 +147,8 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
     if request.method == "GET" and initial_state:
         templates_and_folders_form.op = initial_state
 
+    sending_view = request.args.get("view") == "sending"
+
     return render_template(
         "views/templates/choose.html",
         current_template_folder_id=template_folder_id,
@@ -154,8 +156,8 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
         template_list=template_list,
         show_search_box=current_service.count_of_templates_and_folders > 7,
         show_template_nav=(current_service.has_multiple_template_types and (len(current_service.all_templates) > 2)),
-        sending_view=request.args.get("view") == "sending",
-        template_nav_items=get_template_nav_items(template_folder_id),
+        sending_view=sending_view,
+        template_nav_items=get_template_nav_items(template_folder_id, sending_view),
         template_type=template_type,
         search_form=SearchByNameForm(),
         templates_and_folders_form=templates_and_folders_form,
@@ -192,7 +194,7 @@ def get_template_nav_label(value):
     }[value]
 
 
-def get_template_nav_items(template_folder_id):
+def get_template_nav_items(template_folder_id, sending_view):
     return [
         (
             get_template_nav_label(key),
@@ -202,6 +204,7 @@ def get_template_nav_items(template_folder_id):
                 service_id=current_service.id,
                 template_type=key,
                 template_folder_id=template_folder_id,
+                view="sending" if sending_view else None,
             ),
             "",
         )

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -207,23 +207,27 @@ def test_should_not_show_template_nav_if_only_one_type_of_template(
 def test_should_not_show_checkboxes_if_sending(
     client_request: ClientRequest,
     mock_get_template_folders,
-    mock_get_service_templates_with_only_one_template,
+    mock_get_service_templates,
 ):
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID, view="sending")
     assert "Create template" not in page.text
     assert "Select template to send" in page.text
     assert not page.select("input[type=checkbox]")
+    pill_links = [a["href"] for a in page.select(".pill a")]
+    assert all([link.endswith("?view=sending") for link in pill_links])
 
 
 def test_should_show_checkboxes_if_not_sending(
     client_request: ClientRequest,
     mock_get_template_folders,
-    mock_get_service_templates_with_only_one_template,
+    mock_get_service_templates,
 ):
     page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID)
     assert "Create template" in page.text
     assert "Select template to send" not in page.text
     assert page.select("input[type=checkbox]")
+    pill_links = [a["href"] for a in page.select(".pill a")]
+    assert all([not link.endswith("?view=sending") for link in pill_links])
 
 
 def test_should_not_show_live_search_if_list_of_templates_fits_onscreen(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -204,7 +204,7 @@ def test_should_not_show_template_nav_if_only_one_type_of_template(
     assert not page.select(".pill")
 
 
-def test_should_not_show_checkboxes_if_sending(
+def test_choose_template_page_with_sending_view(
     client_request: ClientRequest,
     mock_get_template_folders,
     mock_get_service_templates,
@@ -217,7 +217,7 @@ def test_should_not_show_checkboxes_if_sending(
     assert all([link.endswith("?view=sending") for link in pill_links])
 
 
-def test_should_show_checkboxes_if_not_sending(
+def test_choose_template_page_without_sending_view(
     client_request: ClientRequest,
     mock_get_template_folders,
     mock_get_service_templates,


### PR DESCRIPTION
Follow up of https://github.com/cds-snc/notification-admin/pull/1062

When coming from the task shortcut to write a message, make sure that pill links (to filter templates between all/email/SMS) include the sending view argument if it's present. At the moment clicking on pill links makes you loose the sending view.