### PR TITLE
Feat/update why notify route fr

### DIFF
--- a/app/articles/routing.py
+++ b/app/articles/routing.py
@@ -19,7 +19,7 @@ GC_ARTICLES_ROUTES = {
     "service-level-objectives": {"en": "/service-level-objectives", "fr": "/objectifs-niveau-de-service"},
     "spreadsheets": {"en": "/spreadsheets", "fr": "/feuille-de-calcul"},
     "terms": {"en": "/terms", "fr": "/conditions-dutilisation"},
-    "whynotify": {"en": "/why-gc-notify", "fr": "/pourquoi-gc-notification"},
+    "whynotify": {"en": "/why-gc-notify", "fr": "/pourquoi-notification-gc"},
 }
 
 

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -319,6 +319,7 @@ def old_page_redirects():
 @main.route("/personalise", endpoint="personalisation_guide")
 @main.route("/format", endpoint="formatting_guide")
 @main.route("/messages-status", endpoint="message_delivery_status")
+@main.route("/pourquoi-gc-notification", endpoint="whynotify")
 def gca_redirects():
     return redirect(gca_url_for(request.endpoint.replace("main.", "")), code=301)
 

--- a/tests/app/articles/test_pages.py
+++ b/tests/app/articles/test_pages.py
@@ -102,8 +102,9 @@ def test_bad_slug_doesnt_save_empty_cache_entry(app_, mocker):
             assert not mock_redis_method.set.called
 
 
-@pytest.mark.skip(reason="TODO: a11y test")
-@pytest.mark.parametrize("url", ["/a11y", "/why-notify", "/personalise", "/format", "/messages-status"])
+@pytest.mark.parametrize(
+    "url", ["/a11y", "/why-notify", "/personalise", "/format", "/messages-status", "/pourquoi-gc-notification"]
+)
 def test_gca_redirects_work(client_request, mocker, url):
     """
     This test ensures that the pages we renamed properly provide a permanent redirect


### PR DESCRIPTION
# Summary | Résumé

- Update the French `/pourquoi-gc-notification` to `/pourquoi-notification-gc` as per our new naming convention.
