### PR TITLE
feat: report csp violations to the CDS report service

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -629,7 +629,7 @@ def useful_headers_after_request(response):
     asset_domain = current_app.config["ASSET_DOMAIN"]
     response.headers.add(
         "Content-Security-Policy",
-        (   
+        (
             "report-uri https://csp-report-to.security.cdssandbox.xyz/report;"
             "default-src 'self' {asset_domain} 'unsafe-inline';"
             f"script-src 'self' {asset_domain} *.google-analytics.com *.googletagmanager.com https://tagmanager.google.com https://js-agent.newrelic.com 'nonce-{nonce}' 'unsafe-eval' data:;"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -629,7 +629,8 @@ def useful_headers_after_request(response):
     asset_domain = current_app.config["ASSET_DOMAIN"]
     response.headers.add(
         "Content-Security-Policy",
-        (
+        (   
+            "report-uri https://csp-report-to.security.cdssandbox.xyz/report;"
             "default-src 'self' {asset_domain} 'unsafe-inline';"
             f"script-src 'self' {asset_domain} *.google-analytics.com *.googletagmanager.com https://tagmanager.google.com https://js-agent.newrelic.com 'nonce-{nonce}' 'unsafe-eval' data:;"
             "connect-src 'self' *.google-analytics.com *.googletagmanager.com;"

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -62,6 +62,7 @@ def test_owasp_useful_headers_set(client, mocker, mock_get_service_and_organisat
     assert response.headers["X-Content-Type-Options"] == "nosniff"
     assert response.headers["X-XSS-Protection"] == "1; mode=block"
     assert response.headers["Content-Security-Policy"] == (
+        "report-uri https://csp-report-to.security.cdssandbox.xyz/report;"
         "default-src 'self' static.example.com 'unsafe-inline';"
         f"script-src 'self' static.example.com *.google-analytics.com *.googletagmanager.com https://tagmanager.google.com https://js-agent.newrelic.com 'nonce-{nonce}' 'unsafe-eval' data:;"
         "connect-src 'self' *.google-analytics.com *.googletagmanager.com;"
@@ -123,6 +124,7 @@ def test_headers_non_ascii_characters_are_replaced(
 
     assert response.status_code == 200
     assert response.headers["Content-Security-Policy"] == (
+        "report-uri https://csp-report-to.security.cdssandbox.xyz/report;"
         "default-src 'self' static.example.com 'unsafe-inline';"
         f"script-src 'self' static.example.com *.google-analytics.com *.googletagmanager.com https://tagmanager.google.com https://js-agent.newrelic.com 'nonce-{nonce}' 'unsafe-eval' data:;"
         "connect-src 'self' *.google-analytics.com *.googletagmanager.com;"


### PR DESCRIPTION
Browsers support sending content security violations to the server identifed in the content security policy header returned by the app.

We recently launched a [new service](https://csp-reports.security.cdssandbox.xyz/) to collect these reports. The goal is to make them available to CDS teams so they can view violations users may be experiencing. This app can only be accessed by CDS employees after authenticating via Google SSO.

Information sent by the browser is the following:
- document-uri
- referrer
- violated-directive
- original-policy
- blocked-uri

