### PR TITLE
fix: create PR review env log group

### DIFF
--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -134,6 +134,9 @@ jobs:
                 API_HOST_NAME=https://api.staging.notification.cdssandbox.xyz,\
                 ADMIN_BASE_URL=$URL
               }" > /dev/null 2>&1
+
+            aws logs create-log-group --log-group-name /aws/lambda/$FUNCTION_NAME-$PR_NUMBER > /dev/null 2>&1
+            aws logs put-retention-policy --log-group-name /aws/lambda/$FUNCTION_NAME-$PR_NUMBER --retention-in-days 14 > /dev/null 2>&1
           fi
 
           aws lambda wait function-updated --function-name $FUNCTION_NAME-$PR_NUMBER


### PR DESCRIPTION
# Summary
Update the PR review environment deploy to also create the CloudWatch log group and set a retention period.

This is being done because:

- the log group is only created when the PR review env function is invoked which was leading to failures cleaning up old review envs trying to delete non-existent log groups; and
- it allows us to set a log retention period.