### PR TITLE
Add a redirect to the welcome page if a user has no services

### DIFF
--- a/app/main/views/choose_account.py
+++ b/app/main/views/choose_account.py
@@ -54,4 +54,7 @@ def show_accounts_or_dashboard():
     if len(current_user.organisation_ids) == 1 and not current_user.trial_mode_services:
         return redirect(url_for(".organisation_dashboard", org_id=current_user.organisation_ids[0]))
 
+    if len(current_user.service_ids) == 0 and not current_user.organisation_ids and not current_user.platform_admin:
+        return redirect(url_for("main.welcome"))
+
     return redirect(url_for(".choose_account"))

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -5,12 +5,7 @@ import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
 
-from tests.conftest import (
-    SERVICE_ONE_ID,
-    SERVICE_TWO_ID,
-    create_api_user_active,
-    normalize_spaces,
-)
+from tests.conftest import SERVICE_ONE_ID, SERVICE_TWO_ID, normalize_spaces
 
 OS1, OS2, OS3, S1, S2, S3 = repeat(uuid.uuid4(), 6)
 

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -5,7 +5,12 @@ import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
 
-from tests.conftest import SERVICE_ONE_ID, SERVICE_TWO_ID, normalize_spaces
+from tests.conftest import (
+    SERVICE_ONE_ID,
+    SERVICE_TWO_ID,
+    create_api_user_active,
+    normalize_spaces,
+)
 
 OS1, OS2, OS3, S1, S2, S3 = repeat(uuid.uuid4(), 6)
 
@@ -198,3 +203,18 @@ def test_choose_account_should_not_show_back_to_service_link_if_not_signed_in(
 
     assert page.select_one("h1").text == "Sign in"  # We’re not signed in
     assert page.select_one(".navigation-service a") is None
+
+
+def test_show_accounts_or_dashboard_should_redirect_to_welcome_if_no_services(
+    client_request,
+    api_user_active,
+):
+    # api_user_active has no services attached
+    client_request.login(api_user_active)
+    client_request.get(
+        "main.show_accounts_or_dashboard",
+        service_id=None,
+        user_id=api_user_active["id"],
+        _expected_status=302,
+        _expected_redirect=url_for("main.welcome"),
+    )

--- a/tests/app/main/views/accounts/test_choose_accounts.py
+++ b/tests/app/main/views/accounts/test_choose_accounts.py
@@ -198,18 +198,3 @@ def test_choose_account_should_not_show_back_to_service_link_if_not_signed_in(
 
     assert page.select_one("h1").text == "Sign in"  # We’re not signed in
     assert page.select_one(".navigation-service a") is None
-
-
-def test_show_accounts_or_dashboard_should_redirect_to_welcome_if_no_services(
-    client_request,
-    api_user_active,
-):
-    # api_user_active has no services attached
-    client_request.login(api_user_active)
-    client_request.get(
-        "main.show_accounts_or_dashboard",
-        service_id=None,
-        user_id=api_user_active["id"],
-        _expected_status=302,
-        _expected_redirect=url_for("main.welcome"),
-    )

--- a/tests/app/main/views/accounts/test_show_accounts_or_dashboard.py
+++ b/tests/app/main/views/accounts/test_show_accounts_or_dashboard.py
@@ -16,7 +16,7 @@ def user_with_orgs_and_services(num_orgs, num_services, platform_admin=False):
 @pytest.mark.parametrize(
     "num_orgs,num_services,endpoint,endpoint_kwargs",
     [
-        (0, 0, ".choose_account", {}),
+        (0, 0, ".welcome", {}),
         (0, 2, ".choose_account", {}),
         # assumption is that live service is part of user’s organisation
         # – real users shouldn’t have orphaned live services, or access to
@@ -27,7 +27,7 @@ def user_with_orgs_and_services(num_orgs, num_services, platform_admin=False):
         (1, 0, ".organisation_dashboard", {"org_id": "org1"}),
     ],
 )
-def test_show_accounts_or_dashboard_redirects_to_choose_account_or_service_dashboard(
+def test_show_accounts_or_dashboard_redirects_to_choose_account_or_service_dashboard_or_welcome(
     client,
     mocker,
     mock_get_organisations_and_services_for_user,


### PR DESCRIPTION
# Summary | Résumé

Add a redirect to the welcome page if a user has no services and they are not platform admin.

If a user does not complete the steps to set up their first service before logging out, GC Notify does not show the Welcome screen when they log back in.

## Testing

1. Create a new user account using the review app
2. Verify your email address and mobile number
3. Observe that you see the Welcome screen
4. Log out without creating a service
5. Log back in
6. Observe that you see the Welcome screen again
