### PR TITLE
Fix catching SMS over limit errors from API

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1058,7 +1058,7 @@ def get_template_error_dict(exception):
         error = "not-allowed-to-send-to"
     elif "Exceeded send limits" in exception.message:
         error = "too-many-messages"
-    elif "Exceeded sms send limits" in exception.message:
+    elif "Exceeded SMS daily sending limit" in exception.message:
         error = "too-many-sms-messages"
     elif "Content for template has a character count greater than the limit of" in exception.message:
         error = "message-too-long"


### PR DESCRIPTION
This PR updates the error message caught from API to show a user an error when they go over their limit.  This will now align with the changes [made here](https://github.com/cds-snc/notification-api/pull/1653).
