### PR TITLE
Make bulk the default priority for newly created templates (#748)

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -44,6 +44,7 @@ from app.main.forms import (
     TemplateFolderForm,
 )
 from app.main.views.send import get_example_csv_rows, get_sender_details
+from app.models.enum.template_process_types import TemplateProcessTypes
 from app.models.service import Service
 from app.models.template_list import TemplateList, TemplateLists
 from app.template_previews import TemplatePreview, get_page_count_for_letter
@@ -707,11 +708,11 @@ def add_service_template(service_id, template_type, template_folder_id=None):
 
     template = get_preview_data(service_id)
     if template.get("process_type") is None:
-        template["process_type"] = "normal"
+        template["process_type"] = TemplateProcessTypes.BULK.value
     form = form_objects[template_type](**template)
 
     if form.validate_on_submit():
-        if form.process_type.data != "normal":
+        if form.process_type.data != TemplateProcessTypes.BULK.value:
             abort_403_if_not_admin_user()
         subject = form.subject.data if hasattr(form, "subject") else None
         if request.form.get("button_pressed") == "preview":
@@ -801,11 +802,12 @@ def edit_service_template(service_id, template_id):
         template["subject"] = new_template_data["subject"]
     template["template_content"] = template["content"]
     if template.get("process_type") is None:
-        template["process_type"] = "normal"
+        template["process_type"] = TemplateProcessTypes.BULK.value
     form = form_objects[template["template_type"]](**template)
 
     if form.validate_on_submit():
-        if form.process_type.data != template["process_type"]:
+        # Do not abort if non-admin user saves an existing template
+        if form.process_type.data != TemplateProcessTypes.BULK.value and request.form.get("button_pressed") != "save":
             abort_403_if_not_admin_user()
 
         subject = form.subject.data if hasattr(form, "subject") else None

--- a/app/models/enum/template_process_types.py
+++ b/app/models/enum/template_process_types.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class TemplateProcessTypes(Enum):
+    NORMAL = "normal"
+    PRIORITY = "priority"
+    BULK = "bulk"

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -4,6 +4,7 @@ import pytest
 from flask import abort, url_for
 from notifications_python_client.errors import HTTPError
 
+from app.models.enum.template_process_types import TemplateProcessTypes
 from app.models.service import Service
 from app.models.user import User
 from tests import sample_uuid
@@ -376,7 +377,7 @@ def test_can_create_email_template_with_parent_folder(client_request, mock_creat
         "template_content": "here's a burrito 🌯",
         "template_type": "email",
         "service": SERVICE_ONE_ID,
-        "process_type": "normal",
+        "process_type": TemplateProcessTypes.BULK.value,
         "parent_folder_id": PARENT_FOLDER_ID,
     }
     client_request.post(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -13,6 +13,7 @@ from app.main.views.templates import (
     get_preview_data,
     set_preview_data,
 )
+from app.models.enum.template_process_types import TemplateProcessTypes
 from app.models.service import Service
 from tests import (
     MockRedis,
@@ -46,6 +47,8 @@ from tests.conftest import (
     mock_get_service_template_with_process_type,
     normalize_spaces,
 )
+
+DEFAULT_PROCESS_TYPE = TemplateProcessTypes.BULK.value
 
 
 class TestRedisPreviewUtilities:
@@ -1271,7 +1274,7 @@ def test_should_redirect_when_saving_a_template(
             "template_content": content,
             "template_type": "sms",
             "service": SERVICE_ONE_ID,
-            "process_type": "normal",
+            "process_type": DEFAULT_PROCESS_TYPE,
         },
         _follow_redirects=True,
     )
@@ -1286,11 +1289,11 @@ def test_should_redirect_when_saving_a_template(
         content,
         SERVICE_ONE_ID,
         None,
-        "normal",
+        TemplateProcessTypes.BULK.value,
     )
 
 
-@pytest.mark.parametrize("process_type", ["bulk", "priority"])
+@pytest.mark.parametrize("process_type", [TemplateProcessTypes.NORMAL.value, TemplateProcessTypes.PRIORITY.value])
 def test_should_edit_content_when_process_type_is_set_not_platform_admin(
     client_request,
     mocker,
@@ -1355,7 +1358,7 @@ def test_should_not_allow_template_edits_without_correct_permission(
     )
 
 
-@pytest.mark.parametrize("process_type", ["bulk", "priority"])
+@pytest.mark.parametrize("process_type", [TemplateProcessTypes.NORMAL.value, TemplateProcessTypes.PRIORITY.value])
 def test_should_403_when_edit_template_with_non_default_process_type_for_non_platform_admin(
     client,
     active_user_with_permissions,
@@ -1389,7 +1392,7 @@ def test_should_403_when_edit_template_with_non_default_process_type_for_non_pla
     mock_update_service_template.called == 0
 
 
-@pytest.mark.parametrize("process_type", ["bulk", "priority"])
+@pytest.mark.parametrize("process_type", [TemplateProcessTypes.NORMAL.value, TemplateProcessTypes.PRIORITY.value])
 def test_should_403_when_create_template_with_non_default_process_type_for_non_platform_admin(
     client,
     active_user_with_permissions,
@@ -1466,7 +1469,7 @@ def test_should_show_interstitial_when_making_breaking_change(
         "template_type": template_type,
         "subject": "reminder '\" <span> & ((name))",
         "service": SERVICE_ONE_ID,
-        "process_type": "normal",
+        "process_type": DEFAULT_PROCESS_TYPE,
     }
 
     if template_type == "letter":
@@ -1547,7 +1550,7 @@ def test_should_not_create_too_big_template(
             "template_content": "template content",
             "template_type": "sms",
             "service": SERVICE_ONE_ID,
-            "process_type": "normal",
+            "process_type": DEFAULT_PROCESS_TYPE,
         },
         _expected_status=200,
     )
@@ -1570,7 +1573,7 @@ def test_should_not_update_too_big_template(
             "template_content": "template content",
             "service": SERVICE_ONE_ID,
             "template_type": "sms",
-            "process_type": "normal",
+            "process_type": DEFAULT_PROCESS_TYPE,
         },
         _expected_status=200,
     )
@@ -1598,7 +1601,7 @@ def test_should_redirect_when_saving_a_template_email(
             "template_type": "email",
             "service": SERVICE_ONE_ID,
             "subject": subject,
-            "process_type": "normal",
+            "process_type": DEFAULT_PROCESS_TYPE,
             "button_pressed": "save",
         },
         _expected_status=302,
@@ -1616,7 +1619,7 @@ def test_should_redirect_when_saving_a_template_email(
         content,
         SERVICE_ONE_ID,
         subject,
-        "normal",
+        DEFAULT_PROCESS_TYPE,
     )
 
 
@@ -1641,7 +1644,7 @@ def test_should_redirect_when_previewing_a_template_email(
             "template_type": "email",
             "service": SERVICE_ONE_ID,
             "subject": subject,
-            "process_type": "normal",
+            "process_type": DEFAULT_PROCESS_TYPE,
             "button_pressed": "preview",
         },
         _expected_status=302,
@@ -2172,7 +2175,7 @@ def test_can_create_email_template_with_emoji(
             "template_content": "here's a burrito 🌯",
             "template_type": "email",
             "service": SERVICE_ONE_ID,
-            "process_type": "normal",
+            "process_type": DEFAULT_PROCESS_TYPE,
             "button_pressed": "save",
         },
         _follow_redirects=True,
@@ -2241,7 +2244,7 @@ def test_should_create_sms_template_without_downgrading_unicode_characters(clien
             "template_content": msg,
             "template_type": "sms",
             "service": SERVICE_ONE_ID,
-            "process_type": "normal",
+            "process_type": DEFAULT_PROCESS_TYPE,
         },
         expected_status=302,
     )


### PR DESCRIPTION
# Summary | Résumé
When creating a service template as a non-admin user, the template's priority now defaults to "bulk" rather than "normal". This change contributes to a reduction in traffic on in our normal queues with the goal of reducing the time-to-send for notifications serviced by the normal priority queues.

Introduced an enum to more strongly type values that relate to reference tables in the DB. Feel free to critique!

# Test instructions | Instructions pour tester la modification
1. Run the Notify Admin app
2. Login with a non-admin account
3. Create a service if you do not already have one
4. Create two service templates, an email and a SMS
5. In another browser, login with an admin account
6. Navigate to the admin panel and open the service you created or used for this test
7. View and edit the templates created in step 4
8. Verify that `Bulk - Not time-sensitive` is selected in the `Choose a priority queue` field 