### PR TITLE
Mark git repo as safe within the devcontainer

### DIFF
--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -29,6 +29,9 @@ mkdir ~/.zfunc
 touch ~/.zfunc/_poetry
 poetry completions zsh > ~/.zfunc/_poetry
 
+# Tell git the workspace repository is safe, else upcoming commands will fail.
+git config --global --add safe.directory /workspaces/notification-admin
+
 # Warm up git index prior to display status in prompt else it will
 # be quite slow on every invocation of starship.
 git status

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Explicitly mark following files with lf end lines. These files
+# are meant to be executed on Linux, so we want to enforce.
+
+.devcontainer/scripts/notify-dev-entrypoints.sh eol=lf
+
+bin/entry.sh eol=lf
+bin/sync_lambda_envs.sh eol=lf
+
+scripts/bootstrap.sh eol=lf
+scripts/generate_en_translations.py eol=lf
+scripts/run_app.sh eol=lf
+scripts/run_tests.sh eol=lf


### PR DESCRIPTION
# Summary | Résumé

Fixes the post command during devcontainer initialization. Prior to this change, the poetry install commands could not follow up without marking the workspace github repository as safe.
