### PR TITLE
fix(autocomplete): add values to missing screens

### DIFF
--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -21,7 +21,8 @@
       form.email_address,
       width='w-full',
       hint=_('This should be a shared inbox managed by your team, not your own email address.'),
-      safe_error_message=True
+      safe_error_message=True,
+      autocomplete="email"
     ) }}
     {% if not first_email_address %}
       <div class="form-group contain-floats box-border mb-gutterHalf md:mb-gutter">

--- a/app/templates/views/service-settings/email-reply-to/add.html
+++ b/app/templates/views/service-settings/email-reply-to/add.html
@@ -21,8 +21,7 @@
       form.email_address,
       width='w-full',
       hint=_('This should be a shared inbox managed by your team, not your own email address.'),
-      safe_error_message=True,
-      autocomplete="email"
+      safe_error_message=True
     ) }}
     {% if not first_email_address %}
       <div class="form-group contain-floats box-border mb-gutterHalf md:mb-gutter">

--- a/app/templates/views/user-profile/change-password.html
+++ b/app/templates/views/user-profile/change-password.html
@@ -18,8 +18,8 @@
   <div class="grid-row contain-floats">
     <div class="md:w-3/4 float-left py-0 px-0 px-gutterHalf box-border">
       {% call form_wrapper(autocomplete=True) %}
-        {{ textbox(form.old_password) }}
-        {{ textbox(form.new_password) }}
+        {{ textbox(form.old_password, autocomplete="current-password") }}
+        {{ textbox(form.new_password, autocomplete="new-password") }}
         {{ page_footer(_('Save')) }}
       {% endcall %}
     </div>


### PR DESCRIPTION
# Summary | Résumé

Add the values to 2 screens that were missed:
- Change password (`/user-profile/password`)
- Add reply-to address (`/services/{id}/service-settings/email-reply-to/add`)

# QA
Ensure the correct `autocomplete` values are set on each page:
- Change password
   - [ ] old password should be `current-password`
   - [ ] new password should be `new-password`

(re)-fixes cds-snc/notification-planning#479