### PR TITLE
Fix/daily fragment limit validation

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -35,7 +35,7 @@ from wtforms.fields.core import EmailField, SearchField, TelField
 from wtforms.validators import URL, AnyOf, DataRequired, Length, Optional, Regexp
 from wtforms.widgets import CheckboxInput, ListWidget
 
-from app import format_thousands
+from app import current_service, format_thousands
 from app.main.validators import (
     Blocklist,
     CsvFileValidator,
@@ -192,9 +192,7 @@ class ForgivingIntegerField(StringField):
         super().__init__(label, **kwargs)
 
     def process_formdata(self, valuelist):
-
         if valuelist:
-
             value = valuelist[0].replace(",", "").replace(" ", "")
 
             try:
@@ -208,7 +206,6 @@ class ForgivingIntegerField(StringField):
         return super().process_formdata([value])
 
     def pre_validate(self, form):
-
         if self.data:
             error = None
             try:
@@ -229,7 +226,6 @@ class ForgivingIntegerField(StringField):
         return super().pre_validate(form)
 
     def __call__(self, **kwargs):
-
         if self.get_form().is_submitted() and not self.get_form().validate():
             return super().__call__(value=(self.raw_data or [None])[0], **kwargs)
 
@@ -708,6 +704,13 @@ class NewOrganisationForm(
 
 
 class MessageLimit(StripWhitespaceForm):
+    def validate_message_limit(form, field):
+        if field.data < current_service.message_limit:
+            raise ValidationError(
+                _l("The daily message limit cannot be less than the number of daily text fragments")
+                + f" ({current_service.sms_daily_limit})"
+            )
+
     message_limit = IntegerField(
         _l("Daily message limit"),
         validators=[
@@ -728,12 +731,16 @@ class EmailMessageLimit(StripWhitespaceForm):
 
 
 class SMSMessageLimit(StripWhitespaceForm):
+    def validate_message_limit(form, field):
+        if field.data > current_service.message_limit:
+            raise ValidationError(
+                _l("The number of daily text fragments cannot exceed the daily message limit")
+                + f" ({current_service.message_limit})"
+            )
+
     message_limit = IntegerField(
         _l("Daily text fragments limit"),
-        validators=[
-            DataRequired(message=_l("This cannot be empty")),
-            validators.NumberRange(min=1),
-        ],
+        validators=[DataRequired(message=_l("This cannot be empty")), validators.NumberRange(min=1)],
     )
 
 
@@ -1049,7 +1056,6 @@ class ServiceContactDetailsForm(StripWhitespaceForm):
     phone_number = StringField(_l("Phone number"))
 
     def validate(self):
-
         if self.contact_details_type.data == "url":
             self.url.validators = [DataRequired(), URL(message="Must be a valid URL")]
 
@@ -1146,7 +1152,6 @@ class OnOffField(RadioField):
 
 class ServiceOnOffSettingForm(StripWhitespaceForm):
     def __init__(self, name, *args, truthy="On", falsey="Off", **kwargs):
-
         super().__init__(*args, **kwargs)
 
         if truthy == "On":
@@ -1619,7 +1624,6 @@ class TemplateAndFoldersSelectionForm(Form):
         *args,
         **kwargs,
     ):
-
         super().__init__(*args, **kwargs)
 
         self.templates_and_folders.choices = template_list.as_id_and_name
@@ -1683,7 +1687,6 @@ class GoLiveNotesForm(StripWhitespaceForm):
 class AcceptAgreementForm(StripWhitespaceForm):
     @classmethod
     def from_organisation(cls, org):
-
         if org.agreement_signed_on_behalf_of_name and org.agreement_signed_on_behalf_of_email_address:
             who = "someone-else"
         elif org.agreement_signed_version:  # only set if user has submitted form previously

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1098,7 +1098,7 @@ def set_message_limit(service_id):
 @user_is_platform_admin
 def set_sms_message_limit(service_id):
 
-    form = SMSMessageLimit(message_limit=current_service.sms_daily_limit, other_data="HI")
+    form = SMSMessageLimit(message_limit=current_service.sms_daily_limit)
 
     if form.validate_on_submit():
         service_api_client.update_sms_message_limit(service_id, form.message_limit.data)

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -13,17 +13,17 @@
     <h1 class="heading-large">{{ _('Settings') }}</h1>
 
     {% if current_service.trial_mode %}
-      <div class="bg-gray px-8 pt-1">
+      <div class="bg-gray p-10">
         {% if current_service.has_submitted_go_live %}
-          <h2 class="heading-small mt-5">{{ _('Your request to go live is being reviewed') }}</h2>
-          <p>
+          <h2 class="heading-small p-0 m-0">{{ _('Your request to go live is being reviewed') }}</h2>
+          <p class="mt-8">
             {{ _("We’ll be in touch within 2 business days.") }}
           </p>
         {% else %}
-          <h2 class="heading-small">{{ _('Your service is in trial mode') }}</h2>
+          <h2 class="heading-small p-0 m-0">{{ _('Your service is in trial mode') }}</h2>
           {% if current_user.has_permissions('manage_service') %}
             <div class="flex mt-5">
-              <p class="flex-1 self-center">
+              <p class="flex-1 self-center mr-10">
                 {{ _('To send notifications to more people, request to go live.') }}
               </p>
               <p class="flex-0 self-center">

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -23,10 +23,10 @@
           <h2 class="heading-small p-0 m-0">{{ _('Your service is in trial mode') }}</h2>
           {% if current_user.has_permissions('manage_service') %}
             <div class="flex mt-5">
-              <p class="flex-1 self-center mr-10">
+              <p class="flex-1 self-center mr-10 mb-0">
                 {{ _('To send notifications to more people, request to go live.') }}
               </p>
-              <p class="flex-0 self-center">
+              <p class="flex-0 self-center mb-0">
                 <a href="{{ url_for('main.request_to_go_live', service_id=current_service.id) }}" class="button" role="button">{{ _('Request to go live') }}</a>
               </p>
             </div>

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -16,7 +16,7 @@
       <div class="bg-gray p-10">
         {% if current_service.has_submitted_go_live %}
           <h2 class="heading-small p-0 m-0">{{ _('Your request to go live is being reviewed') }}</h2>
-          <p class="mt-8">
+          <p class="mt-8 mb-0">
             {{ _("We’ll be in touch within 2 business days.") }}
           </p>
         {% else %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3187,7 +3187,8 @@ def test_should_show_page_to_set_message_limit(
 @pytest.mark.parametrize(
     "given_limit, expected_limit",
     [
-        ("1", 1),
+        pytest.param("1", 1, marks=pytest.mark.xfail),  # this is less than the sms daily limit so will fail
+        ("1000", 1_000),
         ("10_000", 10_000),
         pytest.param("foo", "foo", marks=pytest.mark.xfail),
     ],
@@ -3198,7 +3199,6 @@ def test_should_set_message_limit(
     expected_limit,
     mock_update_message_limit,
 ):
-
     response = platform_admin_client.post(
         url_for(
             "main.set_message_limit",
@@ -3212,6 +3212,37 @@ def test_should_set_message_limit(
     assert response.location == url_for("main.service_settings", service_id=SERVICE_ONE_ID)
 
     mock_update_message_limit.assert_called_with(SERVICE_ONE_ID, expected_limit)
+
+
+@freeze_time("2017-04-01 11:09:00.061258")
+@pytest.mark.parametrize(
+    "given_limit, expected_limit",
+    [
+        ("1", 1),
+        ("1000", 1_000),
+        pytest.param("10_000", 10_000, marks=pytest.mark.xfail),  # this is more than the daily message limit so will fail
+        pytest.param("foo", "foo", marks=pytest.mark.xfail),
+    ],
+)
+def test_should_set_sms_message_limit(
+    platform_admin_client,
+    given_limit,
+    expected_limit,
+    mock_update_sms_message_limit,
+):
+    response = platform_admin_client.post(
+        url_for(
+            "main.set_sms_message_limit",
+            service_id=SERVICE_ONE_ID,
+        ),
+        data={
+            "message_limit": given_limit,
+        },
+    )
+    assert response.status_code == 302
+    assert response.location == url_for("main.service_settings", service_id=SERVICE_ONE_ID)
+
+    mock_update_sms_message_limit.assert_called_with(SERVICE_ONE_ID, expected_limit)
 
 
 def test_should_show_page_to_set_sms_allowance(platform_admin_client, mock_get_free_sms_fragment_limit):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3445,6 +3445,12 @@ def mock_update_message_limit(mocker):
 
 
 @pytest.fixture(scope="function")
+def mock_update_sms_message_limit(mocker):
+    sample_limit = 10000
+    return mocker.patch("app.service_api_client.update_sms_message_limit", return_value=sample_limit)
+
+
+@pytest.fixture(scope="function")
 def mock_create_or_update_free_sms_fragment_limit(mocker):
     sample_limit = 250000
     return mocker.patch(


### PR DESCRIPTION
# Summary | Résumé
This PR adds 2 validations to prevent 2 invalid states from occurring:
1. SMS daily limit being higher than the total daily limit
2. The total daily limit being lower than the SMS daily limit

## QA
- [ ] Ensure setting an SMS daily limit higher than the total daily limit displays a validation error and stops you
- [ ] Ensure setting a total daily limit lower than the SMS daily limit displays a validation error and stops you