### PR TITLE
refactor how the email address is treated

### DIFF
--- a/app/main/views/forgot_password.py
+++ b/app/main/views/forgot_password.py
@@ -1,10 +1,11 @@
-from flask import abort, flash, render_template
+from flask import abort, flash, render_template, session
 from flask_babel import _
 from notifications_python_client.errors import HTTPError
 
 from app import user_api_client
 from app.main import main
 from app.main.forms import ForgotPasswordForm
+from app.models.user import User
 
 
 @main.route("/forgot-password", methods=["GET", "POST"])
@@ -31,8 +32,9 @@ def forgot_password():
     return render_template("views/forgot-password.html", form=form)
 
 
-@main.route("/forced-password-reset/<email_address>", methods=["GET"])
-def forced_password_reset(email_address):
-    email_address = email_address.replace(" ", "+")
-    user_api_client.send_reset_password_url(email_address)
+@main.route("/forced-password-reset", methods=["GET"])
+def forced_password_reset():
+    email_address = session.pop("reset_email_address", None)
+    if email_address and User.from_email_address_or_none(email_address):
+        user_api_client.send_reset_password_url(email_address)
     return render_template("views/forced-password-reset.html")

--- a/app/main/views/forgot_password.py
+++ b/app/main/views/forgot_password.py
@@ -35,6 +35,7 @@ def forgot_password():
 @main.route("/forced-password-reset", methods=["GET"])
 def forced_password_reset():
     email_address = session.pop("reset_email_address", None)
-    if email_address and User.from_email_address_or_none(email_address):
+    user = User.from_email_address_or_none(email_address)
+    if email_address and user and user.password_expired:
         user_api_client.send_reset_password_url(email_address)
     return render_template("views/forced-password-reset.html")

--- a/app/main/views/forgot_password.py
+++ b/app/main/views/forgot_password.py
@@ -35,7 +35,7 @@ def forgot_password():
 @main.route("/forced-password-reset", methods=["GET"])
 def forced_password_reset():
     email_address = session.pop("reset_email_address", None)
-    user = User.from_email_address_or_none(email_address)
+    user = User.from_email_address_or_none(email_address) if email_address else None
     if email_address and user and user.password_expired:
         user_api_client.send_reset_password_url(email_address)
     return render_template("views/forced-password-reset.html")

--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -38,7 +38,8 @@ def sign_in():
 
         user = User.from_email_address_or_none(form.email_address.data)
         if user and user.password_expired:
-            return redirect(url_for("main.forced_password_reset", email_address=user.email_address))
+            session["reset_email_address"] = user.email_address
+            return redirect(url_for("main.forced_password_reset"))
 
         user = User.from_email_address_and_password_or_none(form.email_address.data, form.password.data, login_data)
 

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -143,7 +143,7 @@ def test_process_sms_auth_sign_in_return_2fa_template(
     mock_get_user_by_email.assert_called_with("valid@example.canada.ca")
 
 
-def test_forced_password_reset(
+def test_sign_in_redirects_to_forced_password_reset(
     client,
     mocker,
     mock_send_verify_code,
@@ -160,14 +160,40 @@ def test_forced_password_reset(
         "app.user_api_client.get_user_by_email",
         return_value=sample_user,
     )
-
     response = client.post(url_for("main.sign_in"), data={"email_address": "test@admin.ca", "password": "123_hello_W"})
 
     assert response.location == url_for(
         "main.forced_password_reset",
-        email_address="test@admin.ca",
         _external=True,
     )
+
+
+def test_forced_password_reset(
+    client,
+    mocker,
+    mock_send_verify_code,
+    mock_verify_password,
+    mock_get_security_keys,
+    fake_uuid,
+):
+
+    sample_user = create_active_user(fake_uuid, email_address="test@admin.ca")
+    sample_user["is_authenticated"] = False
+    sample_user["password_expired"] = True
+
+    with client.session_transaction() as session:
+        session["reset_email_address"] = sample_user["email_address"]
+
+    mocker.patch(
+        "app.user_api_client.get_user_by_email",
+        return_value=sample_user,
+    )
+
+    mocked_send_email = mocker.patch("app.user_api_client.send_reset_password_url")
+    response = client.get(url_for("main.forced_password_reset"))
+
+    assert "You need to create a new password" in response.get_data(as_text=True)
+    mocked_send_email.assert_called_with(sample_user["email_address"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary | Résumé

- store the email address in the browser session rather than the url
- only send the email if there is an email address of a user in the session and the user's password is expired.
- add more tests

# Test instructions | Instructions pour tester la modification

Make sure the whole expire password flow still works.