### PR TITLE
Update the error message for too many characters in template

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -18,6 +18,7 @@ from flask_babel import lazy_gettext as _l
 from flask_login import current_user
 from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
+from notifications_utils import EMAIL_CHAR_COUNT_LIMIT, SMS_CHAR_COUNT_LIMIT
 from notifications_utils.formatters import nl2br
 from notifications_utils.recipients import first_column_headings
 
@@ -104,6 +105,11 @@ def delete_preview_data(service_id, template_id=None):
     redis_client.delete(key)
 
 
+def get_char_limit_error_msg(template_type):
+    CHAR_LIMIT = SMS_CHAR_COUNT_LIMIT if template_type == "sms" else EMAIL_CHAR_COUNT_LIMIT
+    return (_("Message must be less than {char_limit} characters")).format(char_limit=CHAR_LIMIT + 1)
+
+
 @main.route("/services/<service_id>/templates/<uuid:template_id>")
 @user_has_permissions()
 def view_template(service_id, template_id):
@@ -182,7 +188,8 @@ def preview_template(service_id, template_id=None):
             except HTTPError as e:
                 if e.status_code == 400:
                     if "content" in e.message and any(["character count greater than" in x for x in e.message["content"]]):
-                        flash(e.message["content"])
+                        error_message = get_char_limit_error_msg(template["template_type"])
+                        flash(error_message)
                     else:
                         raise e
                 else:
@@ -749,7 +756,8 @@ def add_service_template(service_id, template_type, template_folder_id=None):
                 and "content" in e.message
                 and any(["character count greater than" in x for x in e.message["content"]])
             ):
-                form.template_content.errors.extend(e.message["content"])
+                error_message = get_char_limit_error_msg(template_type)
+                form.template_content.errors.extend([error_message])
             else:
                 raise e
         else:
@@ -871,7 +879,8 @@ def edit_service_template(service_id, template_id):
                 except HTTPError as e:
                     if e.status_code == 400:
                         if "content" in e.message and any(["character count greater than" in x for x in e.message["content"]]):
-                            form.template_content.errors.extend(e.message["content"])
+                            error_message = get_char_limit_error_msg(template["template_type"])
+                            form.template_content.errors.extend([error_message])
                         else:
                             raise e
                     else:

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1728,3 +1728,4 @@
 " problem email addresses"," adresses e-mail problématiques"
 ".contact",".etat-du-systeme"
 "Sign in to GC Notify","Se connecter à Notification GC"
+"Message must be less than {char_limit} characters","Le message doit comporter moins de {char_limit} caractères."

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1547,7 +1547,7 @@ def test_should_not_create_too_big_template(
         },
         _expected_status=200,
     )
-    assert "Content has a character count greater than the limit of 459" in page.text
+    assert "Message must be less than 613 characters" in page.text
 
 
 def test_should_not_update_too_big_template(
@@ -1570,7 +1570,7 @@ def test_should_not_update_too_big_template(
         },
         _expected_status=200,
     )
-    assert "Content has a character count greater than the limit of 459" in page.text
+    assert "Message must be less than 613 characters" in page.text
 
 
 def test_should_redirect_when_saving_a_template_email(


### PR DESCRIPTION
# Summary | Résumé

This PR:
- updates the error message for too many characters in template
- adds a translation for this

# Test instructions | Instructions pour tester la modification

1. Log in to the review app and go to your service dashboard
2. Create a new SMS template
3. paste in content that is more than 612 characters long
4. observe that you see the following error message: 
<img width="757" alt="Screenshot 2023-06-22 at 1 34 46 PM" src="https://github.com/cds-snc/notification-admin/assets/5498428/e4f53917-220d-4d5d-82ea-ce57663f52dd">

Repeat these steps with the page set to French.

To check that this works for email:
1. Log into the review app
2. edit this template that is 210k characters: https://zgmdavrqfffyzto7dvp5dr72tm0yezjk.lambda-url.ca-central-1.on.aws/services/1dac916a-05b2-49ca-bf75-072231c3f505/templates/ba535469-53c9-44a7-b614-9c2762dcc1f5/edit
3. make a change and save
4. observe that you see the new error message
