### PR TITLE
Fix the UI vs API report

### DIFF
--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -303,13 +303,8 @@ def performance_platform_xlsx():
 def trial_report_csv():
     data = platform_stats_api_client.usage_for_trial_services()
 
-    output = io.StringIO()
-    writer = csv.DictWriter(output, data[0].keys())
-    writer.writeheader()
-    writer.writerows(data)
-
     return (
-        output.getvalue(),
+        Spreadsheet(json_data=data).as_csv_data,
         200,
         {
             "Content-Type": "text/csv; charset=utf-8",
@@ -376,18 +371,10 @@ def send_method_stats_by_service():
         start_date = form.start_date.data
         end_date = form.end_date.data
 
-        headers = [
-            "service_id",
-            "service_name",
-            "org_name",
-            "notification_type",
-            "send_method",
-            "count",
-        ]
-        result = platform_stats_api_client.get_send_method_stats_by_service(start_date, end_date)
+        data = platform_stats_api_client.get_send_method_stats_by_service(start_date, end_date)
 
         return (
-            Spreadsheet.from_rows([headers] + result).as_csv_data,
+            Spreadsheet(json_data=data).as_csv_data,
             200,
             {
                 "Content-Type": "text/csv; charset=utf-8",

--- a/app/main/views/platform_admin.py
+++ b/app/main/views/platform_admin.py
@@ -1,5 +1,3 @@
-import csv
-import io
 import itertools
 import re
 from collections import OrderedDict

--- a/app/notify_client/platform_stats_api_client.py
+++ b/app/notify_client/platform_stats_api_client.py
@@ -5,14 +5,14 @@ class PlatformStatsAPIClient(NotifyAdminAPIClient):
     def get_aggregate_platform_stats(self, params_dict=None):
         return self.get("/platform-stats", params=params_dict)
 
-    def get_send_method_stats_by_service(self, start_date, end_date):
+    def get_send_method_stats_by_service(self, start_date, end_date) -> list[dict[str, str]]:
         return self.get(
             "/platform-stats/send-method-stats-by-service",
             params={
                 "start_date": start_date,
                 "end_date": end_date,
             },
-        )
+        )  # type: ignore
 
     def usage_for_trial_services(self) -> list[dict[str, str]]:
         return self.get(url="/platform-stats/usage-for-trial-services")  # type: ignore

--- a/app/utils.py
+++ b/app/utils.py
@@ -324,15 +324,16 @@ class Spreadsheet:
 
     allowed_file_extensions = ["csv", "xlsx", "xls", "ods", "xlsm", "tsv"]
 
-    def __init__(self, csv_data=None, rows=None, filename=""):
+    def __init__(self, csv_data=None, rows=None, filename="", json_data=None):
 
         self.filename = filename
 
         if csv_data and rows:
             raise TypeError("Spreadsheet must be created from either rows or CSV data")
 
-        self._csv_data = csv_data or ""
-        self._rows = rows or []
+        self.json_data: list[dict[str, str]] = json_data or []
+        self._csv_data: str = csv_data or ""
+        self._rows: list = rows or []
 
     @property
     def as_dict(self):
@@ -340,8 +341,17 @@ class Spreadsheet:
 
     @property
     def as_csv_data(self):
-        if not self._csv_data:
-            with StringIO() as converted:
+        if self._csv_data:
+            return self._csv_data
+        with StringIO() as converted:
+            if self.json_data:
+                if len(self.json_data) == 0:
+                    return ""
+                writer = csv.DictWriter(converted, self.json_data[0].keys())
+                writer.writeheader()
+                writer.writerows(self.json_data) 
+                self._csv_data = converted.getvalue()
+            else:
                 output = csv.writer(converted)
                 for row in self._rows:
                     output.writerow(row)

--- a/app/utils.py
+++ b/app/utils.py
@@ -349,7 +349,7 @@ class Spreadsheet:
                     return ""
                 writer = csv.DictWriter(converted, self.json_data[0].keys())
                 writer.writeheader()
-                writer.writerows(self.json_data) 
+                writer.writerows(self.json_data)
                 self._csv_data = converted.getvalue()
             else:
                 output = csv.writer(converted)

--- a/tests/app/main/views/test_platform_admin.py
+++ b/tests/app/main/views/test_platform_admin.py
@@ -1381,14 +1381,14 @@ def test_send_method_stats_by_service(platform_admin_client, mocker):
     mock = mocker.patch(
         "app.platform_stats_api_client.get_send_method_stats_by_service",
         return_value=[
-            [
-                "Fake Service ID",
-                "My service",
-                "Org name",
-                "email",
-                "admin",
-                "5",
-            ]
+            {
+                "service_id": "Fake Service ID",
+                "service_name": "My service",
+                "organisation_name": "Org name",
+                "notification_type": "email",
+                "send_method": "admin",
+                "total_notifications": "5",
+            }
         ],
     )
 
@@ -1405,7 +1405,7 @@ def test_send_method_stats_by_service(platform_admin_client, mocker):
     assert response.headers["Content-Disposition"].startswith("attachment; filename=")
 
     assert response.get_data(as_text=True) == (
-        "service_id,service_name,org_name,notification_type,send_method,count\r\n"
+        "service_id,service_name,organisation_name,notification_type,send_method,total_notifications\r\n"
         + "Fake Service ID,My service,Org name,email,admin,5\r\n"
     )
     mock.assert_called_once_with(datetime.date(2020, 11, 1), datetime.date(2020, 12, 1))


### PR DESCRIPTION
# Summary | Résumé

Fix the "Sending method: services sending via API vs. User Interface" report in platform admin. Similar fix to https://github.com/cds-snc/notification-admin/pull/1520 but I created some new functionality in the `Spreadsheet` to support JSON data.

## Test

Log in to the review app and try downloading the report.