### PR TITLE
Remove the email daily limit language and form from the settings page

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -32,7 +32,6 @@ from app.main import main
 from app.main.forms import (
     ChangeEmailFromServiceForm,
     ConfirmPasswordForm,
-    EmailMessageLimit,
     FieldWithLanguageOptions,
     FreeSMSAllowance,
     GoLiveAboutNotificationsForm,
@@ -1047,10 +1046,7 @@ def service_set_letter_contact_block(service_id):
 @user_is_platform_admin
 def set_message_limit(service_id):
 
-    if current_app.config["FF_SPIKE_SMS_DAILY_LIMIT"]:
-        form = EmailMessageLimit(message_limit=current_service.message_limit)
-    else:
-        form = MessageLimit(message_limit=current_service.message_limit)
+    form = MessageLimit(message_limit=current_service.message_limit)
 
     if form.validate_on_submit():
         service_api_client.update_message_limit(service_id, form.message_limit.data)
@@ -1061,7 +1057,7 @@ def set_message_limit(service_id):
     return render_template(
         "views/service-settings/set-message-limit.html",
         form=form,
-        heading=_("Daily email message limit") if current_app.config["FF_SPIKE_SMS_DAILY_LIMIT"] else _("Daily message limit"),
+        heading=_("Daily message limit"),
     )
 
 

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -99,7 +99,7 @@
 
         {% call row() %}
         
-          {% set txt = _('Daily email message limit') if config["FF_SPIKE_SMS_DAILY_LIMIT"]  else _('Daily message limit') %}
+          {% set txt = _('Daily message limit') %}
           {{ text_field(txt)}}
           {% set message_limit = _('{} notifications').format(current_service.message_limit | format_number) %}
           {{ text_field(message_limit) }}
@@ -354,7 +354,7 @@
           {% endcall %}
 
           {% call row() %}
-            {% set txt = _('Daily email message limit') if config["FF_SPIKE_SMS_DAILY_LIMIT"]  else _('Daily message limit') %}
+            {% set txt = _('Daily message limit') %}
             {{ text_field(txt)}}
             {{ text_field(current_service.message_limit | format_number) }}
             {{ edit_field(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -170,7 +170,7 @@ def test_should_show_overview(
                 "Service name Test Service Change",
                 "Sending email address name test.service@{sending_domain} Change",
                 "Sign-in method Text message code Change",
-                "Daily email message limit 1,000 notifications",
+                "Daily message limit 1,000 notifications",
                 "Daily text fragments limit 1,000 notifications",
                 "API rate limit per minute 100 calls",
                 "Label Value Action",
@@ -194,7 +194,7 @@ def test_should_show_overview(
                 "Service name Test Service Change",
                 "Sending email address name test.service@{sending_domain} Change",
                 "Sign-in method Text message code Change",
-                "Daily email message limit 1,000 notifications",
+                "Daily message limit 1,000 notifications",
                 "Daily text fragments limit 1,000 notifications",
                 "API rate limit per minute 100 calls",
                 "Label Value Action",
@@ -212,7 +212,7 @@ def test_should_show_overview(
                 "Live On Change",
                 "Count in list of live services Yes Change",
                 "Organisation Test Organisation Government of Canada Change",
-                "Daily email message limit 1,000 Change",
+                "Daily message limit 1,000 Change",
                 "Daily text fragments limit 1,000 Change",
                 "API rate limit per minute 100",
                 "Text message senders GOVUK Manage",
@@ -406,7 +406,7 @@ def test_should_show_overview_for_service_with_more_things_set(
                 "Service name service one Change",
                 "Sending email address name test.service@{sending_domain} Change",
                 "Sign-in method Text message code Change",
-                "Daily email message limit 1,000 notifications",
+                "Daily message limit 1,000 notifications",
                 "Daily text fragments limit 1,000 notifications",
                 "API rate limit per minute 100 calls",
                 "Label Value Action",
@@ -426,7 +426,7 @@ def test_should_show_overview_for_service_with_more_things_set(
                 "Service name service one Change",
                 "Sending email address name test.service@{sending_domain} Change",
                 "Sign-in method Email code or text message code Change",
-                "Daily email message limit 1,000 notifications",
+                "Daily message limit 1,000 notifications",
                 "Daily text fragments limit 1,000 notifications",
                 "API rate limit per minute 100 calls",
                 "Label Value Action",
@@ -3124,11 +3124,7 @@ def test_should_show_page_to_set_message_limit(
     response = platform_admin_client.get(url_for("main.set_message_limit", service_id=SERVICE_ONE_ID))
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-
-    if app_.config["FF_SPIKE_SMS_DAILY_LIMIT"]:
-        assert normalize_spaces(page.select_one("label").text) == "Daily email message limit"
-    else:
-        assert normalize_spaces(page.select_one("label").text) == "Daily message limit"
+    assert normalize_spaces(page.select_one("label").text) == "Daily message limit"
 
 
 @freeze_time("2017-04-01 11:09:00.061258")


### PR DESCRIPTION
# Summary | Résumé

This is really a combined email + SMS limit, so don't change the name of this setting for now.

# Test instructions | Instructions pour tester la modification

Navigate to your settings page and verify that the setting name is "notification daily limit" and not "email notification daily limit". Verify that the limit is working correctly.