### PR TITLE
Add type-hinting to request_content

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -259,7 +259,7 @@ def page_content():
     response = request_content("wp/v2/pages", {"slug": slug, "lang": get_current_locale(current_app)})
 
     # show technical difficulties if no result
-    if response == "":
+    if response is None:
         abort(500)
 
     nav_url = "menus/v1/menus/notify-admin"

--- a/app/utils.py
+++ b/app/utils.py
@@ -9,7 +9,7 @@ from functools import wraps
 from io import BytesIO, StringIO
 from itertools import chain
 from os import path
-from typing import Any
+from typing import Any, Union
 
 import boto3
 import dateutil
@@ -764,7 +764,7 @@ def is_blank(content: Any) -> bool:
     return not content or content.isspace()
 
 
-def request_content(endpoint: str, params={"slug": "", "lang": "en"}) -> str:
+def request_content(endpoint: str, params={"slug": "", "lang": "en"}) -> Union[list, dict, None]:
     base_endpoint = current_app.config["GC_ARTICLES_API"]
     lang_endpoint = ""
     cache_key = "%s/%s" % (params["lang"], params["slug"])
@@ -787,4 +787,4 @@ def request_content(endpoint: str, params={"slug": "", "lang": "en"}) -> str:
             return cache.get(cache_key)
         else:
             current_app.logger.info(f"Cache miss: {cache_key}")
-            return ""
+            return None


### PR DESCRIPTION
# Summary | Résumé

This PR 
- adds type-hinting to the `request_content` method 
- manually raise a `NotFound` exception if we try to pull content from the API that doesn't exist

### Adds type-hinting

Following up on @jimleroyer's [review from yesterday](https://github.com/cds-snc/notification-admin/pull/1210#discussion_r782605719), this PR adds type-hinting to `request_content`. 

I discovered that pulling a page from the API, we get back a `list`, vs pulling a menu back we get a `dict`, so the type-hinting specifies that we can return `dict`, `list`, or `None`.

 ## raise `NotFound` exceptions manually

If we request a page that doesn't exist from the API, or a menu that doesn't exist, we get different results, but both are valid JSON responses. Since we don't want to treat these as successful responses, I added logic to ensure that our returned responses are actually valid, and raise a `NotFound` exception if not. If this exception is raised, it is caught lower in the function and either a cached response is returned or `None`. 

