### PR TITLE
Add opp.ca to list of allowed domain names

### DIFF
--- a/app/email_domains.txt
+++ b/app/email_domains.txt
@@ -21,3 +21,4 @@ gov.yk.ca
 gov.nt.ca
 gov.nu.ca
 nshealth.ca
+opp.ca


### PR DESCRIPTION
# Summary | Résumé

Allow opp.ca folks to create accounts.