### PR TITLE
Update aria labels for menu links

### DIFF
--- a/app/templates/components/buttons.html
+++ b/app/templates/components/buttons.html
@@ -20,7 +20,7 @@
         {% if link_img %}
             <img
                 aria-hidden="true"
-                alt="{{ _('External link') }}"
+                alt=""
                 class="inline w-6 h-6 ml-2 self-center {% if link_img %} {{ link_img_class }} {% endif %}"
                 src="{{ link_img }}"/>
         {% endif %}

--- a/app/templates/components/nav_menu_item_mobile.html
+++ b/app/templates/components/nav_menu_item_mobile.html
@@ -12,6 +12,9 @@
         class="no-underline hover:underline {% if is_selected %} menu--active {% endif %} {{ css_classes }}"
         {% if is_external_link %}
         target="_blank"
+        aria-label="{{ localised_txt }} ({{ _('Opens in a new tab') }})"
+        {% else %}
+        aria-label="{{ localised_txt }}"
         {% endif %}
       >
         {{ localised_txt }}


### PR DESCRIPTION
# Summary | Résumé

This PR does 2 things: 
1. Removes the "external link" alt text on menu item images
2. Adds "Opens in a new tab" to the `aria-label` for external links in the mobile menu

## Removes the "external link" alt text on menu item images

<img width="200" alt="Screen Shot 2022-03-01 at 13 28 40" src="https://user-images.githubusercontent.com/2454380/156227684-b63b2715-c3d5-4084-b45c-34af14dea25f.png">

Like this one ☝️ 

We are already using `aria-hidden="true"` for these images, so we don't need this extra aria label (it will just be ignored).

## Adds "Opens in a new tab" to the `aria-label` for external links in the mobile menu

Both the footer menu and the top nav will add this to the aria-label, but the mobile nav menu wasn't doing it. Now they all do it.