### PR TITLE
fix: build PR review Docker image with `docker build`

### DIFF
--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -40,43 +40,20 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # v1.5.3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
-
       - name: Move dockerignore
         run: |
           mv ci/Dockerfile.lambda.dockerignore .
 
-      - name: Build base image
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
-        with:
-          context: .
-          file: ci/Dockerfile.lambda
-          platforms: linux/amd64
-          target: base          
-          push: false
-          cache-from: |
-            type=gha,scope=base
-          cache-to: |
-            type=gha,scope=base
-
-      - name: Build and push lambda image
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
-        with:
-          context: .
-          file: ci/Dockerfile.lambda
-          platforms: linux/amd64
-          target: lambda
-          push: true
-          cache-from: |
-            type=gha,scope=base
-            type=gha,scope=lambda
-          cache-to: |
-            type=gha,scope=lambda
-          build-args: |
-            GIT_SHA=${{ github.sha }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.PR_NUMBER }}
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg GIT_SHA=${{ github.sha }} \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.PR_NUMBER }} \
+            -f ci/Dockerfile.lambda .
+          
+      - name: Push Docker image to ECR
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.PR_NUMBER }}
 
       - name: Delete old images
         run: |

--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -53,6 +53,7 @@ jobs:
           context: .
           file: ci/Dockerfile.lambda
           target: base
+          platforms: linux/amd64
           push: false
           cache-from: |
             type=gha,scope=base

--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -52,8 +52,8 @@ jobs:
         with:
           context: .
           file: ci/Dockerfile.lambda
-          target: base
           platforms: linux/amd64
+          target: base          
           push: false
           cache-from: |
             type=gha,scope=base
@@ -65,6 +65,7 @@ jobs:
         with:
           context: .
           file: ci/Dockerfile.lambda
+          platforms: linux/amd64
           target: lambda
           push: true
           cache-from: |

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -36,7 +36,7 @@ COPY requirements.txt ${APP_DIR}
 RUN python -m pip install wheel && \
     pip3 install -r requirements.txt
 
-COPY package.json package-lock.json .snyk ${APP_DIR}
+COPY package.json package-lock.json .snyk ${APP_DIR}/
 RUN npm ci
 
 COPY . ${APP_DIR}


### PR DESCRIPTION
## Summary
The Docker images being built by the GitHub Docker build and push action are no longer working with AWS Lambda.  We get the following error when attempting to create a function with them:

```
The image manifest or layer media type for the source image $IMAGE_TAG is not supported.
```

Using a raw `docker build` command works as expected and is consistent with how all the other Notify Docker images are built.