### PR TITLE
chore: use notifications_utils for config logging

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@ import os
 from typing import Any, List
 
 from dotenv import load_dotenv
+from notifications_utils import logging
 
 load_dotenv()
 
@@ -132,19 +133,9 @@ class Config(object):
         ]
 
     @classmethod
-    def get_config(cls, sensitive_config: list[str]) -> dict[str, Any]:
-        "Returns a dict of config keys and values"
-        config = {}
-        for attr in dir(cls):
-            attr_value = "***" if attr in sensitive_config else getattr(cls, attr)
-            if not attr.startswith("__") and not callable(attr_value):
-                config[attr] = attr_value
-        return config
-
-    @classmethod
     def get_safe_config(cls) -> dict[str, Any]:
         "Returns a dict of config keys and values with sensitive values masked"
-        return cls.get_config(cls.get_sensitive_config())
+        return logging.get_class_attrs(cls, cls.get_sensitive_config())
 
 
 class Development(Config):

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -40,6 +40,6 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@46.3.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@46.3.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -53,28 +53,12 @@ def test_load_config_if_cloudfoundry_not_available(monkeypatch, reload_config):
     assert config.Config.API_HOST_NAME == "env"
 
 
-def test_get_config(reload_config):
-    config.Config.API_HOST_NAME = "http://foo.bar"
-    config.Config.NOTIFY_USER_ID = "bueller"
-    logged_config = config.Config.get_config([])
-    assert logged_config["API_HOST_NAME"] == "http://foo.bar"
-    assert logged_config["NOTIFY_USER_ID"] == "bueller"
-
-    config.Config.SECRET_KEY = "1234"
-    logged_config = config.Config.get_config(["SECRET_KEY"])
-    assert logged_config["SECRET_KEY"] == "***"
-
-    for key, _ in logged_config.items():
-        assert not key.startswith("__")
-        assert not callable(getattr(config.Config, key))
-
-
 def test_get_safe_config(mocker, reload_config):
-    mock_get_config = mocker.patch("app.config.Config.get_config")
+    mock_get_class_attrs = mocker.patch("notifications_utils.logging.get_class_attrs")
     mock_get_sensitive_config = mocker.patch("app.config.Config.get_sensitive_config")
 
     config.Config.get_safe_config()
-    assert mock_get_config.called
+    assert mock_get_class_attrs.called
     assert mock_get_sensitive_config.called
 
 


### PR DESCRIPTION
# Summary
Use the Notification Utils `logging.get_class_attrs` to log the API's
config on startup.

# Related
* cds-snc/notification-planning#522