### PR TITLE
switch to utils 51.0.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1443,7 +1443,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "50.3.4"
+version = "51.0.0"
 description = "Shared python code for Notification - Provides logging utils etc."
 category = "main"
 optional = false
@@ -1477,8 +1477,8 @@ werkzeug = "2.2.3"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "50.3.4"
-resolved_reference = "fbd73b322c7e868b6491bc07032af20550a12692"
+reference = "51.0.0"
+resolved_reference = "b5e6b6a72abe27047fbf5d4a0187bda9c0933348"
 
 [[package]]
 name = "openpyxl"
@@ -2505,4 +2505,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.8"
-content-hash = "a4f465644eebc25597ef20e28977c0ec2226517705f7cf70be226d107c8100d5"
+content-hash = "1229fd5d4d5570cc2dc30cf3dc0a0febcac34cfb05273aff0253b40882cae78a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ awscli-cwlogs = "^1.4.6"
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous = "2.1.2"  # pyup: <1.0.0
 
-notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "50.3.4"}
+notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "51.0.0"}
 
 rsa = "^4.1" # not directly required, pinned by Snyk to avoid a vulnerability
 unidecode = "^1.3.6"


### PR DESCRIPTION
# Summary | Résumé

update utils dependancy to include:
- [ Change token code to not have a salt argument](https://github.com/cds-snc/notification-utils/pull/207)

# Test instructions | Instructions pour tester la modification

Can test together with
https://github.com/cds-snc/notification-api/pull/1890
(but can also just test this PR on its own)

Test (just have to click on link and make sure you don't get an error):
- [ ] inviting someone to your team
- [ ] forget your password
- [ ] change your email
- [ ] create a new account