### PR TITLE
feat: launch scan-websites a11y scanner on PR merge

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -81,6 +81,12 @@ jobs:
         json='{"product": "cds-snc/notification", "revision": "${{github.sha}}", "urls":["https://staging.notification.cdssandbox.xyz"], "spider": 1, "ci": 1}'
         curl -X POST -H 'X-API-KEY: ${{ secrets.A11Y_TRACKER_KEY }}' --data "$json" https://api.a11y.cdssandbox.xyz/v1
 
+    - name: Run scan websites
+      run: |
+        curl -s https://scan-websites.alpha.canada.ca > /dev/null
+        sleep 60
+        curl -X GET -H 'X-API-KEY: ${{ secrets.SCAN_WEBSITES_KEY }}' -H 'X-TEMPLATE-TOKEN: ${{ secrets.SCAN_WEBSITES_TEMPLATE }}' https://scan-websites.alpha.canada.ca/scans/start
+
     - name: Notify Slack channel if this job failed
       if: ${{ failure() }}
       run: |


### PR DESCRIPTION
Enables continuous a11y scanning using CDS [scan-websites](https://scan-websites.alpha.canada.ca/). This PR only enables static scanning and will not result in spam or active security testing.

![image](https://user-images.githubusercontent.com/85885638/162474831-8de3364b-29f0-48fe-b8d8-0a5d496ef2b4.png)
