### PR TITLE
feat: use environs to get boolean and int config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,8 +2,11 @@ import os
 from typing import Any, List
 
 from dotenv import load_dotenv
+from environs import Env
 from notifications_utils import logging
 
+env = Env()
+env.read_env()
 load_dotenv()
 
 
@@ -38,8 +41,8 @@ class Config(object):
     BULK_SEND_TEST_SERVICE_ID = os.getenv("BULK_SEND_TEST_SERVICE_ID")
     CHECK_PROXY_HEADER = False
     CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "assistance+notification@cds-snc.ca")
-    CSV_MAX_ROWS = os.getenv("CSV_MAX_ROWS", 50_000)
-    CSV_MAX_ROWS_BULK_SEND = os.getenv("CSV_MAX_ROWS_BULK_SEND", 100_000)
+    CSV_MAX_ROWS = env.int("CSV_MAX_ROWS", 50_000)
+    CSV_MAX_ROWS_BULK_SEND = env.int("CSV_MAX_ROWS_BULK_SEND", 100_000)
     CSV_UPLOAD_BUCKET_NAME = os.getenv("CSV_UPLOAD_BUCKET_NAME", "notification-alpha-canada-ca-csv-upload")
     DANGEROUS_SALT = os.environ.get("DANGEROUS_SALT")
     DEBUG = False
@@ -53,13 +56,13 @@ class Config(object):
         "school_or_college": 25_000,
         "other": 25_000,
     }
-    DEFAULT_LIVE_SERVICE_LIMIT = int(os.environ.get("DEFAULT_LIVE_SERVICE_LIMIT", 10_000))
-    DEFAULT_SERVICE_LIMIT = int(os.environ.get("DEFAULT_SERVICE_LIMIT", 50))
+    DEFAULT_LIVE_SERVICE_LIMIT = env.int("DEFAULT_LIVE_SERVICE_LIMIT", 10_000)
+    DEFAULT_SERVICE_LIMIT = env.int("DEFAULT_SERVICE_LIMIT", 50)
     DOCUMENTATION_DOMAIN = os.getenv("DOCUMENTATION_DOMAIN", "documentation.notification.canada.ca")
     EMAIL_2FA_EXPIRY_SECONDS = 1_800  # 30 Minutes
     EMAIL_EXPIRY_SECONDS = 3600  # 1 hour
-    FREE_YEARLY_SMS_LIMIT = int(os.getenv("FREE_YEARLY_SMS_LIMIT", 25_000))
-    FREE_YEARLY_EMAIL_LIMIT = int(os.getenv("FREE_YEARLY_EMAIL_LIMIT", 10_000_000))
+    FREE_YEARLY_SMS_LIMIT = env.int("FREE_YEARLY_SMS_LIMIT", 25_000)
+    FREE_YEARLY_EMAIL_LIMIT = env.int("FREE_YEARLY_EMAIL_LIMIT", 10_000_000)
     GOOGLE_ANALYTICS_ID = os.getenv("GOOGLE_ANALYTICS_ID", "UA-102484926-14")
     GOOGLE_TAG_MANAGER_ID = os.getenv("GOOGLE_TAG_MANAGER_ID", "GTM-KRKRZQV")
     HC_EN_SERVICE_ID = os.getenv("HC_EN_SERVICE_ID")
@@ -87,7 +90,7 @@ class Config(object):
     PERMANENT_SESSION_LIFETIME = 20 * 60 * 60  # 20 hours
 
     REDIS_URL = os.environ.get("REDIS_URL")
-    REDIS_ENABLED = os.environ.get("REDIS_ENABLED") == "1"
+    REDIS_ENABLED = env.bool("REDIS_ENABLED", False)
 
     ROUTE_SECRET_KEY_1 = os.environ.get("ROUTE_SECRET_KEY_1", "")
     ROUTE_SECRET_KEY_2 = os.environ.get("ROUTE_SECRET_KEY_2", "")

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,7 @@ Flask==1.1.2
 Flask-WTF==0.14.3
 Flask-Login==0.5.0
 Flask-Caching==1.10.1
+environs==9.5.0
 
 blinker==1.4
 pyexcel==0.6.6

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -34,6 +34,7 @@ WTForms==3.0.0a1
 email-validator==1.1.2
 Werkzeug==1.0.1
 greenlet==1.1.2
+mixpanel==4.9.0
 
 # PaaS
 awscli-cwlogs>=1.4.6,<1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ WTForms==3.0.0a1
 email-validator==1.1.2
 Werkzeug==1.0.1
 greenlet==1.1.2
+mixpanel==4.9.0
 
 # PaaS
 awscli-cwlogs>=1.4.6,<1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask==1.1.2
 Flask-WTF==0.14.3
 Flask-Login==0.5.0
 Flask-Caching==1.10.1
+environs==9.5.0
 
 blinker==1.4
 pyexcel==0.6.6
@@ -47,6 +48,7 @@ git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
 ## The following requirements were added by pip freeze:
+async-timeout==4.0.2
 awscli==1.19.58
 bleach==3.3.0
 botocore==1.20.58
@@ -55,6 +57,7 @@ certifi==2021.5.30
 chardet==4.0.0
 click==8.0.1
 colorama==0.4.3
+Deprecated==1.2.13
 dnspython==1.16.0
 docopt==0.6.2
 docutils==0.15.2
@@ -67,11 +70,11 @@ jmespath==0.10.0
 lml==0.1.0
 lxml==4.6.3
 MarkupSafe==2.0.1
+marshmallow==3.15.0
 mistune==0.8.4
 openpyxl==3.0.9
-mixpanel==4.9.0
 orderedset==2.0.3
-packaging==21.0
+packaging==21.3
 phonenumbers==8.12.21
 py-w3c==0.3.1
 pyasn1==0.4.8
@@ -88,7 +91,8 @@ six==1.16.0
 smartypants==2.0.1
 statsd==3.3.0
 texttable==1.6.4
-urllib3==1.26.7
+urllib3==1.26.9
 webencodings==0.5.1
+wrapt==1.14.0
 xlrd==1.2.0
 xlwt==1.3.0


### PR DESCRIPTION
# Summary
Update to use the environs module for loading boolean and
integer config values.  This will provide more consistent
configuration loading behaviour.

# Related
* cds-snc/notification-planning#503