### PR TITLE
Hide the Organisation question from "go live" flow

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1742,7 +1742,45 @@ class GoLiveAboutServiceForm(StripWhitespaceForm):
     )
 
 
+class GoLiveAboutServiceFormNoOrg(StripWhitespaceForm):
+    purpose = TextAreaField(
+        _l("For what purpose are you using GC Notify?"),
+        validators=[DataRequired(), Length(max=2000)],
+    )
+    intended_recipients = MultiCheckboxField(
+        _l("Who are the intended recipients of notifications?"),
+        default="",
+        choices=[
+            ("internal", _l("Colleagues within your department (internal)")),
+            ("external", _l("Partners from other organisations (external)")),
+            ("public", _l("Public")),
+        ],
+        validators=[DataRequired()],
+    )
+
+
 class GoLiveAboutNotificationsForm(GoLiveAboutServiceForm):
+    notification_types = MultiCheckboxField(
+        _l("Specify the type of notifications you plan on sending."),
+        choices=[
+            ("email", _l("Email")),
+            ("sms", _l("Text message")),
+        ],
+        validators=[DataRequired()],
+    )
+    expected_volume = RadioField(
+        _l("How many notifications do you plan on sending per month?"),
+        choices=[
+            ("1-1k", _l("1 to 1,000 notifications")),
+            ("1k-10k", _l("1,000 to 10,000 notifications")),
+            ("10k-100k", _l("10,000 to 100,000 notifications")),
+            ("100k+", _l("More than 100,000 notifications")),
+        ],
+        validators=[DataRequired()],
+    )
+
+
+class GoLiveAboutNotificationsFormNoOrg(GoLiveAboutServiceFormNoOrg):
     notification_types = MultiCheckboxField(
         _l("Specify the type of notifications you plan on sending."),
         choices=[

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -35,7 +35,9 @@ from app.main.forms import (
     FieldWithLanguageOptions,
     FreeSMSAllowance,
     GoLiveAboutNotificationsForm,
+    GoLiveAboutNotificationsFormNoOrg,
     GoLiveAboutServiceForm,
+    GoLiveAboutServiceFormNoOrg,
     InternationalSMSForm,
     LinkOrganisationsForm,
     MessageLimit,
@@ -247,10 +249,10 @@ def terms_of_use(service_id):
 @user_is_gov_user
 def use_case(service_id):
     DEFAULT_STEP = "about-service"
-
+    display_org_question = not current_service.organisation_notes or not current_app.config["FF_SALESFORCE_CONTACT"]
     steps = [
         {
-            "form": GoLiveAboutServiceForm,
+            "form": GoLiveAboutServiceForm if display_org_question else GoLiveAboutServiceFormNoOrg,
             "current_step": DEFAULT_STEP,
             "previous_step": None,
             "next_step": "about-notifications",
@@ -259,7 +261,7 @@ def use_case(service_id):
             "back_link": url_for("main.request_to_go_live", service_id=current_service.id),
         },
         {
-            "form": GoLiveAboutNotificationsForm,
+            "form": GoLiveAboutNotificationsForm if display_org_question else GoLiveAboutNotificationsFormNoOrg,
             "current_step": "about-notifications",
             "previous_step": DEFAULT_STEP,
             "next_step": None,
@@ -310,6 +312,7 @@ def use_case(service_id):
         step_hint=form_details["step"],
         total_steps_hint=len(steps),
         back_link=form_details["back_link"],
+        display_org_question=display_org_question,
     )
 
 

--- a/app/templates/views/service-settings/use-case.html
+++ b/app/templates/views/service-settings/use-case.html
@@ -26,8 +26,9 @@
         <p>
           {{ _("This information helps us understand how GC Notify is being used so we can better meet your needs.") }}
         </p>
-
-        {{ textbox(form.department_org_name, width='md:w-2/3', autocomplete='organization') }}
+        {% if display_org_question %}
+          {{ textbox(form.department_org_name, width='md:w-2/3', autocomplete='organization') }}
+        {% endif %}
         {{ textbox(form.purpose, width='md:w-2/3', hint='', rows=10) }}
         {{ checkboxes(form.intended_recipients) }}
 


### PR DESCRIPTION
# Summary | Résumé

This PR hides the "what is your organisation" question from the Go Live flow if `FF_SALESFORCE_CONTACT=True` and we have already recorded the user's answer in the `organisation_notes` column in the db.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
