### PR TITLE
test: Renovate ignore Werkzeug dependency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>cds-snc/renovate-config:no-grouping"
-  ]
+  ],
+  "ignoreDeps": ["Werkzeug"]
 }


### PR DESCRIPTION
# Summary
Update the Renote config to no longer manage the Python Werkzeug dependency.  This is being done because Poetry currently has a bug that causes dependency conflicts to result in an infinite dependency resolution bug.

# Related
- cds-snc/notification-planning#658
- cds-snc/platform-core-services#287