### PR TITLE
Bump node version to satisfy minimum version requirement from jest

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,11 @@
+<<<<<<< Updated upstream
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.10@sha256:c0abacd20605a4df2f54d76fda026d875853d8216c9640131c143013242786a2
 
 ENV POETRY_VERSION="1.3.2"
 
+=======
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.10
+>>>>>>> Stashed changes
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \
     && apt-get -y install \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,6 +32,12 @@
 		"bungcip.better-toml",
 	],
 
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "14.17.3"
+		}
+	},
+
 	"forwardPorts": [6012],
 	"postCreateCommand": "notify-dev-entrypoint.sh",
 	"remoteUser": "vscode"


### PR DESCRIPTION
# Summary | Résumé
[Bump node from 12.22.12 to v14.17.3](https://github.com/devcontainers/images/tree/main/src/python#installing-nodejs) as [v12 is no longer supported] due to being an EOL version(https://github.com/facebook/jest/pull/13033/files). This should unblock #1421 

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
