### PR TITLE
fix: return correct status to prevent alarms from triggering

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.9
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install git nodejs npm openssh-client less iproute2 procps lsb-release libsodium-dev vim zsh \
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && apt-get install -y sudo \
+    && apt-get -y install curl unzip net-tools emacs fd-find exa \
+    && apt-get -y install manpages man-db tldr \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+COPY .devcontainer/scripts/notify-dev-entrypoint.sh /usr/local/bin/
+
+EXPOSE 6012
+
+ENV SHELL /bin/zsh
+
+RUN python -m pip install wheel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+	"name": "Python 3.9",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "dev",
+	"workspaceFolder": "/workspace",
+
+	"settings": { 
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "/usr/local/bin/pylint",
+		"python.pythonPath": "/usr/local/bin/python",
+	},
+
+	"extensions": [
+		"donjayamanne.python-extension-pack",
+		"ms-python.vscode-pylance",
+		"eamodio.gitlens",
+		"wholroyd.jinja",
+		"pmbenjamin.vscode-snyk",
+		"visualstudioexptteam.vscodeintellicode",
+		"yzhang.markdown-all-in-one",
+		"ms-ossdata.vscode-postgresql",
+	],
+
+	"postCreateCommand": "notify-dev-entrypoint.sh"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  dev:
+    build: 
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached   
+    command: sleep infinity
+    ports: 
+      - "6012:6012"

--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -ex 
+
+###################################################################
+# This script will get executed *once* the Docker container has 
+# been built. Commands that need to be executed with all available
+# tools and the filesystem mount enabled should be located here. 
+###################################################################
+
+# Define aliases
+echo -e "\n\n# User's Aliases" >> ~/.zshrc
+echo -e "alias fd=fdfind" >> ~/.zshrc
+echo -e "alias l='ls -al --color'" >> ~/.zshrc
+echo -e "alias ls='exa'" >> ~/.zshrc
+echo -e "alias l='exa -alh'" >> ~/.zshrc
+echo -e "alias ll='exa -alh@ --git'" >> ~/.zshrc
+echo -e "alias lt='exa -al -T -L 2'" >> ~/.zshrc
+
+cd /workspace 
+
+# Warm up git index prior to display status in prompt else it will 
+# be quite slow on every invocation of starship.
+git status
+
+pip3 install -r requirements.txt
+pip3 install -r requirements_for_test.txt
+
+npm rebuild node-sass
+make generate-version-file
+make babel
+
+npm install
+npm run build

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -408,4 +408,4 @@ def page_content(path=""):
             stats=get_latest_stats(get_current_locale(current_app)) if slug_en == "home" else None,
         )
     else:
-        abort(500)
+        abort(404)


### PR DESCRIPTION
The introduction of dynamic route handling has resulted in an increase of error `500` Cloudwatch alarms. This is occurring whenever a web scanner targets the app and attempts to load non-existent routes.

The dynamic route handler is currently a fall-through route and will be the last one processed if no other route is triggered. If no route is found during the execution of the dynamic route handler the request will fail with a http status code `500`.

Modifying this to error 404 will result in a significant reduction of Cloudwatch error 500 alarms since invalid paths being browsed is not a condition we want to alarm on.

**Bonus:** devcontainer