### PR TITLE
Upgrade flask to v2 (admin)

### DIFF
--- a/app/articles/api.py
+++ b/app/articles/api.py
@@ -24,7 +24,7 @@ def get_content(endpoint: str, params={}, auth_required=False, cacheable=True) -
     try:
         url = f"https://{base_url}/wp-json/{endpoint}"
         response = requests.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT)
-        parsed = json.loads(response.content)
+        parsed = json.loads(response.content.decode("utf-8"))
 
         if response.status_code == 403:
             raise Forbidden()

--- a/app/s3_client/s3_mou_client.py
+++ b/app/s3_client/s3_mou_client.py
@@ -11,7 +11,7 @@ def get_mou(organisation_is_crown):
     try:
         key = get_s3_object(bucket, filename)
         return {
-            "filename_or_fp": key.get()["Body"],
+            "path_or_file": key.get()["Body"],
             "attachment_filename": attachment_filename,
             "as_attachment": True,
         }

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,4 +1,1 @@
 [python: app/**.py]
-#[jinja2: app/templates/**.html]
-[jinja2: app/templates/**/**.html]
-extensions=jinja2.ext.autoescape,jinja2.ext.with_

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -44,8 +44,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==2.0.1  # pyup: <1.0.0
 
-#git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
-git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
+git+https://github.com/cds-snc/notifier-utils.git@48.0.0#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,8 +2,8 @@
 # with package version changes made in requirements-app.txt
 
 timeago==1.0.15
-Flask==1.1.2
-Flask-WTF==0.14.3
+Flask==2.0.3
+Flask-WTF==1.0.1
 Flask-Login==0.5.0
 Flask-Caching==1.10.1
 environs==9.5.0
@@ -42,8 +42,14 @@ redis==3.5.3 # pinned for now
 awscli-cwlogs>=1.4.6,<1.5
 
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
-itsdangerous==0.24  # pyup: <1.0.0
+itsdangerous==2.0.1  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
+#git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
+
+# stubs libraries to keep mypy happy
+types-python-dateutil==2.8.2
+types-pytz==2021.1
+types-requests==2.25.1

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -47,8 +47,3 @@ itsdangerous==2.0.1  # pyup: <1.0.0
 git+https://github.com/cds-snc/notifier-utils.git@48.0.0#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
-
-# stubs libraries to keep mypy happy
-types-python-dateutil==2.8.2
-types-pytz==2021.1
-types-requests==2.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 
 timeago==1.0.15
 Flask==2.0.3
-Flask-WTF==0.14.3
+Flask-WTF==1.0.1
 Flask-Login==0.5.0
 Flask-Caching==1.10.1
 environs==9.5.0
@@ -47,7 +47,8 @@ awscli-cwlogs>=1.4.6,<1.5
 itsdangerous==2.0.1  # pyup: <1.0.0
 
 #git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
-/libs
+git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
+
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
 # stubs libraries to keep mypy happy
@@ -78,7 +79,7 @@ lxml==4.9.1
 MarkupSafe==2.0.1
 marshmallow==3.17.0
 mistune==0.8.4
-notifications-utils @ file:///libs
+notifications-utils @ git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
 openpyxl==3.0.10
 orderedset==2.0.3
 packaging==21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,8 +46,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==2.0.1  # pyup: <1.0.0
 
-#git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
-git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
+git+https://github.com/cds-snc/notifier-utils.git@48.0.0#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
@@ -79,7 +78,6 @@ lxml==4.9.1
 MarkupSafe==2.0.1
 marshmallow==3.17.0
 mistune==0.8.4
-notifications-utils @ git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
 openpyxl==3.0.10
 orderedset==2.0.3
 packaging==21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,11 +50,6 @@ git+https://github.com/cds-snc/notifier-utils.git@48.0.0#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
-# stubs libraries to keep mypy happy
-types-python-dateutil==2.8.2
-types-pytz==2021.1
-types-requests==2.25.1
-
 ## The following requirements were added by pip freeze:
 awscli==1.19.58
 bleach==3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # with package version changes made in requirements-app.txt
 
 timeago==1.0.15
-Flask==1.1.2
+Flask==2.0.3
 Flask-WTF==0.14.3
 Flask-Login==0.5.0
 Flask-Caching==1.10.1
@@ -44,11 +44,16 @@ redis==3.5.3 # pinned for now
 awscli-cwlogs>=1.4.6,<1.5
 
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
-itsdangerous==0.24  # pyup: <1.0.0
+itsdangerous==2.0.1  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
-
+#git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
+/libs
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
+
+# stubs libraries to keep mypy happy
+types-python-dateutil==2.8.2
+types-pytz==2021.1
+types-requests==2.25.1
 
 ## The following requirements were added by pip freeze:
 awscli==1.19.58
@@ -66,13 +71,14 @@ et-xmlfile==1.1.0
 flask-redis==0.4.0
 future==0.18.2
 idna==2.10
-Jinja2==2.11.3
+Jinja2==3.1.2
 jmespath==0.10.0
 lml==0.1.0
 lxml==4.9.1
 MarkupSafe==2.0.1
 marshmallow==3.17.0
 mistune==0.8.4
+notifications-utils @ file:///libs
 openpyxl==3.0.10
 orderedset==2.0.3
 packaging==21.3
@@ -91,7 +97,7 @@ six==1.16.0
 smartypants==2.0.1
 statsd==3.3.0
 texttable==1.6.4
-urllib3==1.26.9
+urllib3==1.26.10
 webencodings==0.5.1
 xlrd==1.2.0
 xlwt==1.3.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -15,3 +15,8 @@ requests-mock==1.9.3
 jinja2-cli[yaml]==0.8.2
 black==22.3.0
 mypy==0.812
+
+# stubs libraries to keep mypy happy
+types-python-dateutil==2.8.2
+types-pytz==2021.1
+types-requests==2.25.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,7 +17,7 @@ from app.models.user import User
 # In tests where we freeze time, the code in the test function will get the frozen time but the
 # fixtures will be using the current time. This causes itsdangerous to raise an exception - when
 # the session is decoded it appears to be created in the future.
-freezegun.configure(extend_ignore_list=["itsdangerous"])
+freezegun.configure(extend_ignore_list=["itsdangerous"])  # type: ignore
 
 
 class dotdict(dict):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
+import freezegun
 import pytest
 from flask import session as flask_session
 from flask import url_for
@@ -11,6 +12,12 @@ from flask_login import login_user
 
 from app.models.service import Service
 from app.models.user import User
+
+# Add itsdangerous to the libraries which freezegun ignores to avoid errors.
+# In tests where we freeze time, the code in the test function will get the frozen time but the
+# fixtures will be using the current time. This causes itsdangerous to raise an exception - when
+# the session is decoded it appears to be created in the future.
+freezegun.configure(extend_ignore_list=["itsdangerous"])
 
 
 class dotdict(dict):


### PR DESCRIPTION
# Summary | Résumé

## Package bumps
This PR upgrades:
- Flask to 2.0.3
- Flask-WTF to 1.0.1
- itsdangerous to 2.0.1

And adds some packages to keep mypy happy:
- types-python-dateutil  2.8.2
- types-pytz 2021.1
- types-requests 2.25.1

## Flask changes
- the `send_file` method renamed the parameter `filename_or_fp` to `path_or_file`

## Jinja changes
- The `autoescape` and `with_` extensions are now built into jijna and do not need to be referenced as extensions

## Issue with freezegun
As noted by GDS:
> Add itsdangerous to the libraries which freezegun ignores to avoid errors. In tests where we freeze time, the code in the test function will get the frozen time but the  fixtures will be using the current time. This causes itsdangerous to raise an exception - when the session is decoded it appears to be created in the future.

# Testing
- [ ] Ensure pages that use `service_download_agreement()` work
- [ ] Ensure pages that use `public_agreement()` work
- [x] Ensure pages that use GC Articles (i.e. `/home`) works