### PR TITLE
Update autocomplete values

### DIFF
--- a/app/templates/views/forgot-password.html
+++ b/app/templates/views/forgot-password.html
@@ -16,7 +16,7 @@
     <p>{{ _('We’ll send you an email to create a new password.') }}</p>
     {% set btn_txt = _('Send email') %}
     {% call form_wrapper() %}
-      {{ textbox(form.email_address, safe_error_message=True) }}
+      {{ textbox(form.email_address, safe_error_message=True, autocomplete='username') }}
       {{ page_footer(btn_txt) }}
     {% endcall %}
 

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -13,7 +13,7 @@
   <div class="md:w-2/3 float-left py-0 px-0 px-gutterHalf box-border">
     <h1 class="heading-large">{{ _('Create an account') }}</h1>
     {% call form_wrapper(autocomplete=True) %}
-      {{ textbox(form.name, width='w-full md:w-3/4') }}
+      {{ textbox(form.name, width='w-full md:w-3/4', autocomplete='name') }}
       {% set hint_txt = _('Must be a federal government email address') %}
       {{ textbox(form.email_address, hint=hint_txt, width='w-full md:w-3/4', safe_error_message=True, autocomplete='email') }}
       <div class="extra-tracking">

--- a/app/templates/views/signin.html
+++ b/app/templates/views/signin.html
@@ -33,7 +33,7 @@
     {% set forgot = _('Forgot your password?') %}
     {% set btn = _('Continue') %}
     {% call form_wrapper(autocomplete=True) %}
-      {{ textbox(form.email_address, width='w-2/3', autocomplete='email') }}
+      {{ textbox(form.email_address, width='w-2/3', autocomplete='username') }}
       {{ textbox(form.password, width='w-2/3', autocomplete='current-password') }}
       {{ page_footer(btn, secondary_link=url_for('.forgot_password'), secondary_link_text=forgot) }}
     {% endcall %}

--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -28,7 +28,8 @@
       {{ textbox(
         form.two_factor_code,
         width='form-control-5em',
-        autofocus=True
+        autofocus=True,
+        autocomplete='one-time-code'
       ) }}
       {{ page_footer(
         continue,

--- a/app/templates/views/user-profile/change-password.html
+++ b/app/templates/views/user-profile/change-password.html
@@ -18,7 +18,7 @@
   <div class="grid-row contain-floats">
     <div class="md:w-3/4 float-left py-0 px-0 px-gutterHalf box-border">
       {% call form_wrapper(autocomplete=True) %}
-        {{ textbox(form.old_password) }}
+        {{ textbox(form.old_password, autocomplete='current-password') }}
         {{ textbox(form.new_password) }}
         {{ page_footer(_('Save')) }}
       {% endcall %}

--- a/app/templates/views/user-profile/change.html
+++ b/app/templates/views/user-profile/change.html
@@ -18,7 +18,7 @@
   <div class="grid-row contain-floats">
     <div class="md:w-3/4 float-left py-0 px-0 px-gutterHalf box-border">
       {% call form_wrapper() %}
-        {{ textbox(form_field, safe_error_message=True) }}
+        {{ textbox(form_field, safe_error_message=True, autocomplete='change-value') }}
         {{ page_footer(_('Save')) }}
       {% endcall %}
     </div>

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -16,7 +16,7 @@ def test_render_sign_in_template_for_new_user(client_request):
     assert normalize_spaces(page.select_one("h1").text) == "Sign in"
     assert normalize_spaces(page.select("label")[0].text) == "Email address"
     assert page.select_one("#email_address")["value"] == ""
-    assert page.select_one("#email_address")["autocomplete"] == "email"
+    assert page.select_one("#email_address")["autocomplete"] == "username"
     assert normalize_spaces(page.select("label")[1].text) == "Password"
     assert page.select_one("#password")["value"] == ""
     assert page.select_one("#password")["autocomplete"] == "current-password"


### PR DESCRIPTION
# Summary | Résumé

Update `autocomplete` values throughout the app to use appropriate values to make the app easier for users.

# Test instructions | Instructions pour tester la modification
Verify values are set as per:
- Create an account
   - [ ] Email -> `email`
   - [ ] Name -> `name`
   - [ ] Password -> `new-password`
- Change account info
   - [ ] Name -> `change-value`
   - [ ] Email -> `change-value`
   - [ ] Mobile -> `change-value`
- Add reply-to address
   - [ ] Email -> `reply-to-email`
- Sign in
   - [ ] Email -> `username`
   - [ ] Password -> `current-password`
- Send me a link (forgot pw)
   - [ ]  Email -> `username`
- New stuff:
   - [ ] Security code: ->  `one-time-code`
   - [ ] Confirm account info change: ->  `current-password`


Fixes cds-snc/notification-planning#479