### PR TITLE
chore: prevent devcontainer startup from updating lock file

### DIFF
--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -29,5 +29,5 @@ npm rebuild node-sass
 make generate-version-file
 make babel
 
-npm install
+npm ci install
 npm run build


### PR DESCRIPTION
npm install is updating the projects package.json lock file. using npm ci when building the devcontainer will ensure that the package.json and it's lock file are not updated.