### PR TITLE
Fix/incorrect problem email total

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -312,7 +312,7 @@ def calculate_bounce_rate(all_statistics_daily, dashboard_totals_daily):
     # get total hard bounces
     for stat in all_statistics_daily:
         if stat["status"] == "permanent-failure":
-            bounce_rate.bounce_total = stat["count"]
+            bounce_rate.bounce_total += stat["count"]
 
     # calc bounce rate
     bounce_rate.bounce_percentage = 100 * (bounce_rate.bounce_total / total_sent) if total_sent > 0 else 0

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1667,10 +1667,18 @@ class TestBounceRate:
                         "template_type": "email",
                     },
                     {
-                        "count": 2,
+                        "count": 1,
                         "is_precompiled_letter": False,
                         "status": "permanent-failure",
                         "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
+                        "template_name": "test",
+                        "template_type": "email",
+                    },
+                    {
+                        "count": 1,
+                        "is_precompiled_letter": False,
+                        "status": "permanent-failure",
+                        "template_id": "2156a57e-efd7-4531-b8f4-e333c64c03dc",
                         "template_name": "test",
                         "template_type": "email",
                     },
@@ -1738,7 +1746,7 @@ class TestBounceRate:
             ),
         ],
     )
-    def test_bounce_rate_widget_displays_correct_status(
+    def test_bounce_rate_widget_displays_correct_status_and_totals(
         self,
         client_request,
         mocker,


### PR DESCRIPTION
# Summary | Résumé

This PR fixes a bug when a service has problem emails across multiple templates.  Before, only the total number of problem emails from the last send was being shown, instead of the sum of all sends.

