### PR TITLE
Fix "preview page server error" bug

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+
+# Summary | Résumé
+
+
+> 1-3 sentence description of the changed you're proposing, including a link to
+> a GitHub Issue # or Trello card if applicable.
+
+> **Note**: Are you adding a new page from GC Articles? Make sure you add the endpoint to the [WAF rules](https://github.com/cds-snc/notification-utils/tree/main/.github/actions/waffles#supporting-a-new-url-within-gcnotify).
+
+---
+
+> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
+> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.
+
+> **Note**: Ajoutez vous une nouvelle page par Articles GC? Assurez vous d'ajouter le chemin dans les [règles WAF](https://github.com/cds-snc/notification-utils/tree/main/.github/actions/waffles#supporting-a-new-url-within-gcnotify).
+
+# Test instructions | Instructions pour tester la modification
+
+> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
+> will help a developer test things out without too much detective work. Also,
+> include any environmental setup steps that aren't in the normal README steps
+> and/or any time-based elements that this requires.
+
+---
+
+> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
+> modification. Elles aideront les développeurs à faire des tests sans avoir à
+> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
+> de l’environnement qui ne font pas partie des étapes normales dans le fichier
+> README et tout élément temporel requis.

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -128,6 +128,9 @@ def view_template(service_id, template_id):
 @user_has_permissions()
 def preview_template(service_id, template_id=None):
     template = get_preview_data(service_id, template_id)
+    if not template:
+        # template == {} if the user has not yet clicked the preview link
+        template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
 
     if request.method == "POST":
         if request.form["button_pressed"] == "edit":

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1654,8 +1654,9 @@ def test_should_redirect_when_previewing_a_template_email(
     )
 
 
+@pytest.mark.parametrize("redis_initialized", (True, False))
 def test_preview_page_contains_preview(
-    client_request, app_, mock_get_service_email_template, mock_get_user_by_email, fake_uuid, mocker
+    redis_initialized, client_request, app_, mock_get_service_email_template, mock_get_user_by_email, fake_uuid, mocker
 ):
     preview_data = {
         "name": "test name",
@@ -1665,8 +1666,12 @@ def test_preview_page_contains_preview(
         "id": fake_uuid,
     }
     mocker.patch(
-        "app.main.views.templates.get_preview_data",
+        "app.models.service.Service.get_template_with_user_permission_or_403",
         return_value=preview_data,
+    )
+    mocker.patch(
+        "app.main.views.templates.get_preview_data",
+        return_value=preview_data if redis_initialized else {},
     )
 
     page = client_request.get(


### PR DESCRIPTION
# Summary | Résumé

I ran this with the debugger and discovered that the `template` object is an empty dict if we have not yet visited the preview page by clicking on the link. This is because the key/value that stores this info (see the `get_preview_data` fn) has not yet been set in Redis. If this is the case, we can use the `get_template_with_user_permission_or_403` method, which makes a request to the API.

# Test instructions | Instructions pour tester la modification

See the attached issue.