### PR TITLE
fix: add Poetry support to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,9 @@
   "extends": [
     "local>cds-snc/renovate-config"
   ],
-  "ignorePaths": [
-    "requirements.txt"
-  ]
+  "poetry": {
+    "fileMatch": [
+      "(^|/)pyproject\\.toml$"
+    ]
+  }
 }


### PR DESCRIPTION
# Summary 
Add a [Poetry fileMatch pattern](https://docs.renovatebot.com/modules/manager/poetry/) to enable Renovate Poetry dependency PRs. Also removes the ignore for the `requirements.txt` file which is no longer used.