### PR TITLE
Fix the footer links and "top of page" link

### DIFF
--- a/app/templates/components/links.html
+++ b/app/templates/components/links.html
@@ -45,7 +45,7 @@
 {% macro nav_link_light(label="TODO: LABEL THIS LINK", href="/", class=None, external_link_img=None) %}
 <a
     href="{{ href }}"
-    class="p-2 text-blue text-small no-underline line-under border-b-2 border-transparent visited:text-blue link:text-blue hover:underline focus:border-blue focus:outline-none focus:text-blue decoration-clone flex items-center min-h-target {% if class %} {{ class }} {% endif %}"
+    class="p-2 text-blue text-small no-underline line-under border-b-2 border-transparent visited:text-blue link:text-blue hover:underline focus:border-blue focus:outline-none focus:text-blue decoration-clone min-h-target {% if class %} {{ class }} {% endif %}"
     {% if external_link_img %}
         target="_blank"
         aria-label="{{ label }} ({{ _('Opens in a new tab') }})"

--- a/app/templates/partials/nav/footer.html
+++ b/app/templates/partials/nav/footer.html
@@ -33,7 +33,7 @@
       aria-label="{{ _('secondary footer') }}">
 
       <div class="flex flex-col gap-4 lg:flex-row lg:items-center md:col-span-2">
-        <div class="flex-shrink mr-5">
+        <div class="flex-shrink mr-5 flex">
           <img
             aria-hidden="true"
             alt="{{ _('Separator') }}"
@@ -50,7 +50,7 @@
             src="{{ asset_url('images/bullet.svg') }}"
           />
         </div>
-        <div class="flex-shrink lg:mx-5">
+        <div class="flex-shrink lg:mx-5 flex">
           <img
             aria-hidden="true"
             alt="{{ _('Separator') }}"
@@ -67,7 +67,7 @@
             src="{{ asset_url('images/bullet.svg') }}"
           />
         </div>
-        <div class="flex-shrink lg:mx-5">
+        <div class="flex-shrink lg:mx-5 flex">
           <img
             aria-hidden="true"
             alt="{{ _('Separator') }}"
@@ -84,7 +84,7 @@
             src="{{ asset_url('images/bullet.svg') }}"
           />
         </div>
-        <div class="flex-shrink lg:mx-5">
+        <div class="flex-shrink lg:mx-5 flex">
           <img
             aria-hidden="true"
             alt="{{ _('Separator') }}"

--- a/app/templates/partials/nav/footer.html
+++ b/app/templates/partials/nav/footer.html
@@ -93,14 +93,14 @@
           />
           {{ nav_link_light(label=_("Terms of use"), href=url_for('main.terms')) }}
         </div>
-        <div class="lg:hidden p-5 mt-10">
+        <div class="lg:hidden mt-10">
           <div class="inline-block">
             {{ nav_button(
               href="#top",
               label=_('Top of page'),
               aria_label=_('Top of page'),
               link_img=asset_url('images/arrow-licorice.svg'),
-              class="text-blue bg-white",
+              class="text-blue pl-0",
               link_img_class="transform rotate-180"
             ) }}
           </div>


### PR DESCRIPTION
# Summary | Résumé

Footer links layout were breaking on mobile (too wide), but no longer. And then the "Top of page" link was using another background colour, so I changed it. All CSS changes, so no functional changes here.

Edit: made sure the hit state of the footer links was the minimum size of 44px ([according to WCAG](https://www.w3.org/TR/WCAG22/#target-size-enhanced))

| before | after |
|--------|-------|
|   <img width="890" alt="Screen Shot 2022-01-06 at 14 42 37" src="https://user-images.githubusercontent.com/2454380/148441741-8f941ce8-0c9f-4d0d-a9d8-89fbf47e711e.png">    |   <img width="890" alt="Screen Shot 2022-01-06 at 14 42 43" src="https://user-images.githubusercontent.com/2454380/148441746-307d0f28-94c0-4ee6-a65a-00a93dda40b5.png">   |






