### PR TITLE
Improved styling for archived organisations in the platform admin panel

### DIFF
--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -21,13 +21,13 @@
               {% for org in organisations %}
                 <li class="browse-list-item">
                   <a href="{{ url_for('main.organisation_dashboard', org_id=org.id) }}" class="browse-list-link">{{ org.name }}</a>
+                  {% if not org.active %}
+                    <span class="table-field-status-default">- {{_('archived') }}</span>
+                  {% endif %}
                   <p class="browse-list-hint">
                     {{ org.count_of_live_services }}
                     {{ _('live service(s)') }}
                   </p>
-                  {% if not org.active %}
-                    <span class="table-field-status-default heading-medium">- {{_('archived') }}</span>
-                  {% endif %}
                 </li>
               {% endfor %}
             </ul>


### PR DESCRIPTION
# Summary | Résumé

The word "archived" currently shows up multiple lines below the name of the service that is archived. This was a quick fix.

Before:
<img width="1086" alt="Screen Shot 2023-03-21 at 4 55 16 PM" src="https://user-images.githubusercontent.com/5498428/226738729-69387d05-9835-4f48-8e28-9c2159b68596.png">

After:
<img width="1077" alt="Screen Shot 2023-03-21 at 4 55 04 PM" src="https://user-images.githubusercontent.com/5498428/226738705-c1452dca-6fcf-43ec-bb77-6c6612304166.png">

