### PR TITLE
Pin waffles and node alpine to specific versions

### DIFF
--- a/.github/workflows/test_endpoints.yaml
+++ b/.github/workflows/test_endpoints.yaml
@@ -53,7 +53,7 @@ jobs:
         echo "PYTHONPATH=/github/workspace/env/site-packages:${{ env.PYTHONPATH}}" >> $GITHUB_ENV
 
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@main
+      uses: cds-snc/notification-utils/.github/actions/waffles@49.1.0
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.9-alpine3.16
 
 ENV PYTHONDONTWRITEBYTECODE 1
 

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -2,7 +2,7 @@ ARG APP_DIR="/app"
 ARG APP_VENV="/opt/venv"
 
 # Build image
-FROM python:3.9-alpine as base
+FROM python:3.9-alpine3.16 as base
 
 ARG APP_DIR
 ARG APP_VENV
@@ -47,7 +47,7 @@ RUN make babel && \
     make generate-version-file
 
 # Final image
-FROM python:3.9-alpine as lambda
+FROM python:3.9-alpine3.16 as lambda
 
 ARG APP_DIR
 ARG APP_VENV

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.9-alpine3.16
 
 ENV PYTHONDONTWRITEBYTECODE 1
 


### PR DESCRIPTION
# Summary | Résumé

Not having waffles and node alpine pinned to specific versions was causing failure in our CI pipeline over in this PR: https://github.com/cds-snc/notification-admin/pull/1406

I thought it would be best to open a separate PR to address this.

# Test instructions | Instructions pour tester la modification

CI should pass. Test suite should pass in CI. This should be a safe change since this returns us to versions of `notification-utils` and node alpine we have been using until recently.