### PR TITLE
Added poetry to make run to run the admin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ coverage: venv ## Create coverage report
 
 .PHONY: run-dev
 run-dev:
-	flask run -p 6012 --host=localhost
+	poetry run flask run -p 6012 --host=localhost
 
 .PHONY: format
 format:


### PR DESCRIPTION
# Summary | Résumé

The `make run-dev` command should be fixed. It was missing the `poetry` context execution to run properly (and bring proper dependencies in the Python runtime).

# Test instructions | Instructions pour tester la modification

Locally run

```sh
make run-dev
```