### PR TITLE
Re-adjust footer links to that they are centred

### DIFF
--- a/app/templates/components/links.html
+++ b/app/templates/components/links.html
@@ -45,7 +45,7 @@
 {% macro nav_link_light(label="TODO: LABEL THIS LINK", href="/", class=None, is_external_link=False) %}
 <a
     href="{{ href }}"
-    class="p-2 text-blue text-small no-underline line-under border-b-2 border-transparent visited:text-blue link:text-blue hover:underline focus:border-blue focus:outline-none focus:text-blue decoration-clone min-h-target {% if class %} {{ class }} {% endif %}"
+    class="p-2 text-blue text-small no-underline line-under border-b-2 border-transparent visited:text-blue link:text-blue hover:underline focus:border-blue focus:outline-none focus:text-blue decoration-clone inline-flex items-center min-h-target {% if class %} {{ class }} {% endif %}"
     {% if is_external_link %}
         target="_blank"
         aria-label="{{ label }} ({{ _('Opens in a new tab') }})"

--- a/app/templates/partials/nav/footer.html
+++ b/app/templates/partials/nav/footer.html
@@ -33,7 +33,7 @@
       aria-label="{{ _('secondary footer') }}">
 
       <div class="flex flex-col gap-4 lg:flex-row lg:items-center md:col-span-2">
-        <div class="flex-shrink mr-5 flex">
+        <div class="flex-shrink mr-5">
           <img
             aria-hidden="true"
             alt="{{ _('Separator') }}"
@@ -50,7 +50,7 @@
             src="{{ asset_url('images/bullet.svg') }}"
           />
         </div>
-        <div class="flex-shrink lg:mx-5 flex">
+        <div class="flex-shrink lg:mx-5">
           <img
             aria-hidden="true"
             alt="{{ _('Separator') }}"
@@ -67,7 +67,7 @@
             src="{{ asset_url('images/bullet.svg') }}"
           />
         </div>
-        <div class="flex-shrink lg:mx-5 flex">
+        <div class="flex-shrink lg:mx-5">
           <img
             aria-hidden="true"
             alt="{{ _('Separator') }}"
@@ -84,7 +84,7 @@
             src="{{ asset_url('images/bullet.svg') }}"
           />
         </div>
-        <div class="flex-shrink lg:mx-5 flex">
+        <div class="flex-shrink lg:mx-5">
           <img
             aria-hidden="true"
             alt="{{ _('Separator') }}"


### PR DESCRIPTION
# Summary | Résumé

In a previous pull request, I removed `display: flex` from the footer links but then it made the hit state too small for WCAG, so I added `display flex` to the link containers. Unfortunately, I didn't notice yesterday that the links weren't being centred beside the little bullet points.  

This PR fixes the links so they are always centred beside the bullet points (using `display: inline-flex`).

This is a follow-up to https://github.com/cds-snc/notification-admin/pull/1212

## Screenshots

### on big screens

| before | after |
|--------|-------|
|    <img width="1148" alt="Screen Shot 2022-01-07 at 11 43 31" src="https://user-images.githubusercontent.com/2454380/148577837-9379e605-54f3-46c2-af8d-b88968e205d7.png">   |   <img width="1148" alt="Screen Shot 2022-01-07 at 11 42 36" src="https://user-images.githubusercontent.com/2454380/148577830-3c0afca6-18ef-4b6f-a5da-8e291595aecc.png">   |


### on smaller screens 

| before | after |
|--------|-------|
|   <img width="857" alt="Screen Shot 2022-01-07 at 11 43 37" src="https://user-images.githubusercontent.com/2454380/148577842-a49cb27a-dd9a-464a-a54e-9fb1c7b7f67b.png">   |  <img width="857" alt="Screen Shot 2022-01-07 at 11 42 46" src="https://user-images.githubusercontent.com/2454380/148577836-3574f08f-0b09-42a9-8b24-4679728191b6.png">    |

