### PR TITLE
Setting INFO log level for production env

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -181,6 +181,7 @@ class Production(Config):
 
 class Staging(Production):
     NOTIFY_ENVIRONMENT = "staging"
+    NOTIFY_LOG_LEVEL = "INFO"
 
 
 configs = {

--- a/app/config.py
+++ b/app/config.py
@@ -176,6 +176,7 @@ class Production(Config):
     CHECK_PROXY_HEADER = False
     HTTP_PROTOCOL = "https"
     NOTIFY_ENVIRONMENT = "production"
+    NOTIFY_LOG_LEVEL = "INFO"
 
 
 class Staging(Production):

--- a/app/utils.py
+++ b/app/utils.py
@@ -782,7 +782,7 @@ def _geolocate_lookup(ip):
         with urllib.request.urlopen(request) as f:
             response = f.read()
     except urllib.error.HTTPError as e:
-        current_app.logger.debug("Exception found: {}".format(e))
+        current_app.logger.warning("Exception found: {}".format(e))
         return ip
     else:
         return json.loads(response.decode("utf-8-sig"))


### PR DESCRIPTION
# Summary | Résumé

Looking at logging in production, there are a few DEBUG level statements around the nonce injection that pollutes the logs. Reviewing the debug level statements in the app, these are the only ones present in the admin component. It would be useful to keep the DEBUG level out of the production system and have these enabled locally. We can switch back the logging value for STAGING back to DEBUG once this has been tested in that environment.

# Test instructions | Instructions pour tester la modification

Test in staging environment first and look at the AWS CloudWatch logs to compare before/after with expected missing log statements and non-expected ones.

