### PR TITLE
switch to org secret for pr bot

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -78,8 +78,8 @@ jobs:
       id: notify-pr-bot
       uses: getsentry/action-github-app-token@38a3ce582e170ddfe8789f509597c6944f2292a9 # v1.0.6
       with:
-        app_id: ${{ secrets.PRBOT_APP_ID }}
-        private_key: ${{ secrets.PRBOT_PRIVATE_KEY }}
+        app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
+        private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
 
     - uses: cds-snc/notification-pr-bot@main
       env:


### PR DESCRIPTION
# Summary | Résumé

pr-bot creds have been moved to an org secret (and renamed), see https://github.com/cds-snc/notification-admin/settings/secrets/actions

