### PR TITLE
Restore go-live setting service limit to 10k. 

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -371,6 +371,7 @@ def service_switch_live(service_id):
 
         if live:
             message_limit = current_app.config["DEFAULT_LIVE_SERVICE_LIMIT"]
+            sms_daily_limit = current_app.config["DEFAULT_LIVE_SMS_DAILY_LIMIT"]
 
         flash(_("An email has been sent to service users"), "default_with_tick")
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -368,18 +368,11 @@ def service_switch_live(service_id):
         live = form.enabled.data
         message_limit = current_app.config["DEFAULT_SERVICE_LIMIT"]
         sms_daily_limit = current_app.config["DEFAULT_SMS_DAILY_LIMIT"]
+
         if live:
-            if current_service.message_limit != current_app.config["DEFAULT_SERVICE_LIMIT"]:
-                message_limit = current_service.message_limit
-            else:
-                message_limit = current_app.config["DEFAULT_LIVE_SERVICE_LIMIT"]
+            message_limit = current_app.config["DEFAULT_LIVE_SERVICE_LIMIT"]
 
-            if current_service.sms_daily_limit != current_app.config["DEFAULT_SMS_DAILY_LIMIT"]:
-                sms_daily_limit = current_service.sms_daily_limit
-            else:
-                sms_daily_limit = current_app.config["DEFAULT_LIVE_SMS_DAILY_LIMIT"]
-
-            flash(_("An email has been sent to service users"), "default_with_tick")
+        flash(_("An email has been sent to service users"), "default_with_tick")
 
         current_service.update_status(live=live, message_limit=message_limit, sms_daily_limit=sms_daily_limit)
         return redirect(url_for(".service_settings", service_id=service_id))

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -622,10 +622,10 @@ def test_show_restricted_service(
 @pytest.mark.parametrize(
     "current_limit, expected_limit, current_sms_limit, expected_sms_limit",
     [
-        (42, 10_000, 33, 50),
+        (42, 10_000, 33, 1000),
         # Maps to DEFAULT_SERVICE_LIMIT and DEFAULT_LIVE_SERVICE_LIMIT in config
-        (50, 10_000, 50, 50),
-        (50_000, 10_000, 3000, 50),
+        (50, 10_000, 50, 1000),
+        (50_000, 10_000, 3000, 1000),
     ],
 )
 def test_switch_service_to_live(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -622,10 +622,10 @@ def test_show_restricted_service(
 @pytest.mark.parametrize(
     "current_limit, expected_limit, current_sms_limit, expected_sms_limit",
     [
-        (42, 42, 33, 33),
+        (42, 10_000, 33, 50),
         # Maps to DEFAULT_SERVICE_LIMIT and DEFAULT_LIVE_SERVICE_LIMIT in config
-        (50, 10_000, 50, 1000),
-        (50_000, 50_000, 3000, 3000),
+        (50, 10_000, 50, 50),
+        (50_000, 10_000, 3000, 50),
     ],
 )
 def test_switch_service_to_live(


### PR DESCRIPTION
# Summary | Résumé
Reverting work done in [this PR](https://github.com/cds-snc/notification-admin/pull/935) to ensure that when a service goes live, their message limit is properly set to 10k. When the service is no longer live, but restricted, the limit is restored to the default of 50.

# Test instructions | Instructions pour tester la modification
Create a service and change the daily message limit. Go live with the service. Note that the daily message limit is set to 10k.
Turn off live, and note that the message limit is set to 50.
