### PR TITLE
fix: no PR review env for Renovate PRs

### DIFF
--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -3,7 +3,12 @@ name: Deploy test admin environment
 on:
   pull_request:
     branches:
-      - main
+      - main  
+    types:
+      - labeled
+      - opened
+      - reopened
+      - synchronize
 
 env:
   AWS_DEFAULT_REGION: ca-central-1
@@ -14,6 +19,7 @@ env:
 
 jobs:
   build-and-push-container:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'Renovate') }}
     runs-on: ubuntu-latest
     steps:
       - name: Set envs
@@ -81,6 +87,7 @@ jobs:
         run: docker logout $REGISTRY
 
   deploy-test-admin:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'Renovate') }}
     runs-on: ubuntu-latest
     needs: build-and-push-container
     steps:

--- a/.github/workflows/test-admin-remove.yaml
+++ b/.github/workflows/test-admin-remove.yaml
@@ -4,7 +4,8 @@ on:
   pull_request:
     branches:
       - main  
-    types: [closed]
+    types:
+      - closed
 
 env:
   AWS_DEFAULT_REGION: ca-central-1
@@ -15,6 +16,7 @@ env:
 
 jobs:
   remove-test-admin:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'Renovate') }}
     runs-on: ubuntu-latest
     steps:
       - name: Set envs


### PR DESCRIPTION
# Summary
Update the PR review environment workflows to no longer create a review environment automatically for a Renovate PR.

This change is being made so that there is account reserved concurrency left available for developer PRs.