### PR TITLE
Bump notification-utils to 48.2.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -44,6 +44,6 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==2.0.1  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@48.1.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@48.2.0#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==2.0.1  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@48.1.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@48.2.0#egg=notifications-utils
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
@@ -55,7 +55,7 @@ awscli==1.19.58
 bleach==3.3.0
 botocore==1.20.58
 cachetools==4.2.1
-certifi==2022.6.15
+certifi==2022.6.15.1
 chardet==4.0.0
 click==8.1.3
 colorama==0.4.3


### PR DESCRIPTION
# Summary | Résumé
This PR bumps the notification-utils version to make use of the lang tag fixes from https://github.com/cds-snc/notification-utils/pull/129

This PR should be deployed along with:
- https://github.com/cds-snc/notification-api/pull/1593