### PR TITLE
Changed error message for sms limit reached

### DIFF
--- a/app/templates/components/links.html
+++ b/app/templates/components/links.html
@@ -1,4 +1,4 @@
-{% macro content_link_light(
+{% macro content_link(
     label="TODO: LABEL THIS LINK",
     href="/",
     class=None,
@@ -7,14 +7,10 @@
 ) %}
 <a
     {% if id_key %}id="{{ id_key }}"{% endif %}
-    class="my-0 p-2 line-under text-base border-b-2 border-transparent link:text-blue visited:text-blue focus:bg-yellow focus:border-blue focus:no-underline focus:outline-none hover:no-underline decoration-clone {% if class %} {{ class }} {% endif %}"
+    class="my-0 line-under text-base border-b-2 border-transparent link:text-blue visited:text-blue focus:bg-yellow focus:border-blue focus:no-underline focus:outline-none hover:no-underline decoration-clone {% if class %} {{ class }} {% endif %}"
     href="{{ href }}"
     {% if is_external_link %}target="_blank"{% endif %}
-    >
-    {{ label }}
-    {% if is_external_link %}<i aria-hidden="true" class="pl-2 fa-solid fa-arrow-up-right-from-square"></i>{% endif %}
-
-</a>
+    >{{ label }}{% if is_external_link %}<i aria-hidden="true" class="pl-2 fa-solid fa-arrow-up-right-from-square"></i>{% endif %}</a>
 {% endmacro %}
 
 {% macro nav_link_dark(

--- a/app/templates/partials/check/too-many-sms-message-parts.html
+++ b/app/templates/partials/check/too-many-sms-message-parts.html
@@ -1,3 +1,11 @@
+{% from "components/links.html" import content_link %}
+
+<h2 class='banner-title' data-module="track-error" data-error-type="SMS quota reached" data-error-label="{{ upload_id }}">
+  {{ _("You’ve sent too many text messages or too many long messages.") }}
+</h2>
 <p>
-  {{ _('If a message is long, it travels in fragments. Each fragment counts toward your daily limit.') }}
+  {{ _('Long text messages travel in fragments and count toward your daily limit.') }}
+</p>
+<p>
+  {{ _('You can send more text messages tomorrow. To raise your limit for future sends, {contact_us}.').format(contact_us=content_link(_("contact us"), url_for('main.contact'), is_external_link=true)) }}
 </p>

--- a/app/templates/partials/page-content/counter.html
+++ b/app/templates/partials/page-content/counter.html
@@ -1,4 +1,4 @@
-{% from "components/links.html" import content_link_light with context %}
+{% from "components/links.html" import content_link with context %}
 
 {% if stats %}
 <!-- COUNTER -->
@@ -9,7 +9,7 @@
       <div class="space-y-gutterHalf">
         <h2 class="heading-medium">{{ _("GC Notify by the numbers") }}</h2>
         <p>
-          {{ content_link_light(label=_("Learn more about activity on GC&nbsp;Notify"), href=url_for('.activity' ), class="-ml-2") }}
+          {{ content_link(label=_("Learn more about activity on GC&nbsp;Notify"), href=url_for('.activity' )) }}
         </p>
       </div>
       <!-- Box 2-->

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1661,4 +1661,6 @@
 "Too many text message fragments","Trop de bouts de message texte"
 "These messages exceed your daily limit","Ces messages dépassent votre limite quotidienne"
 "This message exceeds your daily limit","Ce message dépasse votre limite quotidienne"
-"If a message is long, it travels in fragments. Each fragment counts toward your daily limit.","Un long message est transmis en fragments. Chaque fragment compte dans votre limite quotidienne de fragments de message texte."
+"You’ve sent too many text messages or too many long messages.","Vous avez envoyé trop de messages texte ou trop de longs messages."
+"Long text messages travel in fragments and count toward your daily limit.","Un long message est transmis en fragments. Chaque fragment compte dans votre limite quotidienne de fragments de message texte."
+"You can send more text messages tomorrow. To raise your limit for future sends, {contact_us}.","Vous pourrez envoyer d’autres messages texte demain. Pour augmenter votre capacité d’envoi à l’avenir, {contact_us}."


### PR DESCRIPTION
# Summary | Résumé

This updates the error message when the sms limit is reached to be a bit more relevant in different situations. 

# Test instructions | Instructions pour tester la modification

1. On a trial service
2. Try to send more messages than you're allowed daily
3. Get this error message,

Maybe as a control
1. Try to send less messages
2. Don't get this error message.  
