### PR TITLE
increase review app lambda concurrency

### DIFF
--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -139,7 +139,7 @@ jobs:
           aws lambda wait function-updated --function-name $FUNCTION_NAME-$PR_NUMBER
           aws lambda put-function-concurrency \
             --function-name $FUNCTION_NAME-$PR_NUMBER \
-            --reserved-concurrent-executions 3
+            --reserved-concurrent-executions 5
 
       - name: Update PR
         if: env.URL != ''


### PR DESCRIPTION
# Summary | Résumé

Review apps would sometimes not load javascript or other files. Fix is to increase the lambda concurrency.

# Test instructions | Instructions pour tester la modification

- Used to always get one or more 429s loading the `/why-gc-notify` page on review apps (in Firefox).
- now don't on this PR's [review app](https://jz2jjkdfu4tgfkw5nd4yrsbbzi0mcsih.lambda-url.ca-central-1.on.aws/) (which has the increased concurrency) 
