### PR TITLE
Fix Organisation type pages

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -549,7 +549,7 @@ class RenameOrganisationForm(StripWhitespaceForm):
 
 
 class OrganisationOrganisationTypeForm(StripWhitespaceForm):
-    organisation_type = OrganisationTypeField("What type of organisation is this?")
+    org_type = OrganisationTypeField("What type of organisation is this?")
 
 
 class OrganisationCrownStatusForm(StripWhitespaceForm):

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -205,7 +205,7 @@ def edit_organisation_name(org_id):
 @user_is_platform_admin
 def edit_organisation_type(org_id):
 
-    form = OrganisationOrganisationTypeForm(organisation_type=current_organisation.organisation_type)
+    form = OrganisationOrganisationTypeForm(org_type=current_organisation.organisation_type)
 
     if form.validate_on_submit():
         org_service_ids = [service["id"] for service in current_organisation.services]
@@ -213,7 +213,7 @@ def edit_organisation_type(org_id):
         organisations_client.update_organisation(
             current_organisation.id,
             cached_service_ids=org_service_ids,
-            organisation_type=form.organisation_type.data,
+            organisation_type=form.org_type.data,
         )
         return redirect(url_for(".organisation_settings", org_id=org_id))
 

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -63,7 +63,7 @@ class Organisation(JSONModel):
                 "non-crown": False,
                 "unknown": None,
             }.get(form.crown_status.data),
-            organisation_type=form.organisation_type.data,
+            organisation_type=form.org_type.data,
         )
 
     @classmethod

--- a/app/templates/views/organisations/add-organisation.html
+++ b/app/templates/views/organisations/add-organisation.html
@@ -25,8 +25,7 @@
           {{ page_header(_('New organisation')) }}
           {% call form_wrapper() %}
             {{textbox(form.name)}}
-            {{radios(form.organisation_type)}}
-            <input type="hidden" name="organisation_type" value="central" />
+            {{radios(form.org_type)}}
             {{radios(form.crown_status)}}
             {% set button_txt = _('Save') %}
             {{ page_footer(button_txt) }}

--- a/app/templates/views/organisations/organisation/settings/edit-type.html
+++ b/app/templates/views/organisations/organisation/settings/edit-type.html
@@ -15,7 +15,7 @@
     back_link=url_for('.organisation_settings', org_id=current_org.id)
   ) }}
   {% call form_wrapper() %}
-    {{ radios(form.organisation_type) }}
+    {{ radios(form.org_type) }}
     {{ page_footer(_('Save')) }}
   {% endcall %}
 {% endblock %}

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -65,15 +65,14 @@ def test_page_to_create_new_organisation(
 
     assert [(input["type"], input["name"], input["value"]) for input in page.select("input")] == [
         ("text", "name", ""),
-        ("radio", "organisation_type", "central"),
-        ("radio", "organisation_type", "local"),
-        ("radio", "organisation_type", "nhs_central"),
-        ("radio", "organisation_type", "nhs_local"),
-        ("radio", "organisation_type", "nhs_gp"),
-        ("radio", "organisation_type", "emergency_service"),
-        ("radio", "organisation_type", "school_or_college"),
-        ("radio", "organisation_type", "other"),
-        ("hidden", "organisation_type", "central"),
+        ("radio", "org_type", "central"),
+        ("radio", "org_type", "local"),
+        ("radio", "org_type", "nhs_central"),
+        ("radio", "org_type", "nhs_local"),
+        ("radio", "org_type", "nhs_gp"),
+        ("radio", "org_type", "emergency_service"),
+        ("radio", "org_type", "school_or_college"),
+        ("radio", "org_type", "other"),
         ("radio", "crown_status", "crown"),
         ("radio", "crown_status", "non-crown"),
         ("hidden", "csrf_token", ANY),
@@ -95,7 +94,7 @@ def test_create_new_organisation(
         ".add_organisation",
         _data={
             "name": "new name",
-            "organisation_type": "local",
+            "org_type": "local",
             "crown_status": "non-crown",
         },
         _expected_redirect=url_for(
@@ -127,7 +126,7 @@ def test_create_new_organisation_validates(
     )
     assert [(error["data-error-label"], normalize_spaces(error.text)) for error in page.select(".error-message")] == [
         ("name", "This cannot be empty"),
-        ("organisation_type", "You need to choose an option"),
+        ("org_type", "You need to choose an option"),
         ("crown_status", "You need to choose an option"),
     ]
     assert mock_create_organisation.called is False
@@ -329,17 +328,17 @@ def test_view_organisation_settings(
     (
         (
             ".edit_organisation_type",
-            {"organisation_type": "central"},
+            {"org_type": "central"},
             {"cached_service_ids": [], "organisation_type": "central"},
         ),
         (
             ".edit_organisation_type",
-            {"organisation_type": "local"},
+            {"org_type": "local"},
             {"cached_service_ids": [], "organisation_type": "local"},
         ),
         (
             ".edit_organisation_type",
-            {"organisation_type": "nhs_local"},
+            {"org_type": "nhs_local"},
             {"cached_service_ids": [], "organisation_type": "nhs_local"},
         ),
         (
@@ -429,7 +428,7 @@ def test_update_organisation_sector_sends_service_id_data_to_api_client(
     client_request.post(
         "main.edit_organisation_type",
         org_id=organisation_one["id"],
-        _data={"organisation_type": "central"},
+        _data={"org_type": "central"},
         _expected_status=302,
         _expected_redirect=url_for(
             "main.organisation_settings",


### PR DESCRIPTION
# Summary | Résumé

The form for editing the organisation type was not working
![image](https://user-images.githubusercontent.com/8228248/202000475-57a41171-8aea-4e95-b8ad-19323bad8011.png)

Renamed a form field variable and now the form works 😬 
![image](https://user-images.githubusercontent.com/8228248/202000400-acce9500-886c-46de-9106-1b13d115c402.png)

The "Add organisation" form also now contains the types:
![image](https://user-images.githubusercontent.com/8228248/202000812-23747ead-92a6-4d8d-abef-ef24b7fafeed.png)

Notes:
- These types are the UK ones and we have an [issue to change them](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/997).
- This form was never made bilingual, [we should fix this](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/998).

# Test instructions | Instructions pour tester la modification

Go change an org type!
