### PR TITLE
Limit the api key name to 255 characters to prevent a 500 error

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -887,7 +887,7 @@ class CreateKeyForm(StripWhitespaceForm):
 
     key_name = StringField(
         "Description of key",
-        validators=[DataRequired(message=_l("You need to give the key a name"))],
+        validators=[DataRequired(message=_l("You need to give the key a name")), Length(max=255)],
     )
 
     def validate_key_name(self, key_name):


### PR DESCRIPTION
# Summary | Résumé

This change will prevent users from entering in api key names longer than the allowed length into the form field.

# Test instructions | Instructions pour tester la modification

See attached issue card.
