### PR TITLE
Styling for the notifications page

### DIFF
--- a/app/templates/components/problem-email-checkbox.html
+++ b/app/templates/components/problem-email-checkbox.html
@@ -2,8 +2,6 @@
 
 {% macro problem_email_checkbox() %}
     {% if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] %}
-        <h2 class="heading-medium">{{ _('Filter') }}</h2>
         {{ checkbox({ "id": "pe_filter", "name": "pe_filter", "data": request.args.get('pe_filter'), "label": { "text": _("Only show problem addresses")}}) }}
-        <br /><br /><br />
     {% endif %}
 {% endmacro %}

--- a/app/templates/partials/jobs/notifications_header.html
+++ b/app/templates/partials/jobs/notifications_header.html
@@ -19,23 +19,19 @@
       {% endcall %}
     </div>
   {% else %}
+    <div class="mb-12 clear-both contain-floats">
+      {{ problem_email_checkbox() }}
+    </div>
     {% if notifications %}
-      <div class="dashboard-table mb-12 clear-both contain-floats">
-    {% endif %}
-
-    {% if percentage_complete < 100 %}
-        <p class="mb-12 clear-both contain-floats hint">
-        {{ _('Report is') }} {{ "{:.0f}%".format(percentage_complete * 0.99) }} {{ _('complete…') }}
-        </p>
-    {% elif notifications %}
-        <p class="mb-12 clear-both contain-floats">
-        <a href="{{ download_link }}" download class="heading-small">{{ _('Download this report') }}</a>
-        &emsp;
-        {{ _("Available until") }} <span id="time-left" class="local-datetime-short-year">{{ available_until_date }}</span>
-        </p>
-    {% endif %}
-
-    {% if notifications %}
+      <div class="dashboard-table mt-12 mb-12 clear-both contain-floats">
+        {% if percentage_complete < 100 %}
+          {{ _('Report is') }} {{ "{:.0f}%".format(percentage_complete * 0.99) }} {{ _('complete…') }}
+        {% else %}
+          <a href="{{ download_link }}" download class="text-smaller leading-tight font-bold">{{ _('Download this report') }}</a>
+          <div class="mt-2 text-small leading-tight font-normal">
+            {{ _("Available until") }} <span id="time-left" class="local-datetime-short-year">{{ available_until_date }}</span>
+          </div>
+        {% endif %}
       </div>
     {% endif %}
   {% endif %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -21,7 +21,6 @@
     {% endif %}
     {{ ajax_block(partials, updates_url, 'counts', finished=finished) }}
     {{ ajax_block(partials, updates_url, 'notifications_header', finished=finished) }}
-    {{ problem_email_checkbox() }}
     {{ ajax_block(partials, updates_url, 'notifications', finished=finished) }}
 
     {% if can_cancel_letter_job %}

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -60,9 +60,11 @@
   {% endif %}
 
   {% if current_user.has_permissions('view_activity') %}
-    <div class="mb-12 clear-both contain-floats">
-      <a href="{{ download_link }}" download="download">{{ _('Download this report') }}</a>
-      {{ _('Data available for') }} {{ partials.service_data_retention_days }} {{ _('days') }}
+    <div class="mb-12 mt-12 clear-both contain-floats">
+      <a href="{{ download_link }}" download="download" class="text-smaller leading-tight font-bold">
+        {{ _('Download this report') }}
+      </a>
+      <div class="mt-2 text-small leading-tight font-normal">{{ _('Data available for') }} {{ partials.service_data_retention_days }} {{ _('days') }}</div>
     </div>
   {% endif %}
   

--- a/app/templates/views/notifications.html
+++ b/app/templates/views/notifications.html
@@ -33,6 +33,7 @@
       url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status),
       'counts'
     ) }}
+    {{ problem_email_checkbox() }}
 
     {% call form_wrapper(
       action=url_for('.view_notifications', service_id=current_service.id, message_type=message_type),
@@ -60,14 +61,11 @@
 
   {% if current_user.has_permissions('view_activity') %}
     <div class="mb-12 clear-both contain-floats">
-      <a href="{{ download_link }}" download="download" class="heading-small">{{ _('Download this report') }}</a>
-      &emsp;
+      <a href="{{ download_link }}" download="download">{{ _('Download this report') }}</a>
       {{ _('Data available for') }} {{ partials.service_data_retention_days }} {{ _('days') }}
     </div>
   {% endif %}
   
-  {{ problem_email_checkbox() }}
-
   {{ ajax_block(
     partials,
     url_for('.get_notifications_as_json', service_id=current_service.id, message_type=message_type, status=status, page=page),

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -365,7 +365,7 @@ def test_should_show_job_in_progress(
         service_id=service_one["id"],
         job_id=fake_uuid,
     )
-    assert page.find("p", {"class": "hint"}).text.strip() == "Report is 50% complete…"
+    assert page.find("div", {"class": "dashboard-table"}).text.strip() == "Report is 50% complete…"
 
 
 @freeze_time("2016-01-01 11:09:00.061258")


### PR DESCRIPTION
# Summary | Résumé

This PR applies some styling fixes to the notifications page. It one step towards fixing the filtering notifications bug (card linked below). This styling change makes it more clear that the checkbox does not filter notifications on the current page, but brings you back to a filtered view on the total page (will implement the "total" highlighting in a follow up PR).

Figma: https://www.figma.com/file/w1rwZuxuh8D6SGskv0KPaK/Bounce-rate?type=design&node-id=1137-12882&t=Bv8MWvlelWrcwsup-0#465647989

## Notifications page
### Before
<img width="1206" alt="Screenshot 2023-06-09 at 2 25 38 PM" src="https://github.com/cds-snc/notification-admin/assets/5498428/4f6a8d23-ab08-4786-8aec-73f9a47fa324">

### After
<img width="1339" alt="Screenshot 2023-06-09 at 2 21 22 PM" src="https://github.com/cds-snc/notification-admin/assets/5498428/5c330537-6428-417a-9328-c3be88f58a8f">

## Jobs page

### Before
<img width="1160" alt="Screenshot 2023-06-09 at 2 25 54 PM" src="https://github.com/cds-snc/notification-admin/assets/5498428/4497d384-1dc0-4bf2-a545-40005d268dea">

### After
<img width="1314" alt="Screenshot 2023-06-09 at 2 20 52 PM" src="https://github.com/cds-snc/notification-admin/assets/5498428/ce267857-65a6-4580-bf0c-e704b134d0f0">


# Test instructions | Instructions pour tester la modification

Visit the following pages (log in as a platform admin user) and verify that the styling matches the designs in Figma:
- [jobs page example](https://4y7wdkercpff4acavzyrvv2lii0udsre.lambda-url.ca-central-1.on.aws/services/1dac916a-05b2-49ca-bf75-072231c3f505/jobs/f931b272-a9a8-48d5-978f-05185c8fde6e?status=delivered) 
- [notifications page example](https://4y7wdkercpff4acavzyrvv2lii0udsre.lambda-url.ca-central-1.on.aws/services/1dac916a-05b2-49ca-bf75-072231c3f505/jobs/f931b272-a9a8-48d5-978f-05185c8fde6e?just_sent=yes)