### PR TITLE
Create external links by passing in a boolean rather than passing in an image

### DIFF
--- a/app/templates/components/buttons.html
+++ b/app/templates/components/buttons.html
@@ -36,24 +36,12 @@
 </a>
 {% endmacro %}
 
-{% macro secondary_button_transparent_white(label="TODO: LABEL THIS BUTTON", href="/", class=None, external_link_img=None) %}
+{% macro secondary_button_transparent_white(label="TODO: LABEL THIS BUTTON", href="/", class=None) %}
 <a
     href="{{ href }}"
     class="p-4 line-under text-base text-default underline text-white border-b-2 border-transparent link:text-white visited:text-white hover:no-underline focus:text-blue focus:outline-none focus:border-b-2 focus:border-white focus:no-underline {% if class %} {{ class }} {% endif %}"
-    {% if external_link_img %}
-        target="_blank"
-        aria-label="{{ label }} ({{ _('Opens in a new tab') }})"
-    {% else %}
-        aria-label="{{ label }}"
-    {% endif %}
+    aria-label="{{ label }}"
     >
     {{ label }}
-    {% if external_link_img %}
-        <img
-            aria-hidden="true"
-            alt="{{ _('External link') }}"
-            class="inline w-6 h-6 ml-2 self-center"
-            src="{{ external_link_img }}"/>
-    {% endif %}
 </a>
 {% endmacro %}

--- a/app/templates/components/links.html
+++ b/app/templates/components/links.html
@@ -1,8 +1,8 @@
-{% macro content_link_light(label="TODO: LABEL THIS LINK", href="/", class=None, external_link_img=None) %}
+{% macro content_link_light(label="TODO: LABEL THIS LINK", href="/", class=None, is_external_link=False) %}
 <a
     class="my-0 p-2 line-under text-base border-b-2 border-transparent link:text-blue visited:text-blue focus:bg-yellow focus:border-blue focus:no-underline focus:outline-none hover:no-underline decoration-clone {% if class %} {{ class }} {% endif %}"
     href="{{ href }}"
-    {% if external_link_img %}
+    {% if is_external_link %}
         target="_blank"
         aria-label="{{ label }} ({{ _('Opens in a new tab') }})"
     {% else %}
@@ -10,21 +10,21 @@
     {% endif %}
     >
     {{ label }}
-    {% if external_link_img %}
+    {% if is_external_link %}
         <img
             aria-hidden="true"
-            src="{{ external_link_img }}"
+            src="{{ asset_url('images/external.svg') }}"
             alt="{{ _('External link') }}"
             class="inline w-8 h-8 ml-2 self-center"/>
     {% endif %}
 </a>
 {% endmacro %}
 
-{% macro nav_link_dark(label="TODO: LABEL THIS LINK", href="/", class=None, external_link_img=None) %}
+{% macro nav_link_dark(label="TODO: LABEL THIS LINK", href="/", class=None, is_external_link=False) %}
 <a
     href="{{ href }}"
     class="p-2 text-white text-small no-underline line-under border-b-2 border-transparent visited:text-white link:text-white hover:underline focus:border-white focus:outline-none focus:text-blue decoration-clone flex items-center min-h-target {% if class %} {{ class }} {% endif %}"
-    {% if external_link_img %}
+    {% if is_external_link %}
         target="_blank"
         aria-label="{{ label }} ({{ _('Opens in a new tab') }})"
     {% else %}
@@ -32,21 +32,21 @@
     {% endif %}
     >
     {{ label }}
-    {% if external_link_img %}
+    {% if is_external_link %}
         <img
             aria-hidden="true"
             alt="{{ _('External link') }}"
             class="inline w-6 h-6 ml-2 self-center"
-            src="{{ external_link_img }}"/>
+            src="{{ asset_url('images/external-white.svg') }}"/>
     {% endif %}
 </a>
 {% endmacro %}
 
-{% macro nav_link_light(label="TODO: LABEL THIS LINK", href="/", class=None, external_link_img=None) %}
+{% macro nav_link_light(label="TODO: LABEL THIS LINK", href="/", class=None, is_external_link=False) %}
 <a
     href="{{ href }}"
     class="p-2 text-blue text-small no-underline line-under border-b-2 border-transparent visited:text-blue link:text-blue hover:underline focus:border-blue focus:outline-none focus:text-blue decoration-clone min-h-target {% if class %} {{ class }} {% endif %}"
-    {% if external_link_img %}
+    {% if is_external_link %}
         target="_blank"
         aria-label="{{ label }} ({{ _('Opens in a new tab') }})"
     {% else %}
@@ -54,12 +54,12 @@
     {% endif %}
     >
     {{ label }}
-    {% if external_link_img %}
+    {% if is_external_link %}
         <img
             aria-hidden="true"
             alt="{{ _('External link') }}"
             class="inline w-6 h-6 ml-2 self-center"
-            src="{{ external_link_img }}"/>
+            src="{{ asset_url('images/external.svg') }}"/>
     {% endif %}
 </a>
 {% endmacro %}

--- a/app/templates/components/nav_menu_item.html
+++ b/app/templates/components/nav_menu_item.html
@@ -1,4 +1,4 @@
-{% macro nav_menu_item(url=None, localised_txt=None, css_classes=None, id_key=None, external_link_img=None) %}
+{% macro nav_menu_item(url=None, localised_txt=None, css_classes=None, id_key=None, is_external_link=False) %}
   {% if url and localised_txt %}
     <div class="pr-10 flex-shrink-0">
       <div
@@ -7,17 +7,17 @@
           {% if id_key %}id="{{ id_key }}"{% endif %}
           href="{{ url }}"
           class="text-smaller text-blue bg-gray py-5 font-bold no-underline self-center hover:underline line-under border-b-4 border-transparent visited:text-blue link:text-blue focus:border-b-4 focus:bg-yellow focus:border-blue focus:outline-none {{ css_classes }}"
-          {% if external_link_img %}
+          {% if is_external_link %}
           target="_blank"
           aria-label="{{ localised_txt }} ({{ _('Opens in a new tab') }})"
           {% else %}
           aria-label="{{ localised_txt }}"
           {% endif %}
         >{{ localised_txt }}
-          {% if external_link_img %}
+          {% if is_external_link %}
             <img
               aria-hidden="true"
-              src="{{ external_link_img }}"
+              src="{{ asset_url('images/external.svg') }}"
               alt="{{ _('External link') }}"
               class="inline w-8 h-8 ml-2 self-center"/>
           {% endif %}

--- a/app/templates/partials/nav/footer.html
+++ b/app/templates/partials/nav/footer.html
@@ -1,5 +1,5 @@
 {% from "components/buttons.html" import nav_button, secondary_button_transparent_white %}
-{% from "components/links.html" import nav_link_dark, nav_link_light %}
+{% from "components/links.html" import nav_link_dark, nav_link_light with context %}
 
 <footer aria-label="{{ _('footer menu') }}">
   <div class="bg-blue">
@@ -13,7 +13,7 @@
         </div>
         <div class="flex-1 grid grid-cols-1 gap-y-1 md:grid-rows-4 place-items-start">
           <span class="text-white text-base font-bold">{{ _("Using GC Notify") }}</span>
-          {{ nav_link_dark(label=_("API documentation"), href=documentation_url(), external_link_img=asset_url('images/external-white.svg'), class="-ml-2") }}
+          {{ nav_link_dark(label=_("API documentation"), href=documentation_url(), is_external_link=True, class="-ml-2") }}
           {{ nav_link_dark(label=_("Guidance"), href=url_for('main.guidance'), class="-ml-2") }}
         </div>
         <div class="flex-1 grid grid-cols-1 gap-y-1 lg:grid-rows-4 place-items-start">

--- a/app/templates/partials/nav/gc_header_nav.html
+++ b/app/templates/partials/nav/gc_header_nav.html
@@ -1,4 +1,4 @@
-{% from "components/nav_menu_item.html" import nav_menu_item %}
+{% from "components/nav_menu_item.html" import nav_menu_item with context %}
 
 {% set lang_switch = 'EN' %}
 {% set long_lang_switch = 'English' %}
@@ -70,7 +70,7 @@
           {{ nav_menu_item('/',_('Home'),'pl-0 header--'+header_navigation.is_selected('home')) }}
           {{ nav_menu_item(url_for('main.why-notify'),_('Why GC Notify'),'header--'+header_navigation.is_selected('why-notify')) }}
           {{ nav_menu_item(url_for('main.features'),_('Features'),'header--'+header_navigation.is_selected('features')) }}
-          {{ nav_menu_item(documentation_url(),_('API documentation'),'header--'+header_navigation.is_selected('documentation'), external_link_img=asset_url('images/external.svg')) }}
+          {{ nav_menu_item(documentation_url(),_('API documentation'),'header--'+header_navigation.is_selected('documentation'), is_external_link=True) }}
           {{ nav_menu_item(url_for('main.contact'),_('Contact us'),'header--'+header_navigation.is_selected('contact')) }}
         {% else %}
           {% if not current_user.platform_admin %}

--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -1,7 +1,7 @@
 {% extends "notify_template.html" %}
 {% set withnav = True %}
 {% from "components/buttons.html" import primary_button_blue_lighter, secondary_button_transparent_white %}
-{% from "components/links.html" import content_link_light %}
+{% from "components/links.html" import content_link_light with context %}
 {% from "components/page-footer.html" import page_footer %}
 
 {% block meta %} {% set description = _('GC Notify lets you send emails and text messages to your users') %}
@@ -265,7 +265,7 @@
                   </li>
                 </ul>
                 <p class="pt-10 text-base mb-0 text-blue">
-                  {{ content_link_light(label=_("How to integrate GC Notify with your system"), href=documentation_url(), external_link_img=asset_url('images/external.svg')) }}
+                  {{ content_link_light(label=_("How to integrate GC Notify with your system"), href=documentation_url(), is_external_link=True) }}
                 </p>
               </div>
               <div class="image-content pt-10 lg:pt-0 flex">


### PR DESCRIPTION
External links have an icon beside them, a little square with an arrow coming out of it.

<img width="236" alt="Screen Shot 2022-01-06 at 16 13 29" src="https://user-images.githubusercontent.com/2454380/148452950-3bf16b57-b8fe-44bc-ab4c-b00f8a245eab.png">

So far, in our macros we are usually (but not always) passing an image path for the "external.svg" icon when a link points somewhere external.

I say _usually_ because it changes sometimes. eg:
-    `is_external_link`: in the mobile header nav: [`nav_menu_item_mobile(documentation_url(), _('API documentation'), False, is_external_link=True)`](https://github.com/cds-snc/notification-admin/blob/78ec5496228d0e2d1ebb7654fa87fbb685105f6e/app/templates/partials/nav/gc_header_nav_mobile.html#L36)
-    `external_link_img`: in the regular header nav: [`nav_menu_item(documentation_url(),_('API documentation'),'header--'+header_navigation.is_selected('documentation'), external_link_img=asset_url('images/external.svg'))`](https://github.com/cds-snc/notification-admin/blob/78ec5496228d0e2d1ebb7654fa87fbb685105f6e/app/templates/partials/nav/gc_header_nav.html#L70)

`external_link_img` isn't really needed: the image path could easily be hard-coded in the macro itself (like [in the mobile header nav link macro](https://github.com/cds-snc/notification-admin/blob/c0b10714a598ab9c0f86239ca56dea165c61a493/app/templates/components/nav_menu_item_mobile.html#L19-L23)) and that makes the macro easier to use. It also makes it easier to build menus from pure data, incidentally.

There are no functional changes from this PR. It just simplifies these macros, and in the case of `secondary_button_transparent_white` removes this option altogether since no one is using it.