### PR TITLE
chore: remove the Renovate Poetry config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>cds-snc/renovate-config"
-  ],
-  "poetry": {
-    "fileMatch": [
-      "(^|/)pyproject\\.toml$"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
# Summary
This config is not required as the default Renovate Python config already manages Poetry manifests by default.

The reason for the lack of dependency updates is because of a related bug with the Poetry dependency resolution causing the Renovate Docker container to fail with a `SIGTERM`.

# Related
- renovatebot/renovate#10769