### PR TITLE
fix: remove wait for function active

### DIFF
--- a/.github/workflows/test-admin-delete-unused.yaml
+++ b/.github/workflows/test-admin-delete-unused.yaml
@@ -37,7 +37,6 @@ jobs:
               if [ $LAST_MODIFIED_EPOCH -lt $DELETE_DATE_EPOCH ]; then
                   echo "Deleting $FUNCTION_NAME"
                   PR_NUMBER="${FUNCTION_NAME##*-}"
-                  aws lambda wait function-active --function-name ${{ env.FUNCTION_PREFIX }}-$PR_NUMBER
                   aws lambda delete-function-url-config --function-name ${{ env.FUNCTION_PREFIX }}-$PR_NUMBER
                   aws lambda delete-function --function-name ${{ env.FUNCTION_PREFIX }}-$PR_NUMBER
                   aws logs delete-log-group --log-group-name /aws/lambda/${{ env.FUNCTION_PREFIX }}-$PR_NUMBER


### PR DESCRIPTION
# Summary
The wait for function active call is timing out on old
functions so it's being removed:

![image](https://user-images.githubusercontent.com/2110107/173350855-3d65c390-20cc-4eaf-804e-4d951e3afa3c.png)

This was originally added to handle a case where this workflow
was called on a function that was just created, but since
the workflow runs in the middle of the night, the risk
of this scenario is low.