### PR TITLE
added the appropriate value for GC_ARTICLES_API to test config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -181,6 +181,7 @@ class Test(Development):
     TEMPLATE_PREVIEW_API_KEY = "dev-notify-secret-key"
     TESTING = True
     WTF_CSRF_ENABLED = False
+    GC_ARTICLES_API = "articles.alpha.canada.ca/notification-gc-notify"
 
 
 class Production(Config):


### PR DESCRIPTION
# Summary | Résumé

I have a staging url set in my .env file for `GC_ARTICLES_API`. This causes the tests to fail. Adding the correct value to the test config makes the tests pass regardless of what you have set in your local .env file.

## Test instructions

Check out branch and try setting a different value for `GC_ARTICLES_API` in your .env file. The tests should still pass.