### PR TITLE
Try again if API slug returns 404

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -371,7 +371,6 @@ def old_page_redirects():
 # --- Dynamic routes handling for GCArticles API-driven pages --- #
 @main.route("/<path:path>")
 def page_content(path=""):
-    nav_items = get_nav_items()
     page_id = ""
     auth_required = False
 
@@ -386,11 +385,17 @@ def page_content(path=""):
 
     response = request_content(f"wp/v2/pages/{page_id}", {"slug": path}, auth_required=auth_required)
 
+    if isinstance(response, str):
+        return redirect(response)
+
     if response:
         title = response["title"]["rendered"]
         slug_en = response["slug_en"]
         html_content = response["content"]["rendered"]
+
+        nav_items = get_nav_items()
         set_active_nav_item(nav_items, request.path)
+
         return render_template(
             "views/page-content.html",
             title=title,

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -385,9 +385,11 @@ def page_content(path=""):
 
     response = request_content(f"wp/v2/pages/{page_id}", {"slug": path}, auth_required=auth_required)
 
+    # when response is a string, redirect to change our language setting
     if isinstance(response, str):
         return redirect(response)
 
+    # when response is a dict, display the content
     if response:
         title = response["title"]["rendered"]
         slug_en = response["slug_en"]

--- a/tests/app/articles/test_request_content.py
+++ b/tests/app/articles/test_request_content.py
@@ -1,5 +1,6 @@
 import pytest
 import requests_mock
+from werkzeug.exceptions import NotFound
 
 from app.articles import request_content
 
@@ -18,9 +19,10 @@ def test_request_content_en(app_, mocker, capsys):
             response = request_content("pages", {"slug": "mypage"})
 
             assert mock.called
+            assert mock.call_count == 1
             assert mock.request_history[0].url == f"{notify_url}?slug=mypage&lang=en"
 
-            assert response is not None
+            assert isinstance(response, dict)
             assert response["title"]["rendered"] == "The Title"
             assert response["content"]["rendered"] == "The Content"
 
@@ -35,11 +37,55 @@ def test_request_content_fr(app_, mocker, capsys):
             response = request_content("pages", {"slug": "la-page"})
 
             assert mock.called
+            assert mock.call_count == 1
             assert mock.request_history[0].url == f"{notify_url}?slug=la-page&lang=fr"
 
-            assert response is not None
+            assert isinstance(response, dict)
             assert response["title"]["rendered"] == "Le titre"
             assert response["content"]["rendered"] == "Le contentu"
+
+
+def test_request_content_en_404_but_fr_exists(app_, mocker, capsys):
+    def json_callback(request, context):
+        if "lang=en" in request.query:
+            return []
+
+        return {"title": {"rendered": "Le titre"}, "content": {"rendered": "Le contentu"}}
+
+    with app_.test_request_context():
+        mocker.patch("app.articles.get_current_locale", return_value="en")
+        mocker.patch.dict("app.current_app.config", values={"GC_ARTICLES_API": gc_articles_api})
+        with requests_mock.mock() as mock:
+            mock.request("GET", notify_url, json=json_callback, status_code=200)
+            response = request_content("pages", {"slug": "la-page"})
+
+            # make sure requests is called twice, with 2 different language parameters
+            assert mock.called
+            assert mock.call_count == 2
+            assert mock.request_history[0].url == f"{notify_url}?slug=la-page&lang=en"
+            assert mock.request_history[1].url == f"{notify_url}?slug=la-page&lang=fr"
+
+            # response should be url for the language switcher, as a string
+            assert isinstance(response, str)
+            assert response == "/set-lang?from=/la-page"
+
+
+def test_request_content_en_404_but_fr_doesnt_exist(app_, mocker, capsys):
+    with app_.test_request_context():
+        mocker.patch("app.articles.get_current_locale", return_value="en")
+        mocker.patch.dict("app.current_app.config", values={"GC_ARTICLES_API": gc_articles_api})
+        with requests_mock.mock() as mock:
+            mock.request("GET", notify_url, json=[], status_code=200)
+
+            # make sure request_content reaises a "Not Found" exception here
+            with pytest.raises(NotFound):
+                request_content("pages", {"slug": "la-nouvelle-page"})
+
+            # make sure requests is called twice, with 2 different language parameters
+            assert mock.called
+            assert mock.call_count == 2
+            assert mock.request_history[0].url == f"{notify_url}?slug=la-nouvelle-page&lang=en"
+            assert mock.request_history[1].url == f"{notify_url}?slug=la-nouvelle-page&lang=fr"
 
 
 @pytest.mark.skip(reason="Work in progress")


### PR DESCRIPTION
# Summary | Résumé

This pull request adds a fix for a problematic behaviour that @amazingphilippe brought up. 

Notify uses a language parameter in the user session, so this will change from person to person. It means that if _my_ browser is in French for Notify, and I send `/une-page` to Tim, whose browser is in English, he will get a `404 Not Found`, even though the page exists.

The logic in here is:
- when we ask for a page by slug
- _if_ it comes back empty
- try again with the other language
  - _if_ page found, return a string and redirect
  - _it_ *no* page found, 404 as normal

I also added a couple tests to make sure those steps happen, one for each case.