### PR TITLE
Update: Notify Security Headers

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -616,6 +616,7 @@ def save_service_or_org_after_request(response):
 
 #  https://www.owasp.org/index.php/List_of_useful_HTTP_headers
 def useful_headers_after_request(response):
+    response.headers.add("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
     response.headers.add("X-Frame-Options", "deny")
     response.headers.add("X-Content-Type-Options", "nosniff")
     response.headers.add("X-XSS-Protection", "1; mode=block")

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -616,6 +616,7 @@ def save_service_or_org_after_request(response):
 
 #  https://www.owasp.org/index.php/List_of_useful_HTTP_headers
 def useful_headers_after_request(response):
+    response.headers.add("Referrer-Policy", "strict-origin-when-cross-origin")
     response.headers.add("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
     response.headers.add("X-Frame-Options", "deny")
     response.headers.add("X-Content-Type-Options", "nosniff")

--- a/config/mixpanel.py
+++ b/config/mixpanel.py
@@ -6,7 +6,7 @@ from mixpanel import Mixpanel  # type: ignore
 from app.models.user import User
 
 
-class NotifyMixpanel():
+class NotifyMixpanel:
 
     enabled = False
 
@@ -27,6 +27,7 @@ class NotifyMixpanel():
         def wrapper(*args, **kwargs):
             if NotifyMixpanel.enabled:
                 callable(*args, **kwargs)
+
         return wrapper
 
     @__mixpanel_enabled  # type: ignore

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -24,6 +24,20 @@ service = [
 ]
 
 
+def test_presence_of_security_headers(client, mocker):
+    mocker.patch("app.service_api_client.get_live_services_data", return_value={"data": service})
+    mocker.patch(
+        "app.service_api_client.get_stats_by_month",
+        return_value={"data": [("2020-11-01", "email", 20)]},
+    )
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+
+    assert response.headers.has_key("Strict-Transport-Security") == True
+    assert response.headers["Strict-Transport-Security"] == "max-age=63072000; includeSubDomains; preload"
+
 def test_owasp_useful_headers_set(
     client,
     mocker,

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -38,6 +38,9 @@ def test_presence_of_security_headers(client, mocker):
     assert response.headers.has_key("Strict-Transport-Security") == True
     assert response.headers["Strict-Transport-Security"] == "max-age=63072000; includeSubDomains; preload"
 
+    assert response.headers.has_key("Referrer-Policy") == True
+    assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+
 def test_owasp_useful_headers_set(
     client,
     mocker,

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -35,11 +35,12 @@ def test_presence_of_security_headers(client, mocker):
 
     assert response.status_code == 200
 
-    assert response.headers.has_key("Strict-Transport-Security") == True
+    assert "Strict-Transport-Security" in response.headers
     assert response.headers["Strict-Transport-Security"] == "max-age=63072000; includeSubDomains; preload"
 
-    assert response.headers.has_key("Referrer-Policy") == True
+    assert "Referrer-Policy" in response.headers
     assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+
 
 def test_owasp_useful_headers_set(
     client,


### PR DESCRIPTION
[Zenhub](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/96)

# Summary | Résumé

Notify's admin requires Referrer-Policy and Strict-Transport-Security, security headers respectively.

Within are 2 commits that add and test the aforementioned

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
