### PR TITLE
fix: disable package grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>cds-snc/renovate-config"
+    "local>cds-snc/renovate-config:no-grouping"
   ]
 }


### PR DESCRIPTION
# Summary
Poetry dependency resolution speed and resource use is very high when multiple resources are updated.

This change updates to a shared config that disables grouping for all dependencies except Docker and GitHub workflows.

# Related
- cds-snc/platform-core-services#287
- cds-snc/renovate-config#37