### PR TITLE
Update docker.yaml

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -82,13 +82,6 @@ jobs:
         project_name: notification-admin/docker
         project_type: docker
 
-    - name: Run a11y tracker
-      run: |
-        curl -s https://api.a11y.cdssandbox.xyz/v1/reports\?recent\=true > /dev/null
-        sleep 60
-        json='{"product": "cds-snc/notification", "revision": "${{github.sha}}", "urls":["https://staging.notification.cdssandbox.xyz"], "spider": 1, "ci": 1}'
-        curl -X POST -H 'X-API-KEY: ${{ secrets.A11Y_TRACKER_KEY }}' --data "$json" https://api.a11y.cdssandbox.xyz/v1
-
     - name: Run scan websites
       run: |
         curl -s https://scan-websites.alpha.canada.ca > /dev/null


### PR DESCRIPTION
Removes the a11y tracker CI step that is being retired
