### PR TITLE
A11Y: Fix up account menu labelling

### DIFF
--- a/app/templates/partials/nav/account_menu_mobile.html
+++ b/app/templates/partials/nav/account_menu_mobile.html
@@ -1,6 +1,7 @@
 <!-- account menu dropdown / mobile -->
 <div class="md:hidden">
   <button
+    aria-label="{{ _('Your account and language') if current_user.is_authenticated else _('Sign-in and language') }}" 
     aria-expanded="false"
     aria-haspopup="true"
     id="account-icon-mobile"
@@ -10,7 +11,6 @@
     data-menu-overlay-close="account-close-mobile">
     <img
       aria-hidden="false"
-      aria-label="{{ _('Account menu') }}"
       src="{{ asset_url('images/account-icon.svg') }}"
       alt="{{ _('Account menu') }}"
       class="w-10 h-10"/>

--- a/app/templates/partials/nav/gc_header_nav.html
+++ b/app/templates/partials/nav/gc_header_nav.html
@@ -33,7 +33,7 @@
       <!--  start mobile navigation -->
       {% include 'partials/nav/gc_header_nav_mobile.html' %}
       <!--  end mobile navigation -->
-      <div aria-label="{{ _('Your account and language') if current_user.is_authenticated else _('Sign-in and language') }}" class="flex justify-end self-center">
+      <div class="flex justify-end self-center">
         {% if current_user.is_authenticated %}
           {% include 'partials/nav/account_menu_mobile.html' %}
         {% else %}


### PR DESCRIPTION
Summary:

- Move the `aria-label` off of the div (it isn't allowed on a non-interactive element) and down to the menu button instead
- Remove `aria-label` from `img` tag