### PR TITLE
Update GC Articles tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,4 @@ filterwarnings =
 addopts = -p no:warnings -n4
 markers =
     a11y: mark a test as an accessibility test.
+    integration: mark a test as an integration test.

--- a/tests/app/articles/test_pages.py
+++ b/tests/app/articles/test_pages.py
@@ -113,36 +113,3 @@ def test_gca_redirects_work(client_request, mocker, url):
 
     # ensure each url is a permenent redirect
     client_request.get_url(url, _expected_status=301)
-
-
-@pytest.mark.skip(reason="This is an integration test, should be elsewhere")
-@pytest.mark.parametrize(
-    "url",
-    [
-        "/why-gc-notify",
-        "/features",
-        "/guidance",
-        "/security",
-        "/privacy",
-        "/accessibility",
-        "/terms",
-        "/pourquoi-gc-notification?lang=fr",
-        "/fonctionnalites?lang=fr",
-        "/guides-reference?lang=fr",
-        "/securite?lang=fr",
-        "/confidentialite?lang=fr",
-        "/accessibilite?lang=fr",
-        "/conditions-dutilisation?lang=fr",
-    ],
-)
-def test_gca_content_exists_en_fr(client_request, mocker, url):
-    """
-    This test is ensures the content we link to exists on GCA.  If someone removes a page on GCA, this will fail.
-    """
-
-    # ensure target location exists and returns content
-    page = client_request.get_url(url, _expected_status=200)
-    assert (
-        page.find("span", id="gc-title").text.strip() == "GC Notify"
-        or page.find("span", id="gc-title").text.strip() == "GC Notification"
-    )

--- a/tests/app/articles/test_pages.py
+++ b/tests/app/articles/test_pages.py
@@ -105,17 +105,17 @@ def test_bad_slug_doesnt_save_empty_cache_entry(app_, mocker):
 @pytest.mark.parametrize("url", ["/a11y", "/why-notify", "/personalise", "/format", "/messages-status"])
 def test_gca_redirects_work(client_request, mocker, url):
     """
-    This test ensures that the pages we renamed properly provide a permanent redirect, and exist in GCA
+    This test ensures that the pages we renamed properly provide a permanent redirect
     """
+
+    mocker.patch("app.main.views.index.get_page_by_slug", return_value={"some": "value"})
+    mocker.patch("app.main.views.index._render_articles_page", return_value="")
 
     # ensure each url is a permenent redirect
     client_request.get_url(url, _expected_status=301)
 
-    # ensure target location exists and returns content
-    page = client_request.get_url(url, _follow_redirects=True)
-    assert page.find("span", id="gc-title").text.strip() == "GC Notify"
 
-
+@pytest.mark.skip(reason="This is an integration test, should be elsewhere")
 @pytest.mark.parametrize(
     "url",
     [

--- a/tests/app/articles/test_routing.py
+++ b/tests/app/articles/test_routing.py
@@ -29,11 +29,13 @@ def test_gca_url_for_creates_asbolute_url(app_, mocker, route, lang, expectedURL
     assert route == expectedURL
 
 
+@pytest.mark.skip(reason="This is an integration test, should be elsewhere")
 @pytest.mark.parametrize("route", list(GC_ARTICLES_ROUTES))
 def test_ensure_all_french_gca_routes_in_GC_ARTICLES_ROUTES_exist(client_request, mocker, route):
 
     mocker.patch("app.articles.routing.get_current_locale", return_value="fr")
     mocker.patch("app.main.views.index.get_current_locale", return_value="fr")
+    mocker.patch("app.main.views.index.get_page_by_slug", return_value={"some": "value"})
     render_article = mocker.patch("app.main.views.index._render_articles_page", return_value="")
 
     url = gca_url_for(route)
@@ -42,11 +44,13 @@ def test_ensure_all_french_gca_routes_in_GC_ARTICLES_ROUTES_exist(client_request
     assert render_article.called
 
 
+@pytest.mark.skip(reason="This is an integration test, should be elsewhere")
 @pytest.mark.parametrize("route", list(GC_ARTICLES_ROUTES))
 def test_ensure_all_english_gca_routes_in_GC_ARTICLES_ROUTES_exist(client_request, mocker, route):
 
     mocker.patch("app.articles.routing.get_current_locale", return_value="en")
     mocker.patch("app.main.views.index.get_current_locale", return_value="en")
+    mocker.patch("app.main.views.index.get_page_by_slug", return_value={"some": "value"})
     render_article = mocker.patch("app.main.views.index._render_articles_page", return_value="")
 
     url = gca_url_for(route)

--- a/tests/app/articles/test_routing.py
+++ b/tests/app/articles/test_routing.py
@@ -29,13 +29,12 @@ def test_gca_url_for_creates_asbolute_url(app_, mocker, route, lang, expectedURL
     assert route == expectedURL
 
 
-@pytest.mark.skip(reason="This is an integration test, should be elsewhere")
+@pytest.mark.integration
 @pytest.mark.parametrize("route", list(GC_ARTICLES_ROUTES))
 def test_ensure_all_french_gca_routes_in_GC_ARTICLES_ROUTES_exist(client_request, mocker, route):
 
     mocker.patch("app.articles.routing.get_current_locale", return_value="fr")
     mocker.patch("app.main.views.index.get_current_locale", return_value="fr")
-    mocker.patch("app.main.views.index.get_page_by_slug", return_value={"some": "value"})
     render_article = mocker.patch("app.main.views.index._render_articles_page", return_value="")
 
     url = gca_url_for(route)
@@ -44,13 +43,12 @@ def test_ensure_all_french_gca_routes_in_GC_ARTICLES_ROUTES_exist(client_request
     assert render_article.called
 
 
-@pytest.mark.skip(reason="This is an integration test, should be elsewhere")
+@pytest.mark.integration
 @pytest.mark.parametrize("route", list(GC_ARTICLES_ROUTES))
 def test_ensure_all_english_gca_routes_in_GC_ARTICLES_ROUTES_exist(client_request, mocker, route):
 
     mocker.patch("app.articles.routing.get_current_locale", return_value="en")
     mocker.patch("app.main.views.index.get_current_locale", return_value="en")
-    mocker.patch("app.main.views.index.get_page_by_slug", return_value={"some": "value"})
     render_article = mocker.patch("app.main.views.index._render_articles_page", return_value="")
 
     url = gca_url_for(route)


### PR DESCRIPTION
# Summary | Résumé

As Jimmy pointed out, some of the tests are actually integration tests that reach over to GC articles.  This PR:
-  marks these as `skip` for now until we have a proper place to run integration tests
- fixes some of the other tests that were mistakenly calling out to GCA and instead mocks those calls
