### PR TITLE
Remove `FF_BOUNCE_RATE_V1`

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -426,97 +426,48 @@ def format_notification_type(notification_type):
 
 
 def format_notification_status(status, template_type, provider_response=None, feedback_subtype=None):
-    if current_app.config["FF_BOUNCE_RATE_V1"] or current_service.id in current_app.config["FF_ABTEST_SERVICE_ID"]:
-        if template_type == "sms" and provider_response:
-            return _(provider_response)
-
-        def _getStatusByBounceSubtype():
-            """Return the status of a notification based on the bounce sub type"""
-            if feedback_subtype:
-                return {
-                    "email": {
-                        "suppressed": _("Blocked"),
-                        "on-account-suppression-list": _("Blocked"),
-                    },
-                }[
-                    template_type
-                ].get(feedback_subtype, _("No such address"))
-            else:
-                return _("No such address")
-
-        return {
-            "email": {
-                "failed": _("Failed"),
-                "technical-failure": _("Tech issue"),
-                "temporary-failure": _("Content or inbox issue"),
-                "virus-scan-failed": _("Virus in attachment"),
-                "permanent-failure": _getStatusByBounceSubtype(),
-                "delivered": _("Delivered"),
-                "sending": _("In transit"),
-                "created": _("In transit"),
-                "sent": _("Delivered"),
-                "pending": _("In transit"),
-                "pending-virus-check": _("In transit"),
-                "pii-check-failed": _("Exceeds Protected A"),
-            },
-            "sms": {
-                "failed": _("Failed"),
-                "technical-failure": _("Tech issue"),
-                "temporary-failure": _("Carrier issue"),
-                "permanent-failure": _("No such number"),
-                "delivered": _("Delivered"),
-                "sending": _("In transit"),
-                "created": _("In transit"),
-                "pending": _("In transit"),
-                "sent": _("In transit"),
-            },
-            "letter": {
-                "failed": "",
-                "technical-failure": "Technical failure",
-                "temporary-failure": "",
-                "permanent-failure": "",
-                "delivered": "",
-                "received": "",
-                "accepted": "",
-                "sending": "",
-                "created": "",
-                "sent": "",
-                "pending-virus-check": "",
-                "virus-scan-failed": "Virus detected",
-                "returned-letter": "",
-                "cancelled": "",
-                "validation-failed": "Validation failed",
-            },
-        }[template_type].get(status, status)
-
-    # -----------------
-    # remove this code when FF_BOUNCE_RATE_V1 is removed
-    # -----------------
-    if provider_response:
+    if template_type == "sms" and provider_response:
         return _(provider_response)
+
+    def _getStatusByBounceSubtype():
+        """Return the status of a notification based on the bounce sub type"""
+        if feedback_subtype:
+            return {
+                "email": {
+                    "suppressed": _("Blocked"),
+                    "on-account-suppression-list": _("Blocked"),
+                },
+            }[
+                template_type
+            ].get(feedback_subtype, _("No such address"))
+        else:
+            return _("No such address")
 
     return {
         "email": {
             "failed": _("Failed"),
-            "technical-failure": _("Technical failure"),
-            "temporary-failure": _("Inbox not accepting messages right now"),
-            "virus-scan-failed": _("Attachment has virus"),
-            "permanent-failure": _("Email address does not exist"),
+            "technical-failure": _("Tech issue"),
+            "temporary-failure": _("Content or inbox issue"),
+            "virus-scan-failed": _("Virus in attachment"),
+            "permanent-failure": _getStatusByBounceSubtype(),
             "delivered": _("Delivered"),
-            "sending": _("Sending"),
-            "created": _("Sending"),
+            "sending": _("In transit"),
+            "created": _("In transit"),
             "sent": _("Delivered"),
+            "pending": _("In transit"),
+            "pending-virus-check": _("In transit"),
+            "pii-check-failed": _("Exceeds Protected A"),
         },
         "sms": {
             "failed": _("Failed"),
-            "technical-failure": _("Technical failure"),
-            "temporary-failure": _("Phone number not accepting messages right now"),
-            "permanent-failure": _("Phone number does not exist"),
+            "technical-failure": _("Tech issue"),
+            "temporary-failure": _("Carrier issue"),
+            "permanent-failure": _("No such number"),
             "delivered": _("Delivered"),
-            "sending": _("Sending"),
-            "created": _("Sending"),
-            "pending": _("Sending"),
-            "sent": _("Sent"),
+            "sending": _("In transit"),
+            "created": _("In transit"),
+            "pending": _("In transit"),
+            "sent": _("In transit"),
         },
         "letter": {
             "failed": "",
@@ -584,11 +535,7 @@ def format_notification_status_as_field_status(status, notification_type):
 
 def format_notification_status_as_url(status, notification_type):
     def url(_anchor):
-        if current_app.config["FF_BOUNCE_RATE_V1"] or current_service.id in current_app.config["FF_ABTEST_SERVICE_ID"]:
-            return gca_url_for("delivery_failure") + "#" + _anchor
-        # remove this when FF_BOUNCE_RATE_V1 is removed
-        else:
-            return gca_url_for("message_delivery_status") + "#" + _anchor
+        return gca_url_for("delivery_failure") + "#" + _anchor
 
     if status not in {
         "technical-failure",

--- a/app/config.py
+++ b/app/config.py
@@ -138,7 +138,6 @@ class Config(object):
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
     FF_SPIKE_SMS_DAILY_LIMIT = env.bool("FF_SPIKE_SMS_DAILY_LIMIT", False)
     FF_SMS_PARTS_UI = env.bool("FF_SMS_PARTS_UI", False)
-    FF_BOUNCE_RATE_V1 = env.bool("FF_BOUNCE_RATE_V1", False)
     FF_BOUNCE_RATE_V15 = env.bool("FF_BOUNCE_RATE_V15", False)
     FF_ABTEST_SERVICE_ID = [x.strip() for x in os.environ.get("FF_ABTEST_SERVICE_ID", "").split(",")]
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)

--- a/app/config.py
+++ b/app/config.py
@@ -139,7 +139,6 @@ class Config(object):
     FF_SPIKE_SMS_DAILY_LIMIT = env.bool("FF_SPIKE_SMS_DAILY_LIMIT", False)
     FF_SMS_PARTS_UI = env.bool("FF_SMS_PARTS_UI", False)
     FF_BOUNCE_RATE_V15 = env.bool("FF_BOUNCE_RATE_V15", False)
-    FF_ABTEST_SERVICE_ID = [x.strip() for x in os.environ.get("FF_ABTEST_SERVICE_ID", "").split(",")]
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
 
     @classmethod

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -258,7 +258,6 @@ def get_dashboard_partials(service_id):
         scheduled_jobs = job_api_client.get_scheduled_jobs(service_id)
         immediate_jobs = [add_rate_to_job(job) for job in job_api_client.get_immediate_jobs(service_id)]
 
-    stats_weekly = aggregate_notifications_stats(all_statistics_weekly)
     # get the daily stats
     dashboard_totals_daily, highest_notification_count_daily, all_statistics_daily = _get_daily_stats(service_id)
 

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -283,9 +283,7 @@ def get_dashboard_partials(service_id):
         "weekly_totals": render_template(
             "views/dashboard/_totals.html",
             service_id=service_id,
-            statistics=dashboard_totals_daily[0]
-            if current_app.config["FF_BOUNCE_RATE_V1"] or current_service.id in current_app.config["FF_ABTEST_SERVICE_ID"]
-            else dashboard_totals_weekly[0],
+            statistics=dashboard_totals_daily[0],
             column_width=column_width,
             smaller_font_size=(highest_notification_count_daily > max_notifiction_count),
             bounce_rate=bounce_rate_data,

--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -265,7 +265,6 @@ def get_dashboard_partials(service_id):
     column_width, max_notifiction_count = get_column_properties(
         number_of_columns=(3 if current_service.has_permission("letter") else 2)
     )
-    dashboard_totals_weekly = (get_dashboard_totals(stats_weekly),)
     bounce_rate_data = (
         get_bounce_rate_data_from_redis(service_id)
         if current_app.config["FF_BOUNCE_RATE_V15"]

--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -39,49 +39,30 @@
   <div class="big-number-with-status">
     {{ big_number(number, label, link=link, status=True, smaller=smaller, smallest=smallest) }}
     {% if show_failures %}
-      {% if not config["FF_BOUNCE_RATE_V1"] and not current_service.id in config["FF_ABTEST_SERVICE_ID"] %}
-        <div class="big-number-status{% if danger_zone %} bg-red{% endif %}{% if not failures %} p-6{% endif %}">
-          {% if failures %}
-            {% if failure_link %}
-              <a class="p-6 big-number-status-link flex justify-between items-end border-0" href="{{ failure_link }}">
-                {{ "{:,}".format(failures) }}
-                {{ _('failed') }} – {{ failure_percentage }}%
-                <i aria-hidden="true" class="p-1 fa-solid fa-circle-question"></i>
-              </a>
-            {% else %}
-              {{ "{:,}".format(failures) }}
-              {{ _('failed') }} – {{ failure_percentage }}%
-            {% endif %}
+      {% if failure_link %}
+        <a class="big-number-link border-0 focus:border-b-0 " href="{{ failure_link }}">
+      {% endif %}
+      <div class="pb-4 big-number-status{% if danger_zone %} bg-red{% endif %}{% if not failures %} p-6{% endif %}">
+        {% if failures %}
+          {% if failure_link %}
+            <div class="p-6 flex justify-between items-end border-0 no-underline" href="{{ failure_link }}">
+              {{ failure_percentage }}%  {{_('failed') }}
+              <i aria-hidden="true" class="p-1 fa-solid {% if danger_zone %}fa-triangle-exclamation{% else %}{% endif %}"></i>
+            </div>
+            <div class="px-6 flex justify-between items-end border-0">
+              <span class="underline font-bold">{{_('Review reports') }}</span>
+              <i aria-hidden="true" class="p-1 fa-solid fa-fas fa-arrow-right"></i>
+            </div>
           {% else %}
-            {{ _('No failures') }}
+            {{ "{:,}".format(failures) }}
+            {{ _('failed') }} – {{ failure_percentage }}%
           {% endif %}
-        </div>
-      {% else %}
-        {% if failure_link %}
-          <a class="big-number-link border-0 focus:border-b-0 " href="{{ failure_link }}">
+        {% else %}
+          {{ _('No failures') }}
         {% endif %}
-        <div class="pb-4 big-number-status{% if danger_zone %} bg-red{% endif %}{% if not failures %} p-6{% endif %}">
-          {% if failures %}
-            {% if failure_link %}
-              <div class="p-6 flex justify-between items-end border-0 no-underline" href="{{ failure_link }}">
-                {{ failure_percentage }}%  {{_('failed') }}
-                <i aria-hidden="true" class="p-1 fa-solid {% if danger_zone %}fa-triangle-exclamation{% else %}{% endif %}"></i>
-              </div>
-              <div class="px-6 flex justify-between items-end border-0">
-                <span class="underline font-bold">{{_('Review reports') }}</span>
-                <i aria-hidden="true" class="p-1 fa-solid fa-fas fa-arrow-right"></i>
-              </div>
-            {% else %}
-              {{ "{:,}".format(failures) }}
-              {{ _('failed') }} – {{ failure_percentage }}%
-            {% endif %}
-          {% else %}
-            {{ _('No failures') }}
-          {% endif %}
-        </div>
-        {% if failure_link %}
-          </a>
-        {% endif %}
+      </div>
+      {% if failure_link %}
+        </a>
       {% endif %}
     {% endif %}
   </div>

--- a/app/templates/components/problem-email-checkbox.html
+++ b/app/templates/components/problem-email-checkbox.html
@@ -1,7 +1,5 @@
 {% from "components/checkbox.html" import checkbox %}
 
 {% macro problem_email_checkbox() %}
-    {% if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] %}
-        {{ checkbox({ "id": "pe_filter", "name": "pe_filter", "data": request.args.get('pe_filter'), "label": { "text": _("Only show problem addresses")}}) }}
-    {% endif %}
+    {{ checkbox({ "id": "pe_filter", "name": "pe_filter", "data": request.args.get('pe_filter'), "label": { "text": _("Only show problem addresses")}}) }}
 {% endmacro %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -16,8 +16,8 @@
         caption=uploaded_file_name,
         caption_visible=False,
         empty_message=_("No messages to show"),
-        field_headings=[heading_1,heading_2,heading_3] if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] else [heading_1, heading_3],
-        field_headings_visible=False if not notifications else True if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] and notifications else False
+        field_headings=[heading_1,heading_2,heading_3],
+        field_headings_visible=False if not notifications else True
       ) %}
         {% call row_heading() %}
           <a class="file-list-filename" href="{{ url_for('.view_notification', service_id=current_service.id, notification_id=item.id, from_job=job.id) }}">{{ item.to }}</a>
@@ -25,11 +25,9 @@
             {{ item.preview_of_content }}
           </p>
         {% endcall %}
-        {% if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] %}
-          {% call field() %}
-            {{ is_probem_email(item) }}
-          {% endcall %}
-        {% endif %}
+        {% call field() %}
+          {{ is_probem_email(item) }}
+        {% endcall %}
 
         {{ notification_status_field(item) }}
       {% endcall %}

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -18,8 +18,8 @@
       caption="Recent activity",
       caption_visible=False,
       empty_message=empty_txt.format(limit_days)|safe,
-      field_headings=[heading_1,heading_2,heading_3] if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] else [heading_1, heading_3],
-      field_headings_visible=False if not notifications else True if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] else False
+      field_headings=[heading_1,heading_2,heading_3],
+      field_headings_visible=False if not notifications else True
     ) %}
       {% call row_heading() %}
         {% if item.status in ('pending-virus-check', 'virus-scan-failed') %}
@@ -32,11 +32,9 @@
         </p>
       {% endcall %}
       
-      {% if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] %}
-        {% call field() %}
-          {{ is_probem_email(item) }}
-        {% endcall %}
-      {% endif %}
+      {% call field() %}
+        {{ is_probem_email(item) }}
+      {% endcall %}
 
       {{ notification_status_field(item) }}
 

--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -8,11 +8,7 @@
 {% set address_plural = _('addresses') %}
 <div class="ajax-block-container">
   <h2 class="heading-medium mt-8">
-    {% if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] %}
-      {{ _("Email in the last 24 hours") }}
-    {% else %}
-      {{ _("Sent in the last week") }}
-    {% endif %}
+    {{ _("Email in the last 24 hours") }}
   </h2>
   <div class="grid-row contain-floats">
     <div id="total-email" class="{{column_width}}">
@@ -29,30 +25,17 @@
     </div>
 
     <div id="problem-email-addresses" class="{{column_width}}">
-      {% if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] %}
-        {{ big_number_review_emails_with_status(
-          number=bounce_rate["bounce_total"],
-          label=problem_email_label(bounce_rate["bounce_total"]),
-          problem_percentage=bounce_rate["bounce_percentage_display"],
-          bounce_status=bounce_rate["bounce_status"],
-          bounce_threshold=bounce_rate["below_threshold"],
-          failure_link=url_for('.problem_emails', service_id=service_id) if bounce_rate["bounce_percentage"] > 0 else None,
-          link=None,
-          smaller=smaller_font_size,
-          failure_link_label=_("Review email addresses")
-        ) }}
-      {% else %}
-        {{ big_number_with_status(
-          statistics['sms']['requested'],
-          message_count_label(statistics['sms']['requested'], 'sms', suffix=sent_single, suffix_plural=sent_plural),
-          statistics['sms']['failed'],
-          statistics['sms']['failed_percentage'],
-          statistics['sms']['show_warning'],
-          failure_link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='failed'),
-          link=url_for(".view_notifications", service_id=service_id, message_type='sms', status='sending,delivered,failed'),
-          smaller=smaller_font_size
-        ) }}
-      {% endif%}
+      {{ big_number_review_emails_with_status(
+        number=bounce_rate["bounce_total"],
+        label=problem_email_label(bounce_rate["bounce_total"]),
+        problem_percentage=bounce_rate["bounce_percentage_display"],
+        bounce_status=bounce_rate["bounce_status"],
+        bounce_threshold=bounce_rate["below_threshold"],
+        failure_link=url_for('.problem_emails', service_id=service_id) if bounce_rate["bounce_percentage"] > 0 else None,
+        link=None,
+        smaller=smaller_font_size,
+        failure_link_label=_("Review email addresses")
+      ) }}
     </div>
 
     {% if current_service.has_permission('letter') %}
@@ -70,7 +53,6 @@
       </div>
     {% endif %}
     </div>
-    {% if config["FF_BOUNCE_RATE_V1"] or current_service.id in config["FF_ABTEST_SERVICE_ID"] %}
     <div id="total-sms">
     <h2 class="heading-medium mt-8">
       {{ _('Text messages in the last 24 hours') }}
@@ -86,6 +68,5 @@
         smaller=smaller_font_size
       ) }}
     </div>
-  {% endif %}
   </div>
 </div>

--- a/tests/app/main/test_formatters.py
+++ b/tests/app/main/test_formatters.py
@@ -57,72 +57,7 @@ def test_format_notification_status_as_url(
     expected,
     app_,
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        assert format_notification_status_as_url(status, notification_type) == expected
-
-
-# -----------------
-# remove this test when FF_BOUNCE_RATE_V1 is removed
-# -----------------
-@pytest.mark.parametrize(
-    "status, notification_type, expected",
-    (
-        # Successful statuses aren’t linked
-        ("created", "email", None),
-        ("sending", "email", None),
-        ("delivered", "email", None),
-        # Failures are linked to the channel-specific page
-        (
-            "temporary-failure",
-            "email",
-            "/message-delivery-status#email-statuses",
-        ),
-        (
-            "permanent-failure",
-            "email",
-            "/message-delivery-status#email-statuses",
-        ),
-        (
-            "technical-failure",
-            "email",
-            "/message-delivery-status#email-statuses",
-        ),
-        (
-            "temporary-failure",
-            "sms",
-            "/message-delivery-status#sms-statuses",
-        ),
-        (
-            "permanent-failure",
-            "sms",
-            "/message-delivery-status#sms-statuses",
-        ),
-        (
-            "technical-failure",
-            "sms",
-            "/message-delivery-status#sms-statuses",
-        ),
-        # Letter statuses are never linked
-        ("technical-failure", "letter", None),
-        ("cancelled", "letter", None),
-        ("accepted", "letter", None),
-        ("received", "letter", None),
-    ),
-)
-def test_format_notification_status_as_url_REMOVE(
-    client,
-    status,
-    notification_type,
-    expected,
-    app_,
-):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", False):
-
-        class FakeService:
-            id = "123"
-
-        g.current_service = FakeService()
-        assert format_notification_status_as_url(status, notification_type) == expected
+    assert format_notification_status_as_url(status, notification_type) == expected
 
 
 @pytest.mark.parametrize(
@@ -145,5 +80,4 @@ def test_format_notification_status_as_url_REMOVE(
     ),
 )
 def test_format_notification_status_uses_correct_labels(client, template_type, status, feedback_subtype, expected, app_):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        assert format_notification_status(status, template_type, None, feedback_subtype) == expected
+    assert format_notification_status(status, template_type, None, feedback_subtype) == expected

--- a/tests/app/main/test_formatters.py
+++ b/tests/app/main/test_formatters.py
@@ -1,8 +1,6 @@
 import pytest
-from flask import g
 
 from app import format_notification_status, format_notification_status_as_url
-from tests.conftest import set_config
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -16,7 +16,6 @@ from tests.conftest import (
     create_active_user_with_permissions,
     create_notifications,
     normalize_spaces,
-    set_config,
 )
 
 

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -523,36 +523,18 @@ def test_html_contains_notification_id(
 def test_html_contains_links_for_failed_notifications(
     client_request, active_user_with_permissions, mock_get_service_statistics, mock_get_service_data_retention, mocker, app_
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        notifications = create_notifications(status="technical-failure")
-        mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
-        response = client_request.get(
-            "main.view_notifications",
-            service_id=SERVICE_ONE_ID,
-            message_type="sms",
-            status="sending%2Cdelivered%2Cfailed",
-        )
-        notifications = response.tbody.find_all("tr")
-        for tr in notifications:
-            link_text = tr.find("div", class_="table-field-status-error").find("a").text
-            assert normalize_spaces(link_text) == "Tech issue"
-
-    # -----------------
-    # remove the following code when FF_BOUNCE_RATE_V1 is removed
-    # -----------------
-    with set_config(app_, "FF_BOUNCE_RATE_V1", False):
-        notifications = create_notifications(status="technical-failure")
-        mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
-        response = client_request.get(
-            "main.view_notifications",
-            service_id=SERVICE_ONE_ID,
-            message_type="sms",
-            status="sending%2Cdelivered%2Cfailed",
-        )
-        notifications = response.tbody.find_all("tr")
-        for tr in notifications:
-            link_text = tr.find("div", class_="table-field-status-error").find("a").text
-            assert normalize_spaces(link_text) == "Technical failure"
+    notifications = create_notifications(status="technical-failure")
+    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    response = client_request.get(
+        "main.view_notifications",
+        service_id=SERVICE_ONE_ID,
+        message_type="sms",
+        status="sending%2Cdelivered%2Cfailed",
+    )
+    notifications = response.tbody.find_all("tr")
+    for tr in notifications:
+        link_text = tr.find("div", class_="table-field-status-error").find("a").text
+        assert normalize_spaces(link_text) == "Tech issue"
 
 
 @pytest.mark.parametrize(
@@ -622,104 +604,6 @@ def test_big_numbers_and_search_dont_show_for_letters(
 
     assert (len(page.select("nav.pill")) > 0) == tablist_visible
     assert (len(page.select("[type=search]")) > 0) == search_bar_visible
-
-
-# --------------------------------------------------------------------
-# remove the following test when FF_BOUNCE_RATE_V1 is removed
-# --------------------------------------------------------------------
-@freeze_time("2017-09-27 16:30:00.000000")
-@pytest.mark.parametrize(
-    "message_type, status, expected_hint_status, single_line",
-    [
-        ("email", "created", "Sending since 2017-09-27T16:30:00+00:00", True),
-        ("email", "sending", "Sending since 2017-09-27T16:30:00+00:00", True),
-        (
-            "email",
-            "temporary-failure",
-            "Inbox not accepting messages right now 16:31:00",
-            False,
-        ),
-        ("email", "permanent-failure", "Email address does not exist 16:31:00", False),
-        ("email", "delivered", "Delivered 16:31:00", True),
-        ("sms", "created", "Sending since 2017-09-27T16:30:00+00:00", True),
-        ("sms", "sending", "Sending since 2017-09-27T16:30:00+00:00", True),
-        (
-            "sms",
-            "temporary-failure",
-            "Phone number not accepting messages right now 16:31:00",
-            False,
-        ),
-        ("sms", "permanent-failure", "Phone number does not exist 16:31:00", False),
-        ("sms", "delivered", "Delivered 16:31:00", True),
-        ("letter", "created", "2017-09-27T16:30:00+00:00", True),
-        ("letter", "pending-virus-check", "2017-09-27T16:30:00+00:00", True),
-        ("letter", "sending", "2017-09-27T16:30:00+00:00", True),
-        ("letter", "delivered", "2017-09-27T16:30:00+00:00", True),
-        ("letter", "received", "2017-09-27T16:30:00+00:00", True),
-        ("letter", "accepted", "2017-09-27T16:30:00+00:00", True),
-        (
-            "letter",
-            "cancelled",
-            "2017-09-27T16:30:00+00:00",
-            False,
-        ),  # The API won’t return cancelled letters
-        (
-            "letter",
-            "permanent-failure",
-            "16:31:00",
-            False,
-        ),  # Deprecated for ‘cancelled’
-        (
-            "letter",
-            "temporary-failure",
-            "2017-09-27T16:30:00+00:00",
-            False,
-        ),  # Not currently a real letter status
-        (
-            "letter",
-            "virus-scan-failed",
-            "Virus detected 2017-09-27T16:30:00+00:00",
-            False,
-        ),
-        (
-            "letter",
-            "validation-failed",
-            "Validation failed 2017-09-27T16:30:00+00:00",
-            False,
-        ),
-        (
-            "letter",
-            "technical-failure",
-            "Technical failure 2017-09-27T16:30:00+00:00",
-            False,
-        ),
-    ],
-)
-def test_sending_status_hint_displays_correctly_on_notifications_page(
-    client_request,
-    service_one,
-    active_user_with_permissions,
-    mock_get_service_statistics,
-    mock_get_service_data_retention,
-    message_type,
-    status,
-    expected_hint_status,
-    single_line,
-    mocker,
-    app_,
-):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", False):
-        notifications = create_notifications(template_type=message_type, status=status)
-        mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
-
-        page = client_request.get(
-            "main.view_notifications",
-            service_id=service_one["id"],
-            message_type=message_type,
-        )
-
-        assert normalize_spaces(page.select(".table-field-right-aligned")[0].text) == expected_hint_status
-        assert bool(page.select(".align-with-message-body")) is single_line
 
 
 @freeze_time("2017-09-27 16:30:00.000000")
@@ -803,18 +687,17 @@ def test_sending_status_hint_displays_correctly_on_notifications_page_new_status
     mocker,
     app_,
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        notifications = create_notifications(template_type=message_type, status=status)
-        mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
+    notifications = create_notifications(template_type=message_type, status=status)
+    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value=notifications)
 
-        page = client_request.get(
-            "main.view_notifications",
-            service_id=service_one["id"],
-            message_type=message_type,
-        )
+    page = client_request.get(
+        "main.view_notifications",
+        service_id=service_one["id"],
+        message_type=message_type,
+    )
 
-        assert normalize_spaces(page.select(".table-field-right-aligned")[0].text) == expected_hint_status
-        assert bool(page.select(".align-with-message-body")) is single_line
+    assert normalize_spaces(page.select(".table-field-right-aligned")[0].text) == expected_hint_status
+    assert bool(page.select(".align-with-message-body")) is single_line
 
 
 @pytest.mark.skip(reason="letters: unused functionality")

--- a/tests/app/main/views/test_bounce_rate.py
+++ b/tests/app/main/views/test_bounce_rate.py
@@ -393,10 +393,7 @@ def test_bounce_rate_widget_displays_correct_status_and_totals_v1(
 
         if expected_problem_emails > 0:
             assert (
-                page.select_one("#problem-email-addresses .review-email-label")
-                .text.strip()
-                .replace("\n", "")
-                .replace("  ", "")
+                page.select_one("#problem-email-addresses .review-email-label").text.strip().replace("\n", "").replace("  ", "")
                 == expected_problem_percent
             )
 
@@ -439,10 +436,7 @@ def test_bounce_rate_widget_displays_correct_status_and_totals_v15(
 
         if total_hard_bounces > 0:
             assert (
-                page.select_one("#problem-email-addresses .review-email-label")
-                .text.strip()
-                .replace("\n", "")
-                .replace("  ", "")
+                page.select_one("#problem-email-addresses .review-email-label").text.strip().replace("\n", "").replace("  ", "")
                 == expected_problem_percent
             )
 

--- a/tests/app/main/views/test_bounce_rate.py
+++ b/tests/app/main/views/test_bounce_rate.py
@@ -379,27 +379,26 @@ def test_bounce_rate_widget_displays_correct_status_and_totals_v1(
     expected_problem_percent,
     app_,
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        with set_config(app_, "FF_BOUNCE_RATE_V15", False):
-            mocker.patch(
-                "app.main.views.dashboard.template_statistics_client.get_template_statistics_for_service", return_value=totals
+    with set_config(app_, "FF_BOUNCE_RATE_V15", False):
+        mocker.patch(
+            "app.main.views.dashboard.template_statistics_client.get_template_statistics_for_service", return_value=totals
+        )
+
+        page = client_request.get(
+            "main.service_dashboard",
+            service_id=service_one["id"],
+        )
+
+        assert int(page.select_one("#problem-email-addresses .big-number-number").text.strip()) == expected_problem_emails
+
+        if expected_problem_emails > 0:
+            assert (
+                page.select_one("#problem-email-addresses .review-email-label")
+                .text.strip()
+                .replace("\n", "")
+                .replace("  ", "")
+                == expected_problem_percent
             )
-
-            page = client_request.get(
-                "main.service_dashboard",
-                service_id=service_one["id"],
-            )
-
-            assert int(page.select_one("#problem-email-addresses .big-number-number").text.strip()) == expected_problem_emails
-
-            if expected_problem_emails > 0:
-                assert (
-                    page.select_one("#problem-email-addresses .review-email-label")
-                    .text.strip()
-                    .replace("\n", "")
-                    .replace("  ", "")
-                    == expected_problem_percent
-                )
 
 
 @pytest.mark.parametrize(
@@ -426,27 +425,26 @@ def test_bounce_rate_widget_displays_correct_status_and_totals_v15(
     expected_problem_percent,
     app_,
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        with set_config(app_, "FF_BOUNCE_RATE_V15", True):
-            mocker.patch("app.main.views.dashboard.bounce_rate_client.get_bounce_rate", return_value=bounce_rate)
-            mocker.patch("app.main.views.dashboard.bounce_rate_client.check_bounce_rate_status", return_value=bounce_rate_status)
-            mocker.patch("app.main.views.dashboard.bounce_rate_client.get_total_hard_bounces", return_value=total_hard_bounces)
+    with set_config(app_, "FF_BOUNCE_RATE_V15", True):
+        mocker.patch("app.main.views.dashboard.bounce_rate_client.get_bounce_rate", return_value=bounce_rate)
+        mocker.patch("app.main.views.dashboard.bounce_rate_client.check_bounce_rate_status", return_value=bounce_rate_status)
+        mocker.patch("app.main.views.dashboard.bounce_rate_client.get_total_hard_bounces", return_value=total_hard_bounces)
 
-            page = client_request.get(
-                "main.service_dashboard",
-                service_id=service_one["id"],
+        page = client_request.get(
+            "main.service_dashboard",
+            service_id=service_one["id"],
+        )
+
+        assert int(page.select_one("#problem-email-addresses .big-number-number").text.strip()) == total_hard_bounces
+
+        if total_hard_bounces > 0:
+            assert (
+                page.select_one("#problem-email-addresses .review-email-label")
+                .text.strip()
+                .replace("\n", "")
+                .replace("  ", "")
+                == expected_problem_percent
             )
-
-            assert int(page.select_one("#problem-email-addresses .big-number-number").text.strip()) == total_hard_bounces
-
-            if total_hard_bounces > 0:
-                assert (
-                    page.select_one("#problem-email-addresses .review-email-label")
-                    .text.strip()
-                    .replace("\n", "")
-                    .replace("  ", "")
-                    == expected_problem_percent
-                )
 
 
 def test_bounce_rate_widget_doesnt_change_when_under_threshold_v1(
@@ -459,40 +457,39 @@ def test_bounce_rate_widget_doesnt_change_when_under_threshold_v1(
     service_one,
     app_,
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        with set_config(app_, "FF_BOUNCE_RATE_V15", False):
-            threshold = app_.config["BR_DISPLAY_VOLUME_MINIMUM"]
+    with set_config(app_, "FF_BOUNCE_RATE_V15", False):
+        threshold = app_.config["BR_DISPLAY_VOLUME_MINIMUM"]
 
-            mock_data = [
-                {
-                    "count": (threshold - 20) * 0.5,
-                    "is_precompiled_letter": False,
-                    "status": "delivered",
-                    "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
-                    "template_name": "test",
-                    "template_type": "email",
-                },
-                {
-                    "count": (threshold - 20) * 0.5,
-                    "is_precompiled_letter": False,
-                    "status": "permanent-failure",
-                    "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
-                    "template_name": "test",
-                    "template_type": "email",
-                },
-            ]
+        mock_data = [
+            {
+                "count": (threshold - 20) * 0.5,
+                "is_precompiled_letter": False,
+                "status": "delivered",
+                "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
+                "template_name": "test",
+                "template_type": "email",
+            },
+            {
+                "count": (threshold - 20) * 0.5,
+                "is_precompiled_letter": False,
+                "status": "permanent-failure",
+                "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
+                "template_name": "test",
+                "template_type": "email",
+            },
+        ]
 
-            mocker.patch(
-                "app.main.views.dashboard.template_statistics_client.get_template_statistics_for_service", return_value=mock_data
-            )
+        mocker.patch(
+            "app.main.views.dashboard.template_statistics_client.get_template_statistics_for_service", return_value=mock_data
+        )
 
-            page = client_request.get(
-                "main.service_dashboard",
-                service_id=service_one["id"],
-            )
+        page = client_request.get(
+            "main.service_dashboard",
+            service_id=service_one["id"],
+        )
 
-            assert len(page.find_all(class_="review-email-status-critical")) == 0
-            assert len(page.find_all(class_="review-email-status-neutral")) == 1
+        assert len(page.find_all(class_="review-email-status-critical")) == 0
+        assert len(page.find_all(class_="review-email-status-neutral")) == 1
 
 
 def test_bounce_rate_widget_doesnt_change_when_under_threshold_v15(
@@ -505,53 +502,51 @@ def test_bounce_rate_widget_doesnt_change_when_under_threshold_v15(
     service_one,
     app_,
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        with set_config(app_, "FF_BOUNCE_RATE_V15", True):
-            mocker.patch("app.main.views.dashboard.bounce_rate_client.get_bounce_rate", return_value=0.30)  # 30%
-            mocker.patch("app.main.views.dashboard.bounce_rate_client.check_bounce_rate_status", return_value="normal")
-            mocker.patch("app.main.views.dashboard.bounce_rate_client.get_total_hard_bounces", return_value=10)
+    with set_config(app_, "FF_BOUNCE_RATE_V15", True):
+        mocker.patch("app.main.views.dashboard.bounce_rate_client.get_bounce_rate", return_value=0.30)  # 30%
+        mocker.patch("app.main.views.dashboard.bounce_rate_client.check_bounce_rate_status", return_value="normal")
+        mocker.patch("app.main.views.dashboard.bounce_rate_client.get_total_hard_bounces", return_value=10)
 
-            page = client_request.get(
-                "main.service_dashboard",
-                service_id=service_one["id"],
-            )
+        page = client_request.get(
+            "main.service_dashboard",
+            service_id=service_one["id"],
+        )
 
-            assert len(page.find_all(class_="review-email-status-critical")) == 0
-            assert len(page.find_all(class_="review-email-status-normal")) == 0
-            assert len(page.find_all(class_="review-email-status-neutral")) == 1
+        assert len(page.find_all(class_="review-email-status-critical")) == 0
+        assert len(page.find_all(class_="review-email-status-normal")) == 0
+        assert len(page.find_all(class_="review-email-status-neutral")) == 1
 
 
 @pytest.mark.parametrize("FF_BOUNCE_RATE_V15", [True, False])
 def test_review_problem_emails_is_empty_when_no_probems(mocker, service_one, app_, client_request, FF_BOUNCE_RATE_V15):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        with set_config(app_, "FF_BOUNCE_RATE_V15", FF_BOUNCE_RATE_V15):
-            threshold = app_.config["BR_DISPLAY_VOLUME_MINIMUM"]
+    with set_config(app_, "FF_BOUNCE_RATE_V15", FF_BOUNCE_RATE_V15):
+        threshold = app_.config["BR_DISPLAY_VOLUME_MINIMUM"]
 
-            mock_data = [
-                {
-                    "count": int((threshold - 20) * 0.5),
-                    "is_precompiled_letter": False,
-                    "status": "delivered",
-                    "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
-                    "template_name": "test",
-                    "template_type": "email",
-                }
-            ]
+        mock_data = [
+            {
+                "count": int((threshold - 20) * 0.5),
+                "is_precompiled_letter": False,
+                "status": "delivered",
+                "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
+                "template_name": "test",
+                "template_type": "email",
+            }
+        ]
 
-            mocker.patch(
-                "app.main.views.dashboard.template_statistics_client.get_template_statistics_for_service", return_value=mock_data
-            )
-            mocker.patch("app.main.views.dashboard.get_jobs_and_calculate_hard_bounces", return_value=[])
-            mocker.patch("app.notification_api_client.get_notifications_for_service", return_value={"notifications": []})
-            page = client_request.get(
-                "main.problem_emails",
-                service_id=service_one["id"],
-            )
+        mocker.patch(
+            "app.main.views.dashboard.template_statistics_client.get_template_statistics_for_service", return_value=mock_data
+        )
+        mocker.patch("app.main.views.dashboard.get_jobs_and_calculate_hard_bounces", return_value=[])
+        mocker.patch("app.notification_api_client.get_notifications_for_service", return_value={"notifications": []})
+        page = client_request.get(
+            "main.problem_emails",
+            service_id=service_one["id"],
+        )
 
-            assert (
-                page.find("p", {"class": "text-title"}).text.strip().replace("\n", "").replace("  ", "")
-                == "Less than 0.1% of email addresses need review"
-            )
+        assert (
+            page.find("p", {"class": "text-title"}).text.strip().replace("\n", "").replace("  ", "")
+            == "Less than 0.1% of email addresses need review"
+        )
 
 
 @pytest.mark.parametrize(
@@ -568,34 +563,33 @@ def test_review_problem_emails_is_empty_when_no_probems(mocker, service_one, app
 def test_review_problem_emails_shows_csvs_when_problem_emails_exist(
     mocker, service_one, app_, client_request, jobs, expected_problem_list_count, FF_BOUNCE_RATE_V15
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        with set_config(app_, "FF_BOUNCE_RATE_V15", FF_BOUNCE_RATE_V15):
-            threshold = app_.config["BR_DISPLAY_VOLUME_MINIMUM"]
+    with set_config(app_, "FF_BOUNCE_RATE_V15", FF_BOUNCE_RATE_V15):
+        threshold = app_.config["BR_DISPLAY_VOLUME_MINIMUM"]
 
-            mock_data = [
-                {
-                    "count": (threshold - 20) * 0.5,
-                    "is_precompiled_letter": False,
-                    "status": "delivered",
-                    "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
-                    "template_name": "test",
-                    "template_type": "email",
-                }
-            ]
+        mock_data = [
+            {
+                "count": (threshold - 20) * 0.5,
+                "is_precompiled_letter": False,
+                "status": "delivered",
+                "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
+                "template_name": "test",
+                "template_type": "email",
+            }
+        ]
 
-            mocker.patch(
-                "app.main.views.dashboard.template_statistics_client.get_template_statistics_for_service", return_value=mock_data
-            )
+        mocker.patch(
+            "app.main.views.dashboard.template_statistics_client.get_template_statistics_for_service", return_value=mock_data
+        )
 
-            mocker.patch("app.main.views.dashboard.get_jobs_and_calculate_hard_bounces", return_value=jobs)
-            mocker.patch("app.notification_api_client.get_notifications_for_service", return_value={"notifications": []})
-            page = client_request.get(
-                "main.problem_emails",
-                service_id=service_one["id"],
-            )
+        mocker.patch("app.main.views.dashboard.get_jobs_and_calculate_hard_bounces", return_value=jobs)
+        mocker.patch("app.notification_api_client.get_notifications_for_service", return_value={"notifications": []})
+        page = client_request.get(
+            "main.problem_emails",
+            service_id=service_one["id"],
+        )
 
-            # ensure the number of CSVs displayed on this page correspond to what is found in the jobs data
-            assert len(page.select_one(".ajax-block-container .list.list-bullet").find_all("li")) == expected_problem_list_count
+        # ensure the number of CSVs displayed on this page correspond to what is found in the jobs data
+        assert len(page.select_one(".ajax-block-container .list.list-bullet").find_all("li")) == expected_problem_list_count
 
 
 @pytest.mark.parametrize(
@@ -711,31 +705,30 @@ def test_review_problem_emails_shows_one_offs_when_problem_emails_exist(
     ],
 )
 def test_review_problem_emails_checks_problem_filter_checkbox(mocker, service_one, app_, client_request, jobs):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        threshold = app_.config["BR_DISPLAY_VOLUME_MINIMUM"]
+    threshold = app_.config["BR_DISPLAY_VOLUME_MINIMUM"]
 
-        mock_data = [
-            {
-                "count": (threshold - 20) * 0.5,
-                "is_precompiled_letter": False,
-                "status": "delivered",
-                "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
-                "template_name": "test",
-                "template_type": "email",
-            }
-        ]
+    mock_data = [
+        {
+            "count": (threshold - 20) * 0.5,
+            "is_precompiled_letter": False,
+            "status": "delivered",
+            "template_id": "2156a57e-efd7-4531-b8f4-e7e0c64c03dc",
+            "template_name": "test",
+            "template_type": "email",
+        }
+    ]
 
-        mocker.patch(
-            "app.main.views.dashboard.template_statistics_client.get_template_statistics_for_service", return_value=mock_data
-        )
+    mocker.patch(
+        "app.main.views.dashboard.template_statistics_client.get_template_statistics_for_service", return_value=mock_data
+    )
 
-        mocker.patch("app.main.views.dashboard.get_jobs_and_calculate_hard_bounces", return_value=jobs)
-        mocker.patch("app.notification_api_client.get_notifications_for_service", return_value={"notifications": []})
-        page = client_request.get(
-            "main.problem_emails",
-            service_id=service_one["id"],
-        )
+    mocker.patch("app.main.views.dashboard.get_jobs_and_calculate_hard_bounces", return_value=jobs)
+    mocker.patch("app.notification_api_client.get_notifications_for_service", return_value={"notifications": []})
+    page = client_request.get(
+        "main.problem_emails",
+        service_id=service_one["id"],
+    )
 
-        # ensure the number of CSVs displayed on this page correspond to what is found in the jobs data
-        assert "pe_filter=true" in page.select_one(".ajax-block-container .list.list-bullet").select_one("li a")["href"]
-        assert "status=permanent-failure" in page.select_one(".ajax-block-container .list.list-bullet").select_one("li a")["href"]
+    # ensure the number of CSVs displayed on this page correspond to what is found in the jobs data
+    assert "pe_filter=true" in page.select_one(".ajax-block-container .list.list-bullet").select_one("li a")["href"]
+    assert "status=permanent-failure" in page.select_one(".ajax-block-container .list.list-bullet").select_one("li a")["href"]

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1,7 +1,7 @@
 import copy
 
 import pytest
-from flask import g, url_for
+from flask import url_for
 from freezegun import freeze_time
 
 from app.main.views.dashboard import (
@@ -20,7 +20,6 @@ from tests.conftest import (
     create_active_caseworking_user,
     create_active_user_view_permissions,
     normalize_spaces,
-    set_config,
 )
 
 stub_template_stats = [

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -257,63 +257,6 @@ def test_no_sending_link_if_no_templates(
     assert "Reuse a message you’ve already created." not in str(page)
 
 
-# -----------------
-# remove the following test when FF_BOUNCE_RATE_V1 is removed
-# -----------------
-def test_should_show_recent_templates_on_dashboard_REMOVE(
-    client_request,
-    mocker,
-    mock_get_service_templates,
-    mock_get_jobs,
-    mock_get_service_statistics,
-    mock_get_usage,
-    mock_get_inbound_sms_summary,
-    app_,
-):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", False):
-
-        class FakeService:
-            id = "123"
-
-        g.current_service = FakeService()
-
-        mock_template_stats = mocker.patch(
-            "app.template_statistics_client.get_template_statistics_for_service",
-            return_value=copy.deepcopy(stub_template_stats),
-        )
-
-        page = client_request.get(
-            "main.service_dashboard",
-            service_id=SERVICE_ONE_ID,
-        )
-
-        mock_template_stats.assert_any_call(SERVICE_ONE_ID, limit_days=7)
-        mock_template_stats.assert_any_call(SERVICE_ONE_ID, limit_days=1)
-
-        headers = [header.text.strip() for header in page.find_all("h2") + page.find_all("h1")]
-        assert "Sent in the last week" in headers
-
-        table_rows = page.find_all("tbody")[1].find_all("tr")
-
-        assert len(table_rows) == 4
-
-        assert "Provided as PDF" in table_rows[0].find_all("th")[0].text
-        assert "Letter" in table_rows[0].find_all("th")[0].text
-        assert "400" in table_rows[0].find_all("td")[0].text
-
-        assert "three" in table_rows[1].find_all("th")[0].text
-        assert "Letter template" in table_rows[1].find_all("th")[0].text
-        assert "300" in table_rows[1].find_all("td")[0].text
-
-        assert "two" in table_rows[2].find_all("th")[0].text
-        assert "Email template" in table_rows[2].find_all("th")[0].text
-        assert "200" in table_rows[2].find_all("td")[0].text
-
-        assert "one" in table_rows[3].find_all("th")[0].text
-        assert "Text message template" in table_rows[3].find_all("th")[0].text
-        assert "100" in table_rows[3].find_all("td")[0].text
-
-
 def test_should_show_recent_templates_on_dashboard(
     client_request,
     mocker,
@@ -324,42 +267,41 @@ def test_should_show_recent_templates_on_dashboard(
     mock_get_inbound_sms_summary,
     app_,
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        mock_template_stats = mocker.patch(
-            "app.template_statistics_client.get_template_statistics_for_service",
-            return_value=copy.deepcopy(stub_template_stats),
-        )
+    mock_template_stats = mocker.patch(
+        "app.template_statistics_client.get_template_statistics_for_service",
+        return_value=copy.deepcopy(stub_template_stats),
+    )
 
-        page = client_request.get(
-            "main.service_dashboard",
-            service_id=SERVICE_ONE_ID,
-        )
+    page = client_request.get(
+        "main.service_dashboard",
+        service_id=SERVICE_ONE_ID,
+    )
 
-        mock_template_stats.assert_any_call(SERVICE_ONE_ID, limit_days=7)
-        mock_template_stats.assert_any_call(SERVICE_ONE_ID, limit_days=1)
+    mock_template_stats.assert_any_call(SERVICE_ONE_ID, limit_days=7)
+    mock_template_stats.assert_any_call(SERVICE_ONE_ID, limit_days=1)
 
-        headers = [header.text.strip() for header in page.find_all("h2") + page.find_all("h1")]
-        assert "Email in the last 24 hours" in headers
+    headers = [header.text.strip() for header in page.find_all("h2") + page.find_all("h1")]
+    assert "Email in the last 24 hours" in headers
 
-        table_rows = page.find_all("tbody")[1].find_all("tr")
+    table_rows = page.find_all("tbody")[1].find_all("tr")
 
-        assert len(table_rows) == 4
+    assert len(table_rows) == 4
 
-        assert "Provided as PDF" in table_rows[0].find_all("th")[0].text
-        assert "Letter" in table_rows[0].find_all("th")[0].text
-        assert "400" in table_rows[0].find_all("td")[0].text
+    assert "Provided as PDF" in table_rows[0].find_all("th")[0].text
+    assert "Letter" in table_rows[0].find_all("th")[0].text
+    assert "400" in table_rows[0].find_all("td")[0].text
 
-        assert "three" in table_rows[1].find_all("th")[0].text
-        assert "Letter template" in table_rows[1].find_all("th")[0].text
-        assert "300" in table_rows[1].find_all("td")[0].text
+    assert "three" in table_rows[1].find_all("th")[0].text
+    assert "Letter template" in table_rows[1].find_all("th")[0].text
+    assert "300" in table_rows[1].find_all("td")[0].text
 
-        assert "two" in table_rows[2].find_all("th")[0].text
-        assert "Email template" in table_rows[2].find_all("th")[0].text
-        assert "200" in table_rows[2].find_all("td")[0].text
+    assert "two" in table_rows[2].find_all("th")[0].text
+    assert "Email template" in table_rows[2].find_all("th")[0].text
+    assert "200" in table_rows[2].find_all("td")[0].text
 
-        assert "one" in table_rows[3].find_all("th")[0].text
-        assert "Text message template" in table_rows[3].find_all("th")[0].text
-        assert "100" in table_rows[3].find_all("td")[0].text
+    assert "one" in table_rows[3].find_all("th")[0].text
+    assert "Text message template" in table_rows[3].find_all("th")[0].text
+    assert "100" in table_rows[3].find_all("td")[0].text
 
 
 @freeze_time("2016-07-01 12:00")  # 4 months into 2016 financial year
@@ -564,79 +506,6 @@ def test_daily_usage_section_shown(
         assert "text messages  left today" not in big_number_labels
 
 
-# -----------------
-# remove the following test when FF_BOUNCE_RATE_V1 is removed
-# -----------------
-@pytest.mark.parametrize(
-    "permissions, totals, big_number_class, expected_column_count",
-    [
-        (
-            ["email", "sms"],
-            {
-                "email": {"requested": 0, "delivered": 0, "failed": 0},
-                "sms": {"requested": 999999999, "delivered": 0, "failed": 0},
-            },
-            ".big-number",
-            2,
-        ),
-        (
-            ["email", "sms"],
-            {
-                "email": {"requested": 1000000000, "delivered": 0, "failed": 0},
-                "sms": {"requested": 1000000, "delivered": 0, "failed": 0},
-            },
-            ".big-number-dark",
-            2,
-        ),
-        (
-            ["email", "sms", "letter"],
-            {
-                "email": {"requested": 0, "delivered": 0, "failed": 0},
-                "sms": {"requested": 99999, "delivered": 0, "failed": 0},
-                "letter": {"requested": 99999, "delivered": 0, "failed": 0},
-            },
-            ".big-number",
-            3,
-        ),
-        (
-            ["email", "sms", "letter"],
-            {
-                "email": {"requested": 0, "delivered": 0, "failed": 0},
-                "sms": {"requested": 0, "delivered": 0, "failed": 0},
-                "letter": {"requested": 100000, "delivered": 0, "failed": 0},
-            },
-            ".big-number-dark",
-            3,
-        ),
-    ],
-)
-def test_correct_font_size_for_big_numbers_REMOVE(
-    client_request,
-    mocker,
-    mock_get_service_templates,
-    mock_get_template_statistics,
-    mock_get_service_statistics,
-    mock_get_jobs,
-    service_one,
-    permissions,
-    totals,
-    big_number_class,
-    expected_column_count,
-    app_,
-):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", False):
-        service_one["permissions"] = permissions
-
-        mocker.patch("app.main.views.dashboard.get_dashboard_totals", return_value=totals)
-
-        page = client_request.get(
-            "main.service_dashboard",
-            service_id=service_one["id"],
-        )
-
-        assert expected_column_count == len(page.select(".big-number-with-status {}".format(big_number_class)))
-
-
 @pytest.mark.parametrize(
     "permissions, totals, big_number_class, expected_column_count",
     [
@@ -694,106 +563,16 @@ def test_correct_font_size_for_big_numbers(
     expected_column_count,
     app_,
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        service_one["permissions"] = permissions
+    service_one["permissions"] = permissions
 
-        mocker.patch("app.main.views.dashboard.get_dashboard_totals", return_value=totals)
+    mocker.patch("app.main.views.dashboard.get_dashboard_totals", return_value=totals)
 
-        page = client_request.get(
-            "main.service_dashboard",
-            service_id=service_one["id"],
-        )
+    page = client_request.get(
+        "main.service_dashboard",
+        service_id=service_one["id"],
+    )
 
-        assert expected_column_count == len(page.select(".big-number-with-status {}".format(big_number_class)))
-
-
-# -----------------
-# remove the following test when FF_BOUNCE_RATE_V1 is removed
-# -----------------
-@pytest.mark.parametrize(
-    "permissions, totals, expected_big_numbers_single_plural, lang",
-    [
-        (
-            ["email", "sms"],
-            {
-                "email": {"requested": 0, "delivered": 0, "failed": 0},
-                "sms": {"requested": 0, "delivered": 0, "failed": 0},
-            },
-            ("0 emails sent No failures", "0 text messages sent No failures"),
-            "en",
-        ),
-        (
-            ["email", "sms"],
-            {
-                "email": {"requested": 0, "delivered": 0, "failed": 0},
-                "sms": {"requested": 0, "delivered": 0, "failed": 0},
-            },
-            ("0 courriel envoyé Aucun échec", "0 message texte envoyé Aucun échec"),
-            "fr",
-        ),
-        (
-            ["email", "sms"],
-            {
-                "email": {"requested": 1, "delivered": 1, "failed": 0},
-                "sms": {"requested": 1, "delivered": 1, "failed": 0},
-            },
-            ("1 email sent No failures", "1 text message sent No failures"),
-            "en",
-        ),
-        (
-            ["email", "sms"],
-            {
-                "email": {"requested": 1, "delivered": 1, "failed": 0},
-                "sms": {"requested": 1, "delivered": 1, "failed": 0},
-            },
-            ("1 courriel envoyé Aucun échec", "1 message texte envoyé Aucun échec"),
-            "fr",
-        ),
-        (
-            ["email", "sms"],
-            {
-                "email": {"requested": 2, "delivered": 2, "failed": 0},
-                "sms": {"requested": 2, "delivered": 2, "failed": 0},
-            },
-            ("2 emails sent No failures", "2 text messages sent No failures"),
-            "en",
-        ),
-        (
-            ["email", "sms"],
-            {
-                "email": {"requested": 2, "delivered": 2, "failed": 0},
-                "sms": {"requested": 2, "delivered": 2, "failed": 0},
-            },
-            ("2 courriels envoyés Aucun échec", "2 messages texte envoyés Aucun échec"),
-            "fr",
-        ),
-    ],
-)
-def test_dashboard_single_and_plural_REMOVE(
-    client_request,
-    mocker,
-    mock_get_service_templates,
-    mock_get_template_statistics,
-    mock_get_service_statistics,
-    mock_get_jobs,
-    service_one,
-    permissions,
-    totals,
-    expected_big_numbers_single_plural,
-    lang,
-    app_,
-):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", False):
-        service_one["permissions"] = permissions
-
-        mocker.patch("app.main.views.dashboard.get_dashboard_totals", return_value=totals)
-
-        page = client_request.get("main.service_dashboard", service_id=service_one["id"], lang=lang)
-
-        assert (
-            normalize_spaces(page.select(".big-number-with-status")[0].text),
-            normalize_spaces(page.select(".big-number-with-status")[1].text),
-        ) == expected_big_numbers_single_plural
+    assert expected_column_count == len(page.select(".big-number-with-status {}".format(big_number_class)))
 
 
 @pytest.mark.parametrize(
@@ -881,18 +660,17 @@ def test_dashboard_single_and_plural(
     lang,
     app_,
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        service_one["permissions"] = permissions
+    service_one["permissions"] = permissions
 
-        mocker.patch("app.main.views.dashboard.get_dashboard_totals", return_value=totals)
+    mocker.patch("app.main.views.dashboard.get_dashboard_totals", return_value=totals)
 
-        page = client_request.get("main.service_dashboard", service_id=service_one["id"], lang=lang)
+    page = client_request.get("main.service_dashboard", service_id=service_one["id"], lang=lang)
 
-        assert (
-            normalize_spaces(page.select(".big-number-with-status")[0].text),
-            normalize_spaces(page.select(".big-number-with-status")[1].text),
-            normalize_spaces(page.select(".big-number-with-status")[2].text),
-        ) == expected_big_numbers_single_plural
+    assert (
+        normalize_spaces(page.select(".big-number-with-status")[0].text),
+        normalize_spaces(page.select(".big-number-with-status")[1].text),
+        normalize_spaces(page.select(".big-number-with-status")[2].text),
+    ) == expected_big_numbers_single_plural
 
 
 @freeze_time("2016-01-01 11:09:00.061258")

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -177,9 +177,7 @@ def test_should_show_page_for_one_job(
     )
 
     assert page.h1.text.strip() == "thisisatest.csv"
-    assert " ".join(page.find("tbody").find("tr").text.split()) == (
-        "6502532222 template content No Delivered 11:10:00.061258"
-    )
+    assert " ".join(page.find("tbody").find("tr").text.split()) == ("6502532222 template content No Delivered 11:10:00.061258")
     assert page.find("div", {"data-key": "notifications"})["data-resource"] == url_for(
         "main.view_job_updates",
         service_id=SERVICE_ONE_ID,

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -111,107 +111,6 @@ def test_jobs_page_doesnt_show_scheduled_on_page_2(
         assert normalize_spaces(page.select("tr")[index].text) == row
 
 
-# -----------------
-# remove the following test when FF_BOUNCE_RATE_V1 is removed
-# -----------------
-@pytest.mark.parametrize(
-    "user",
-    [
-        create_active_user_with_permissions,
-        create_active_caseworking_user,
-    ],
-)
-@pytest.mark.parametrize(
-    "status_argument, expected_api_call",
-    [
-        (
-            "",
-            [
-                "created",
-                "pending",
-                "sending",
-                "pending-virus-check",
-                "delivered",
-                "sent",
-                "returned-letter",
-                "failed",
-                "temporary-failure",
-                "permanent-failure",
-                "technical-failure",
-                "virus-scan-failed",
-                "validation-failed",
-            ],
-        ),
-        ("sending", ["sending", "created", "pending", "pending-virus-check"]),
-        ("delivered", ["delivered", "sent", "returned-letter"]),
-        (
-            "failed",
-            [
-                "failed",
-                "temporary-failure",
-                "permanent-failure",
-                "technical-failure",
-                "virus-scan-failed",
-                "validation-failed",
-            ],
-        ),
-    ],
-)
-@freeze_time("2016-01-01 11:09:00.061258")
-def test_should_show_page_for_one_job_REMOVE(
-    client_request,
-    active_user_with_permissions,
-    mock_get_service_template,
-    mock_get_job,
-    mocker,
-    mock_get_notifications,
-    mock_get_service_data_retention,
-    fake_uuid,
-    status_argument,
-    expected_api_call,
-    user,
-    app_,
-):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", False):
-        page = client_request.get(
-            "main.view_job",
-            service_id=SERVICE_ONE_ID,
-            job_id=fake_uuid,
-            status=status_argument,
-        )
-
-        assert page.h1.text.strip() == "thisisatest.csv"
-        assert " ".join(page.find("tbody").find("tr").text.split()) == ("6502532222 template content Delivered 11:10:00.061258")
-        assert page.find("div", {"data-key": "notifications"})["data-resource"] == url_for(
-            "main.view_job_updates",
-            service_id=SERVICE_ONE_ID,
-            job_id=fake_uuid,
-            status=status_argument,
-            pe_filter="",
-        )
-        csv_link = page.select_one("a[download]")
-        assert csv_link["href"] == url_for(
-            "main.view_job_csv",
-            service_id=SERVICE_ONE_ID,
-            job_id=fake_uuid,
-            status=status_argument,
-        )
-        assert csv_link.text == "Download this report"
-        assert page.find("span", {"id": "time-left"}).text.split(" ")[0] == "2016-01-09"
-
-        assert normalize_spaces(page.select_one("tbody tr").text) == normalize_spaces(
-            "6502532222 " "template content " "Delivered 11:10:00.061258"
-        )
-        assert page.select_one("tbody tr a")["href"] == url_for(
-            "main.view_notification",
-            service_id=SERVICE_ONE_ID,
-            notification_id=sample_uuid(),
-            from_job=fake_uuid,
-        )
-
-        mock_get_notifications.assert_called_with(SERVICE_ONE_ID, fake_uuid, status=expected_api_call)
-
-
 @pytest.mark.parametrize(
     "user",
     [
@@ -270,46 +169,45 @@ def test_should_show_page_for_one_job(
     user,
     app_,
 ):
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        page = client_request.get(
-            "main.view_job",
-            service_id=SERVICE_ONE_ID,
-            job_id=fake_uuid,
-            status=status_argument,
-        )
+    page = client_request.get(
+        "main.view_job",
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+        status=status_argument,
+    )
 
-        assert page.h1.text.strip() == "thisisatest.csv"
-        assert " ".join(page.find("tbody").find("tr").text.split()) == (
-            "6502532222 template content No Delivered 11:10:00.061258"
-        )
-        assert page.find("div", {"data-key": "notifications"})["data-resource"] == url_for(
-            "main.view_job_updates",
-            service_id=SERVICE_ONE_ID,
-            job_id=fake_uuid,
-            status=status_argument,
-            pe_filter="",
-        )
-        csv_link = page.select_one("a[download]")
-        assert csv_link["href"] == url_for(
-            "main.view_job_csv",
-            service_id=SERVICE_ONE_ID,
-            job_id=fake_uuid,
-            status=status_argument,
-        )
-        assert csv_link.text == "Download this report"
-        assert page.find("span", {"id": "time-left"}).text.split(" ")[0] == "2016-01-09"
+    assert page.h1.text.strip() == "thisisatest.csv"
+    assert " ".join(page.find("tbody").find("tr").text.split()) == (
+        "6502532222 template content No Delivered 11:10:00.061258"
+    )
+    assert page.find("div", {"data-key": "notifications"})["data-resource"] == url_for(
+        "main.view_job_updates",
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+        status=status_argument,
+        pe_filter="",
+    )
+    csv_link = page.select_one("a[download]")
+    assert csv_link["href"] == url_for(
+        "main.view_job_csv",
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+        status=status_argument,
+    )
+    assert csv_link.text == "Download this report"
+    assert page.find("span", {"id": "time-left"}).text.split(" ")[0] == "2016-01-09"
 
-        assert normalize_spaces(page.select_one("tbody tr").text) == normalize_spaces(
-            "6502532222 " "template content " "No " "Delivered 11:10:00.061258"
-        )
-        assert page.select_one("tbody tr a")["href"] == url_for(
-            "main.view_notification",
-            service_id=SERVICE_ONE_ID,
-            notification_id=sample_uuid(),
-            from_job=fake_uuid,
-        )
+    assert normalize_spaces(page.select_one("tbody tr").text) == normalize_spaces(
+        "6502532222 " "template content " "No " "Delivered 11:10:00.061258"
+    )
+    assert page.select_one("tbody tr a")["href"] == url_for(
+        "main.view_notification",
+        service_id=SERVICE_ONE_ID,
+        notification_id=sample_uuid(),
+        from_job=fake_uuid,
+    )
 
-        mock_get_notifications.assert_called_with(SERVICE_ONE_ID, fake_uuid, status=expected_api_call)
+    mock_get_notifications.assert_called_with(SERVICE_ONE_ID, fake_uuid, status=expected_api_call)
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
@@ -882,11 +780,10 @@ class TestBounceRate:
         fake_uuid,
         app_,
     ):
-        with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-            page = client_request.get(
-                "main.view_job",
-                service_id=SERVICE_ONE_ID,
-                job_id=fake_uuid,
-            )
+        page = client_request.get(
+            "main.view_job",
+            service_id=SERVICE_ONE_ID,
+            job_id=fake_uuid,
+        )
 
-            assert len(page.find(id="pe_filter")) is not None
+        assert len(page.find(id="pe_filter")) is not None

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -15,7 +15,6 @@ from tests.conftest import (
     create_template,
     mock_get_notifications,
     normalize_spaces,
-    set_config,
 )
 
 

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -89,117 +89,24 @@ def test_notification_status_page_shows_details_new_statuses(
 ):
     mocker.patch("app.user_api_client.get_user", return_value=user)
 
-    with set_config(app_, "FF_BOUNCE_RATE_V1", True):
-        notification = create_notification(
-            notification_status=notification_status,
-            notification_provider_response=provider_response,
-            key_type=key_type,
-        )
-        _mock_get_notification = mocker.patch("app.notification_api_client.get_notification", return_value=notification)
+    notification = create_notification(
+        notification_status=notification_status,
+        notification_provider_response=provider_response,
+        key_type=key_type,
+    )
+    _mock_get_notification = mocker.patch("app.notification_api_client.get_notification", return_value=notification)
 
-        page = client_request.get(
-            "main.view_notification",
-            service_id=service_one["id"],
-            notification_id=fake_uuid,
-        )
+    page = client_request.get(
+        "main.view_notification",
+        service_id=service_one["id"],
+        notification_id=fake_uuid,
+    )
 
-        assert normalize_spaces(page.select(".sms-message-recipient")[0].text) == ("To: 6502532222")
-        assert normalize_spaces(page.select(".sms-message-wrapper")[0].text) == ("service one: hello Jo")
-        assert normalize_spaces(page.select(".ajax-block-container p")[0].text) == (expected_status)
+    assert normalize_spaces(page.select(".sms-message-recipient")[0].text) == ("To: 6502532222")
+    assert normalize_spaces(page.select(".sms-message-wrapper")[0].text) == ("service one: hello Jo")
+    assert normalize_spaces(page.select(".ajax-block-container p")[0].text) == (expected_status)
 
-        _mock_get_notification.assert_called_with(service_one["id"], fake_uuid)
-
-
-# --------------------------------------------------------------------
-# remove the following test when FF_BOUNCE_RATE_V1 is removed
-# --------------------------------------------------------------------
-@pytest.mark.parametrize(
-    "key_type, notification_status, provider_response, expected_status",
-    [
-        (None, "created", None, "Sending"),
-        (None, "sending", None, "Sending"),
-        (None, "delivered", None, "Delivered"),
-        (None, "failed", None, "Failed"),
-        (
-            None,
-            "temporary-failure",
-            None,
-            "Phone number not accepting messages right now",
-        ),
-        (None, "permanent-failure", None, "Phone number does not exist"),
-        (None, "technical-failure", None, "Technical failure"),
-        (
-            None,
-            "technical-failure",
-            "Blocked as spam by phone carrier",
-            "Blocked as spam by phone carrier",
-        ),
-        (
-            None,
-            "permanent-failure",
-            "The email address is on the GC Notify suppression list",
-            "The email address is on the GC Notify suppression list",
-        ),
-        (
-            None,
-            "permanent-failure",
-            "Email address is on our email provider suppression list",
-            "Email address is on our email provider suppression list",
-        ),
-        (
-            None,
-            "temporary-failure",
-            "Email was rejected because of its attachments",
-            "Email was rejected because of its attachments",
-        ),
-        ("team", "delivered", None, "Delivered"),
-        ("live", "delivered", None, "Delivered"),
-        ("test", "sending", None, "Sending (test)"),
-        ("test", "delivered", None, "Delivered (test)"),
-        ("test", "permanent-failure", None, "Phone number does not exist (test)"),
-    ],
-)
-@pytest.mark.parametrize(
-    "user",
-    [
-        create_active_user_with_permissions(),
-        create_active_caseworking_user(),
-    ],
-)
-@freeze_time("2016-01-01 11:09:00.061258")
-def test_notification_status_page_shows_details(
-    client_request,
-    mocker,
-    mock_has_no_jobs,
-    service_one,
-    fake_uuid,
-    user,
-    key_type,
-    notification_status,
-    provider_response,
-    expected_status,
-    app_,
-):
-    mocker.patch("app.user_api_client.get_user", return_value=user)
-    with set_config(app_, "FF_BOUNCE_RATE_V1", False):
-        notification = create_notification(
-            notification_status=notification_status,
-            notification_provider_response=provider_response,
-            key_type=key_type,
-        )
-        _mock_get_notification = mocker.patch("app.notification_api_client.get_notification", return_value=notification)
-
-        page = client_request.get(
-            "main.view_notification",
-            service_id=service_one["id"],
-            notification_id=fake_uuid,
-        )
-
-        assert normalize_spaces(page.select(".sms-message-recipient")[0].text) == ("To: 6502532222")
-        assert normalize_spaces(page.select(".sms-message-wrapper")[0].text) == ("service one: hello Jo")
-        assert normalize_spaces(page.select(".ajax-block-container p")[0].text) == (expected_status)
-
-        _mock_get_notification.assert_called_with(service_one["id"], fake_uuid)
+    _mock_get_notification.assert_called_with(service_one["id"], fake_uuid)
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -16,7 +16,6 @@ from tests.conftest import (
     create_notification,
     mock_get_notification,
     normalize_spaces,
-    set_config,
 )
 
 


### PR DESCRIPTION
# Summary | Résumé

Remove the feature flag for bounce rate V1 - `FF_BOUNCE_RATE_V1` and the A/B testing feature flag: `FF_ABTEST_SERVICE_ID`. This will really simplify our v1.5 release for bounce rate and we will avoid having `if` statements that have to check all three of these feature flags and decide what to do for the different cases. Many of those cases also would make no sense and could create potential bugs - like if `FF_BOUNCE_RATE_V1=False` and `FF_BOUNCE_RATE_V15=True`.

## Reviewing

- Tests should pass in CI
- Searching in the project for the string "FF_BOUNCE_RATE_V1" or "FF_ABTEST_SERVICE_ID" should turn up nothing
- The review app should look and behave the same as what is currently in staging/production, i.e. the bounce rate feature should be visible in the dashboard and elsewhere and work as expected
