### PR TITLE
A11y/fix headings broken when no notifications

### DIFF
--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -17,7 +17,7 @@
         caption_visible=False,
         empty_message=_("No messages to show"),
         field_headings=[heading_1,heading_2,heading_3] if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] else [heading_1, heading_3],
-        field_headings_visible=True if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] and notifications else False
+        field_headings_visible=False if not notifications else True if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] and notifications else False
       ) %}
         {% call row_heading() %}
           <a class="file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id, from_job=job.id) }}">{{ item.to }}</a>

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -5,11 +5,12 @@
 
 <div class="ajax-block-container" id='pill-selected-item'>
   {% set empty_txt = _('No messages found &thinsp;(messages are kept for {} days)') %}
+  {% set heading_1 = _('Recipient') %}
+  {% set heading_2 = _('Review Address') %}
+  {% set heading_3 = right_aligned_field_heading(_('Status')) %}
+
   {% if notifications %}
     <div class='dashboard-table'>
-      {% set heading_1 = _('Recipient') %}
-      {% set heading_2 = _('Review Address') %}
-      {% set heading_3 = right_aligned_field_heading(_('Status')) %}
   {% endif %}
     
     {% call(item, row_number) list_table(
@@ -18,7 +19,7 @@
       caption_visible=False,
       empty_message=empty_txt.format(limit_days)|safe,
       field_headings=[heading_1,heading_2,heading_3] if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] else [heading_1, heading_3],
-      field_headings_visible=True if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] else False
+      field_headings_visible=False if not notifications else True if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] else False
     ) %}
       {% call row_heading() %}
         {% if item.status in ('pending-virus-check', 'virus-scan-failed') %}

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -850,6 +850,25 @@ def test_should_show_letter_job_with_first_class_if_no_notifications(
     assert normalize_spaces(page.select(".keyline-block")[1].text) == "5 January Estimated delivery date"
 
 
+def test_a11y_ensure_headings_are_hidden_when_no_data_on_view_job_page(
+    client_request,
+    fake_uuid,
+    service_one,
+    mock_get_job,
+    mock_get_service_template,
+    mock_get_no_notifications,
+    mock_get_service_data_retention,
+):
+    page = client_request.get(
+        "main.view_job",
+        service_id=service_one["id"],
+        job_id=fake_uuid,
+        status="sending",
+    )
+    assert len(page.find_all("thead", {"class": "table-field-headings-visible"})) == 0
+    assert len(page.find_all("thead", {"class": "table-field-headings"})) == 1
+
+
 class TestBounceRate:
     def test_jobs_page_shows_problem_email_filter(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2376,6 +2376,7 @@ def mock_get_notifications_with_previous_next(mocker):
         side_effect=_get_notifications,
     )
 
+
 @pytest.fixture(scope="function")
 def mock_get_no_notifications(mocker):
     def _get_notifications(
@@ -2397,6 +2398,7 @@ def mock_get_no_notifications(mocker):
         "app.notification_api_client.get_notifications_for_service",
         side_effect=_get_notifications,
     )
+
 
 @pytest.fixture(scope="function")
 def mock_get_api_notifications_with_previous_next(mocker):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2376,6 +2376,27 @@ def mock_get_notifications_with_previous_next(mocker):
         side_effect=_get_notifications,
     )
 
+@pytest.fixture(scope="function")
+def mock_get_no_notifications(mocker):
+    def _get_notifications(
+        service_id,
+        job_id=None,
+        page=1,
+        count_pages=None,
+        template_type=None,
+        status=None,
+        limit_days=None,
+        include_jobs=None,
+        include_from_test_key=None,
+        to=None,
+        include_one_off=None,
+    ):
+        return notification_json(service_id, rows=0, with_links=True if count_pages is None else count_pages)
+
+    return mocker.patch(
+        "app.notification_api_client.get_notifications_for_service",
+        side_effect=_get_notifications,
+    )
 
 @pytest.fixture(scope="function")
 def mock_get_api_notifications_with_previous_next(mocker):


### PR DESCRIPTION
# Summary | Résumé

This PR updates the notification reports page for jobs and for the service to hide the headers when there are no notifications to show.

Before:
![image](https://github.com/cds-snc/notification-admin/assets/823749/fd50c58f-e3f3-4f65-9ce3-f46a7be185af)

After:
![image](https://github.com/cds-snc/notification-admin/assets/823749/3b7f5c83-f02a-4f87-b6b1-d0b0234bcd6d)
