### PR TITLE
Fix/update incorrect bounce links

### DIFF
--- a/app/templates/views/dashboard/review-email-list.html
+++ b/app/templates/views/dashboard/review-email-list.html
@@ -47,7 +47,7 @@
             {% for job in jobs %}
                 {% if job["bounce_count"] > 0 %}
                     <li>
-                        <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=job.id, status='failed') }}">
+                        <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=job.id, status='failed', pe_filter='true') }}">
                             {{ job["bounce_count"] }}
                             {% if job["bounce_count"] > 1 %}
                                 {{_(' problem email addresses')}}

--- a/app/templates/views/dashboard/review-email-list.html
+++ b/app/templates/views/dashboard/review-email-list.html
@@ -16,7 +16,7 @@
     <div class="page-content">
         <h1 class="heading-large py-4">{{ _('Review email addresses') }}</h1>
         <p>{{ _("GC Notify's email provider could suspend our services if we send too many problem emails.") }}</p>
-        <p>{{ _("<a href='{}'>Keep accurate contact information</a>. Check email addresses are correct. If necessary confirm recipient’s email address using another contact method.").format(gca_url_for('delivery_failure')) }}</p>
+        <p>{{ _("<a href='{}'>Keep accurate contact information</a>. Check email addresses are correct. If necessary confirm recipient’s email address using another contact method.").format(gca_url_for('bounce_guidance')) }}</p>
         <p>{{ _('Remove addresses you cannot correct.') }}</p>
 
         <div class="{% if bounce_rate["bounce_status"] == "critical" %}review-email-status-critical{% elif bounce_rate["bounce_status"] == "warning"%}review-email-status-critical{% else%}review-email-status-normal{% endif %} px-5">

--- a/app/templates/views/dashboard/review-email-list.html
+++ b/app/templates/views/dashboard/review-email-list.html
@@ -47,7 +47,7 @@
             {% for job in jobs %}
                 {% if job["bounce_count"] > 0 %}
                     <li>
-                        <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=job.id, status='failed', pe_filter='true') }}">
+                        <a href="{{ url_for('.view_job', service_id=current_service.id, job_id=job.id, status='permanent-failure', pe_filter='true') }}">
                             {{ job["bounce_count"] }}
                             {% if job["bounce_count"] > 1 %}
                                 {{_(' problem email addresses')}}

--- a/tests/app/main/views/test_bounce_rate.py
+++ b/tests/app/main/views/test_bounce_rate.py
@@ -711,9 +711,7 @@ def test_review_problem_emails_shows_one_offs_when_problem_emails_exist(
         (jobs_1_failure),
     ],
 )
-def test_review_problem_emails_checks_problem_filter_checkbox(
-    mocker, service_one, app_, client_request, jobs
-):
+def test_review_problem_emails_checks_problem_filter_checkbox(mocker, service_one, app_, client_request, jobs):
     with set_config(app_, "FF_BOUNCE_RATE_V1", True):
         threshold = app_.config["BR_DISPLAY_VOLUME_MINIMUM"]
 
@@ -740,4 +738,4 @@ def test_review_problem_emails_checks_problem_filter_checkbox(
         )
 
         # ensure the number of CSVs displayed on this page correspond to what is found in the jobs data
-        assert "pe_filter=true" in page.select_one(".ajax-block-container .list.list-bullet").select_one("li a")['href']
+        assert "pe_filter=true" in page.select_one(".ajax-block-container .list.list-bullet").select_one("li a")["href"]

--- a/tests/app/main/views/test_bounce_rate.py
+++ b/tests/app/main/views/test_bounce_rate.py
@@ -702,3 +702,42 @@ def test_review_problem_emails_shows_one_offs_when_problem_emails_exist(
 
     # ensure the number of CSVs displayed on this page correspond to what is found in the jobs data
     assert len(page.select_one(".ajax-block-container .list.list-bullet").find_all("li")) == expected_problem_list_count
+
+
+@pytest.mark.parametrize(
+    "jobs",
+    [
+        (jobs_2_failures),
+        (jobs_1_failure),
+    ],
+)
+def test_review_problem_emails_checks_problem_filter_checkbox(
+    mocker, service_one, app_, client_request, jobs
+):
+    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
+        threshold = app_.config["BR_DISPLAY_VOLUME_MINIMUM"]
+
+        mock_data = [
+            {
+                "count": (threshold - 20) * 0.5,
+                "is_precompiled_letter": False,
+                "status": "delivered",
+                "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
+                "template_name": "test",
+                "template_type": "email",
+            }
+        ]
+
+        mocker.patch(
+            "app.main.views.dashboard.template_statistics_client.get_template_statistics_for_service", return_value=mock_data
+        )
+
+        mocker.patch("app.main.views.dashboard.get_jobs_and_calculate_hard_bounces", return_value=jobs)
+        mocker.patch("app.notification_api_client.get_notifications_for_service", return_value={"notifications": []})
+        page = client_request.get(
+            "main.problem_emails",
+            service_id=service_one["id"],
+        )
+
+        # ensure the number of CSVs displayed on this page correspond to what is found in the jobs data
+        assert "pe_filter=true" in page.select_one(".ajax-block-container .list.list-bullet").select_one("li a")['href']

--- a/tests/app/main/views/test_bounce_rate.py
+++ b/tests/app/main/views/test_bounce_rate.py
@@ -739,3 +739,4 @@ def test_review_problem_emails_checks_problem_filter_checkbox(mocker, service_on
 
         # ensure the number of CSVs displayed on this page correspond to what is found in the jobs data
         assert "pe_filter=true" in page.select_one(".ajax-block-container .list.list-bullet").select_one("li a")["href"]
+        assert "status=permanent-failure" in page.select_one(".ajax-block-container .list.list-bullet").select_one("li a")["href"]


### PR DESCRIPTION
# Summary | Résumé

This PR fixes two incorrect links on the `/problem-emails` page:
1. The link to "Keep accurate contact information": it should point to `/keep-accurate-contact-information`
2. The link to bulk csv's should include the `pe_filter` param to check the checkbox by default: `pe_filter=true`