### PR TITLE
fix: revert Poetry specific fixes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>cds-snc/renovate-config:no-grouping"
-  ],
-  "ignoreDeps": ["Werkzeug"]
+    "local>cds-snc/renovate-config"
+  ]
 }


### PR DESCRIPTION
# Summary
Now that Poetry has resolved the infinite loop bug when conflicting dependencies are specified we can revert the fixes in our Renovate config.

# ⚠️  Note
This should not be merged until:
1. An updated Poetry version is released with the fix; and
2. Renovate has been updated to use that version of Poetry (this can be confirmed via the [Renovate logs](https://app.renovatebot.com/dashboard#github/cds-snc/notification-admin)).

# Related
- python-poetry/poetry#7405
- #1481 
- #1482