### PR TITLE
feat: delete unused PR review environments

### DIFF
--- a/.github/workflows/test-admin-delete-unused.yaml
+++ b/.github/workflows/test-admin-delete-unused.yaml
@@ -1,0 +1,46 @@
+name: Delete unused PR review environments
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *" # Nightly at 4am
+
+env:
+  AWS_DEFAULT_REGION: ca-central-1
+  DELETE_AFTER_DAYS: 21
+  FUNCTION_PREFIX: "notify-admin-pr"
+  IMAGE: notify/admin
+
+jobs:
+  delete-unused-test-admin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        id: aws-creds
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Delete old PR review environments
+        run: |
+          IFS=$'\n\t'
+          DELETE_DATE_EPOCH=$(date -d "-${{ env.DELETE_AFTER_DAYS }} days" +%s)
+          PR_REVIEW_ENVS="$(aws lambda list-functions --query 'Functions[?starts_with(FunctionName, `${{ env.FUNCTION_PREFIX }}`) == `true`]' | jq -c -r '.[]')"
+
+          for ENV in $PR_REVIEW_ENVS; do
+              FUNCTION_NAME="$(jq -r '.FunctionName' <<< $ENV)"
+              LAST_MODIFIED="$(jq -r '.LastModified' <<< $ENV)"
+              LAST_MODIFIED_EPOCH="$(date -d $LAST_MODIFIED +%s)"
+
+              if [ $LAST_MODIFIED_EPOCH -lt $DELETE_DATE_EPOCH ]; then
+                  echo "Deleting $FUNCTION_NAME"
+                  PR_NUMBER="${FUNCTION_NAME##*-}"
+                  aws lambda wait function-active --function-name ${{ env.FUNCTION_PREFIX }}-$PR_NUMBER
+                  aws lambda delete-function-url-config --function-name ${{ env.FUNCTION_PREFIX }}-$PR_NUMBER
+                  aws lambda delete-function --function-name ${{ env.FUNCTION_PREFIX }}-$PR_NUMBER
+                  aws logs delete-log-group --log-group-name /aws/lambda/${{ env.FUNCTION_PREFIX }}-$PR_NUMBER
+                  aws ecr batch-delete-image --repository-name $IMAGE --image-ids imageTag=$PR_NUMBER
+              fi
+          done

--- a/.github/workflows/test-admin-remove.yaml
+++ b/.github/workflows/test-admin-remove.yaml
@@ -28,15 +28,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
-      - name: Delete lambda function
+      - name: Delete lambda function resources
         run: |
           aws lambda wait function-active --function-name $FUNCTION_NAME-$PR_NUMBER
           aws lambda delete-function-url-config --function-name $FUNCTION_NAME-$PR_NUMBER
           aws lambda delete-function --function-name $FUNCTION_NAME-$PR_NUMBER
-
-      - name: Delete old images
-        run: |
-          aws ecr batch-delete-image \
-            --repository-name $IMAGE \
-            --image-ids imageTag=$PR_NUMBER            
+          aws logs delete-log-group --log-group-name /aws/lambda/$FUNCTION_NAME-$PR_NUMBER
+          aws ecr batch-delete-image --repository-name $IMAGE --image-ids imageTag=$PR_NUMBER
         


### PR DESCRIPTION
# Summary
Nightly job to delete PR review environments that haven't been
updated in 21 days.

Also updates the PR close workflow to remove the review
environment's CloudWatch log group.

# Related
* cds-snc/notification-planning#625