### PR TITLE
Display Qualtrics survey widget in production

### DIFF
--- a/app/templates/partials/qualtrics-head.html
+++ b/app/templates/partials/qualtrics-head.html
@@ -1,6 +1,4 @@
-{% set is_not_prod_domain = '.canada.ca' not in admin_base_url %}
-
-{% if current_user.is_authenticated and is_not_prod_domain %}
+{% if current_user.is_authenticated %}
     <!--BEGIN QUALTRICS WEBSITE FEEDBACK SNIPPET-->
     <script type='text/javascript' nonce='{{ request_nonce }}'>
         // Qualtrics expects upper case for the language, default to 'EN'.

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -200,7 +200,7 @@ def test_task_shortcuts_are_visible_based_on_permissions(
     [
         ("http://localhost:6012", True),
         ("https://staging.notification.cdssandbox.xyz", True),
-        ("https://notification.canada.ca", False),
+        ("https://notification.canada.ca", True),
     ],
 )
 def test_survey_widget_presence(


### PR DESCRIPTION
# Summary | Résumé (do not merge yet!)

Removed production constraint from Qualtrics display conditions, i.e. ready for prime time! 🎉 ...well, when we have Jeana's approval.

# Test instructions | Instructions pour tester la modification

* [x] Test it is present in the review app environment.
* [ ] Test it is present in the staging environment.
* [ ] Test it is present in the production environment.