### PR TITLE
switch ECR auth to OIDC

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -30,14 +30,15 @@ jobs:
         sudo mv ./kubectl /usr/local/bin/kubectl
         kubectl version --client
         mkdir -p $HOME/.kube
-    - name: AWS auth with ECR
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
-      run: |
-        aws ecr-public get-login-password --region us-east-1 > /tmp/aws
-        cat /tmp/aws | docker login --username AWS --password-stdin $DOCKER_ORG
-        rm /tmp/aws
+    - name: Configure credentials to CDS public ECR using OIDC
+      uses: aws-actions/configure-aws-credentials@master
+      with:
+        role-to-assume: arn:aws:iam::283582579564:role/sre-bot-apply
+        role-session-name: SREBotGitHubActions
+        aws-region: "ca-central-1"
+    - name: Login to ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # v1.5.3
     - name: Build
       run: |
         docker pull $DOCKER_SLUG:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Configure credentials to CDS public ECR using OIDC
       uses: aws-actions/configure-aws-credentials@master
       with:
-        role-to-assume: arn:aws:iam::283582579564:role/sre-bot-apply
+        role-to-assume: arn:aws:iam::283582579564:role/notification-admin-apply
         role-session-name: SREBotGitHubActions
         aws-region: "ca-central-1"
     - name: Login to ECR


### PR DESCRIPTION
# Summary | Résumé

Switch auth to CDS' public ECR from IAM user to OIDC.
One less key to rotate next time 🎉 

# Test instructions | Instructions pour tester la modification

Basically, after this merges to main we should make sure that the new admin image gets uploaded to https://gallery.ecr.aws/cds-snc/notify-admin