### PR TITLE
Fix horizontal scrolling in admin view

### DIFF
--- a/app/templates/views/platform-admin/services.html
+++ b/app/templates/views/platform-admin/services.html
@@ -47,7 +47,7 @@
 
         {% call row() %}
           {% call field(border=False) %}
-            <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="browse-list-link">{{ service['name'] }}</a>
+            <a href="{{ url_for('main.service_dashboard', service_id=service['id']) }}" class="browse-list-link">{{ service['name']|truncate(35) }}</a>
           {% endcall %}
 
           {{ stats_fields('email', service['stats']) }}


### PR DESCRIPTION
# Summary | Résumé

Trello: https://trello.com/c/KkjoPad1/648-fix-horizontal-scrolling-on-the-admin-view-of-the-all-services-table

Truncate the service name at 35 characters. This was about as high as I could go before the table was wider than the content above it. You can still see the full service name by clicking the link in the table. 

This fixes both the Trial services and Live services pages.

Before:
<img width="1461" alt="Screen Shot 2021-08-06 at 1 06 28 PM" src="https://user-images.githubusercontent.com/5498428/128570164-a9f34749-ff82-48b1-9eee-4772f5d03869.png">


After:
<img width="1792" alt="Screen Shot 2021-08-06 at 4 49 29 PM" src="https://user-images.githubusercontent.com/5498428/128570169-861c3516-4ba2-4e35-b681-b4d365c179f1.png">

