### PR TITLE
fix/parsing api sms error message

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1047,7 +1047,7 @@ def get_template_error_dict(exception):
     # TODO: Make API return some computer-friendly identifier as well as the end user error messages
     if "service is in trial mode" in exception.message:
         error = "not-allowed-to-send-to"
-    elif "Exceeded send limits" in exception.message:
+    elif "Exceeded send limits" in exception.message or "Exceeded sms send limits" in exception.message:
         error = "too-many-messages"
     elif "Content for template has a character count greater than the limit of" in exception.message:
         error = "message-too-long"


### PR DESCRIPTION
# Summary | Résumé

In https://github.com/cds-snc/notification-api/pull/1612 we changed api (when the FF is on) to returns an error message "Exceeded sms send limits" to admin if sending the sms would put a service over its limits, as required by #1343.  This causes an admin server error since admin currently doesn't know what to do with this error.

This PR makes admin treat the error as an "over daily limit" error for now. This will be remedied by #1343.

Note that this has no affect when the FF is off in api, ie production.

# Test instructions | Instructions pour tester la modification

Set your sms daily limit low and try to send sms messages. no more 500 errors!
