### PR TITLE
Fix/bad org invitation token

### DIFF
--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -1,4 +1,4 @@
-from flask import abort, flash, redirect, render_template, session, url_for
+from flask import abort, current_app, flash, redirect, render_template, session, url_for
 from flask_babel import _
 from flask_login import current_user
 from markupsafe import Markup
@@ -75,7 +75,13 @@ def accept_invite(token):
 
 @main.route("/organisation-invitation/<token>")
 def accept_org_invite(token):
-    invited_org_user = InvitedOrgUser.from_token(token)
+    try:
+        invited_org_user = InvitedOrgUser.from_token(token)
+    except InviteTokenError:
+        current_app.logger.warning(f"Bad org invite token: {token}")
+        flash(message="Bad token")
+        abort(403)
+
     if not current_user.is_anonymous and current_user.email_address.lower() != invited_org_user.email_address.lower():
         message = Markup(
             _(

--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -79,7 +79,7 @@ def accept_org_invite(token):
         invited_org_user = InvitedOrgUser.from_token(token)
     except InviteTokenError:
         current_app.logger.warning(f"Bad org invite token: {token}")
-        flash(message="Bad token")
+        flash(message=_("bad invitation link"))
         abort(403)
 
     if not current_user.is_anonymous and current_user.email_address.lower() != invited_org_user.email_address.lower():


### PR DESCRIPTION
# Summary | Résumé

We are getting a 500 error when visiting the following URL: `https://staging.notification.cdssandbox.xyz/organisation-invitation/<token>`. To fix, we can just handle the bad token error and show our standard message for this.

# Test instructions | Instructions pour tester la modification

- visit `https://staging.notification.cdssandbox.xyz/organisation-invitation/%3Ctoken%3E`
- observe that you see a 500 error
- In the review environment, go to https://ro6hunpitjfymkorsrp7p6agva0zxsxh.lambda-url.ca-central-1.on.aws/organisation-invitation/%3Ctoken%3E
- observe that the 500 error is fixed and you see the following:
<img width="1101" alt="Screenshot 2023-06-07 at 3 51 52 PM" src="https://github.com/cds-snc/notification-admin/assets/5498428/7b480516-a3b7-456e-adb5-209e93ab5d09">
