### PR TITLE
Remove extra padding on the task shortcuts

### DIFF
--- a/app/templates/views/dashboard/task-shortcuts.html
+++ b/app/templates/views/dashboard/task-shortcuts.html
@@ -1,6 +1,6 @@
 {% from "components/task-shortcut.html" import task_shortcut %}
 
-<div class="flex space-x-gutter mb-16 mt-12 px-12">
+<div class="flex space-x-gutter mb-16 mt-12">
   {% if current_user.has_permissions('manage_templates') %}
     {{ task_shortcut(
         _("Write"),


### PR DESCRIPTION
# Summary | Résumé

Figma: https://www.figma.com/file/VRqRRfX7Ko5ssg2VryVVET/Dashboard-%2F-Main-landing-spot-in-a-service-%7C-Tableau-de-bord-%2F-Arriv%C3%A9e-principale-dans-un-service?node-id=545%3A3370

Before:
<img width="1146" alt="Screen Shot 2021-07-06 at 4 09 45 PM" src="https://user-images.githubusercontent.com/5498428/124661000-2bed4d00-de64-11eb-8220-0709a9e06778.png">

After:
<img width="1166" alt="Screen Shot 2021-07-06 at 4 11 03 PM" src="https://user-images.githubusercontent.com/5498428/124661006-2ee83d80-de64-11eb-9983-e7fd56616237.png">
