### PR TITLE
Review unauthenticated pages content (pt 1)

### DIFF
--- a/app/templates/views/contact/thanks.html
+++ b/app/templates/views/contact/thanks.html
@@ -3,12 +3,12 @@
 {% from "components/page-footer.html" import page_footer %}
 
 {% block per_page_title %}
-  {{ _('Thanks for contacting us') }}
+  {{ _('Thank you for contacting us') }}
 {% endblock %}
 
 {% block maincolumn_content %}
   <h1 class="heading-large">
-    {{ _('Thanks for contacting us') }}
+    {{ _('Thank you for contacting us') }}
   </h1>
 
   <p class="mb-10">

--- a/app/templates/views/contact/thanks.html
+++ b/app/templates/views/contact/thanks.html
@@ -12,7 +12,7 @@
   </h1>
 
   <p class="mb-10">
-    {{ _("We'll be in touch within 2 business days.") }}
+    {{ _("We'll be in touch by email within 2 business days.") }}
   </p>
 
   <p>

--- a/app/templates/views/contact/thanks.html
+++ b/app/templates/views/contact/thanks.html
@@ -25,6 +25,10 @@
       <p>{{ _("What's possible with GC Notify") }}</p>
     </li>
     <li class="mb-5">
+      <a href="{{ url_for('.guidance') }}">{{ _('Guidance') }}</a><br>
+      <p>{{ _("How to use GC Notify to send messages") }}</p>
+    </li>
+    <li class="mb-5">
       <a href="{{ documentation_url() }}" target="_blank">{{ _('API documentation') }}</a><br>
       <p>{{ _("How to connect your system to GC Notify") }}</p>
     </li>

--- a/app/templates/views/registration-continue.html
+++ b/app/templates/views/registration-continue.html
@@ -8,6 +8,6 @@
 
   <h1 class="heading-large">{{ _('Check your email​') }}</h1>
   <p>{{ _('An email has been sent to')}} {{ session['user_details']['email'] }}.</p>
-  <p>{{ _('Click the link in the email to continue your registration.') }}</p>
+  <p>{{ _('Click the link in the email to continue creating an account.') }}</p>
 
 {% endblock %}

--- a/app/templates/views/resend-email-verification.html
+++ b/app/templates/views/resend-email-verification.html
@@ -10,6 +10,6 @@
 
 <h1 class="heading-large">{{ _('Check your email') }}</h1>
 <p class="email-confirm">{{ _('A new confirmation email has been sent to') }} {{ email }}</p>
-<p>{{ _('Click the link in the email to continue your registration.') }}</p>
+<p>{{ _('Click the link in the email to continue creating an account.') }}</p>
 
 {% endblock %}

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -443,7 +443,7 @@
             <div class="flex flex-col items-start justify-end pb-10 lg:pb-0">
               <div class="text-brand font-bold extra-tight font-sans">{{ _("GC Notify by the numbers") }}</div>
               <div class="text-base py-2">
-                {{ content_link_light(label=_("Learn more about activity on the platform"), href=url_for('.activity' ), class="-ml-2") }}
+                {{ content_link_light(label=_("Learn more about activity on GC Notify"), href=url_for('.activity' ), class="-ml-2") }}
               </div>
             </div>
             <!-- Box 2-->

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1210,7 +1210,7 @@
 "Download data as CSV","Télécharger les données en CSV"
 "Updated daily","Mis à jour quotidiennement"
 "Total","Total"
-"Learn more about activity on the platform","En savoir plus sur l'activité sur la<br>plateforme"
+"Learn more about activity on GC Notify","En savoir plus sur l'activité sur<br>GC Notification"
 "Team members who can see this folder","Les membres de votre équipe qui peuvent voir ce dossier"
 "How to format your message","Comment faire la mise en forme de votre message"
 "Email address does not exist","L'adresse courriel n'existe pas"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -529,7 +529,7 @@
 "Your account will be created with this email:","Votre compte sera créé avec cette adresse courriel :"
 "Must be a federal government email address","Veuillez entrer une adresse courriel du gouvernement fédéral."
 "By creating an account, you agree to the <a href='{}'>terms of use</a>.","En créant un compte, vous acceptez de vous soumettre aux <a href='{}'>conditions d’utilisation</a>."
-"Click the link in the email to continue your registration.","Cliquez sur le lien dans le courriel pour continuer votre inscription."
+"Click the link in the email to continue creating an account.","Cliquez sur le lien dans le courriel pour continuer à créer un compte."
 "A new confirmation email has been sent to","Un nouveau courriel de confirmation a été envoyé à"
 "Roadmap","Feuille de route"
 "Coming soon","À venir bientôt"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1239,6 +1239,7 @@
 "We'll be in touch within 2 business days.","Nous communiquerons avec vous dans un délai de 2 jours ouvrables."
 "Learn more about GC Notify:","Pour en savoir plus sur GC Notification"
 "What's possible with GC Notify","Ce que vous pouvez faire avec GC Notification"
+"How to use GC Notify to send messages","Comment utiliser GC Notification pour envoyer des messages"
 "How to connect your system to GC Notify","Comment connecter votre système à GC Notification"
 "Start sending test messages right away!","Envoyez vos premiers messages!"
 "Want to know more?","Vous voulez en savoir plus?"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1236,7 +1236,7 @@
 "Action required by each recipient (e.g. password reset)","Action demandée à des destinataires (ex : réinitialisation de mot de passe)"
 "News or information sent in bulk to many recipients (e.g. newsletter)","Informations générales envoyées en lot à de nombres destinataires (ex : infolettres)"
 "What will messages be about?","Sur quoi porteront les messages?"
-"We'll be in touch within 2 business days.","Nous communiquerons avec vous dans un délai de 2 jours ouvrables."
+"We'll be in touch by email within 2 business days.","Nous communiquerons avec vous par courriel dans un délai de 2 jours ouvrables."
 "Learn more about GC Notify:","Pour en savoir plus sur GC Notification"
 "What's possible with GC Notify","Ce que vous pouvez faire avec GC Notification"
 "How to use GC Notify to send messages","Comment utiliser GC Notification pour envoyer des messages"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1059,7 +1059,7 @@
 "Code already sent","Le code a déjà été envoyé"
 "Code already sent, wait 10 seconds","Le code a déjà été envoyé, veuillez attendre 10 secondes"
 "The security code in the email we sent you has expired. We’ve sent you a new one.","Le code de sécurité que nous vous avons envoyé par courriel a expiré. Nous vous avons envoyé un nouveau lien."
-"Thanks for contacting us","Merci de nous avoir contacté"
+"Thank you for contacting us","Merci de nous avoir contacté"
 "The security code in the email we sent you has expired. Enter your email address to re-send.","Le code de sécurité que nous vous avons envoyé par courriel a expiré. Entrez votre adresse courriel pour le renvoyer."
 "The security code in the email has already been used","Le code de sécurité envoyé par courriel a déjà été utilisé"
 "Are you sure you want to remove","Êtes-vous certain de vouloir retirer"

--- a/tests/app/main/test_contact.py
+++ b/tests/app/main/test_contact.py
@@ -42,7 +42,7 @@ def test_identity_step_logged_in(client_request, mocker):
 
     # Contact email has been sent
     assert_no_back_link(page)
-    assert normalize_spaces(page.find("h1").text) == "Thanks for contacting us"
+    assert normalize_spaces(page.find("h1").text) == "Thank you for contacting us"
     mock_send_contact_request.assert_called_once()
 
 
@@ -181,7 +181,7 @@ def test_saves_form_to_session(client_request, mocker):
     page = client_request.post(".contact", _expected_status=200, _data={"message": "My message"})
 
     assert_no_back_link(page)
-    assert normalize_spaces(page.find("h1").text) == "Thanks for contacting us"
+    assert normalize_spaces(page.find("h1").text) == "Thank you for contacting us"
 
     mock_send_contact_request.assert_called_once()
 
@@ -232,7 +232,7 @@ def test_all_reasons_message_step_success(
     page = client_request.post(".contact", _expected_status=200, _data={"message": message})
 
     assert_no_back_link(page)
-    assert normalize_spaces(page.find("h1").text) == "Thanks for contacting us"
+    assert normalize_spaces(page.find("h1").text) == "Thank you for contacting us"
 
     profile = url_for(".user_information", user_id=current_user.id, _external=True)
 
@@ -286,7 +286,7 @@ def test_demo_steps_success(client_request, mocker):
 
     # Thank you page
     assert_no_back_link(page)
-    assert normalize_spaces(page.find("h1").text) == "Thanks for contacting us"
+    assert normalize_spaces(page.find("h1").text) == "Thank you for contacting us"
 
     mock_send_contact_request.assert_called_once_with(
         {


### PR DESCRIPTION
Minor tweaks to content in the signed-out pages, including:

- Adjusting voice/tone: `Thank you` instead of `Thanks`
- Referring to `registration` as `creating an account` for consistency
- Specifying that we'll be in touch `by email` after someone submits the contact us form
- Changing `Activity on the platform` to `Activity on GC Notify` on the homepage
- Adding a link to `Guidance` in the post-Contact_Us form page as another option for folks in case it's helpful