### PR TITLE
A11y/fix duplicate ids template usage

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -150,7 +150,7 @@ def template_usage(service_id):
             "name": month_name,
             "templates_used": [
                 {
-                    "id": stat["template_id"],
+                    "id": month_name + "_" + stat["template_id"],
                     "name": stat["name"],
                     "type": stat["type"],
                     "requested_count": stat["count"],

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1,4 +1,5 @@
 import copy
+import re
 
 import pytest
 from flask import g, url_for
@@ -1627,3 +1628,16 @@ def test_dashboard_page_a11y(
 
     assert response.status_code == 200
     a11y_test(url, response.data.decode("utf-8"))
+
+
+def test_a11y_template_usage_should_not_contain_duplicate_ids(
+    client_request,
+    mock_get_monthly_template_usage_with_multiple_months,
+):
+    page = client_request.get("main.template_usage", service_id=SERVICE_ONE_ID, year=2023)
+
+    list = []
+    for element in page.findAll("tr", {"id": re.compile(r".*")}):
+        list.append(element["id"])
+
+    assert len(list) == len(set(list))  # check for duplicates

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2790,6 +2790,45 @@ def mock_get_monthly_template_usage(mocker, service_one, fake_uuid):
 
 
 @pytest.fixture(scope="function")
+def mock_get_monthly_template_usage_with_multiple_months(mocker, service_one, fake_uuid):
+    def _stats(service_id, year):
+        return [
+            {
+                "count": 1101,
+                "is_precompiled_letter": False,
+                "month": 5,
+                "name": "testtes",
+                "template_id": "34a2693e-664f-4081-870d-da42c8c1d320",
+                "type": "email",
+                "year": 2023,
+            },
+            {
+                "count": 1,
+                "is_precompiled_letter": False,
+                "month": 5,
+                "name": "tetet",
+                "template_id": "d98bf1a3-64e9-41ae-a907-d4a35e9cbdec",
+                "type": "email",
+                "year": 2023,
+            },
+            {
+                "count": 1,
+                "is_precompiled_letter": False,
+                "month": 6,
+                "name": "tetet",
+                "template_id": "d98bf1a3-64e9-41ae-a907-d4a35e9cbdec",
+                "type": "email",
+                "year": 2023,
+            },
+        ]
+
+    return mocker.patch(
+        "app.template_statistics_client.get_monthly_template_usage_for_service",
+        side_effect=_stats,
+    )
+
+
+@pytest.fixture(scope="function")
 def mock_get_monthly_notification_stats(mocker, service_one, fake_uuid):
     def _stats(service_id, year):
         return {


### PR DESCRIPTION
# Summary | Résumé

This PR updates the `template_usage` method to ensure that unique ids will be created even when the same template is used across multiple months.
