### PR TITLE
Clear the data-retention cache when we assign a service to an organisation

### DIFF
--- a/app/notify_client/organisations_api_client.py
+++ b/app/notify_client/organisations_api_client.py
@@ -59,6 +59,7 @@ class OrganisationsClient(NotifyAdminAPIClient):
     @cache.delete("service-{service_id}")
     @cache.delete("live-service-and-organisation-counts")
     @cache.delete("organisations")
+    @cache.delete("service-{service_id}-data-retention")
     def update_service_organisation(self, service_id, org_id):
         data = {"service_id": service_id}
         return self.post(url="/organisations/{}/service".format(org_id), data=data)

--- a/tests/app/notify_client/test_organisation_client.py
+++ b/tests/app/notify_client/test_organisation_client.py
@@ -191,6 +191,7 @@ def test_update_service_organisation(mocker, fake_uuid):
 
     mock_post.assert_called_with(url="/organisations/{}/service".format(org_id), data={"service_id": service_id})
     assert mock_redis_delete.call_args_list == [
+        call("service-{}-data-retention".format(service_id)),
         call("organisations"),
         call("live-service-and-organisation-counts"),
         call("service-{}".format(service_id)),


### PR DESCRIPTION
# Summary | Résumé

Clear the data-retention cache when we assign a service to an organisation. This is so, when a service is assigned to a P/T organisation, the platform admin user will immediately see the new data retention of 3 days.

# Test instructions | Instructions pour tester la modification

No changes should be visible currently - this is just groundwork for another PR to notification-api.