### PR TITLE
Add template_type for bounce_rate calculation

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -349,7 +349,7 @@ def calculate_bounce_rate(all_statistics_daily, dashboard_totals_daily):
 
     # get total hard bounces
     for stat in all_statistics_daily:
-        if stat["status"] == "permanent-failure":
+        if stat["status"] == "permanent-failure" and stat["template_type"] == "email":
             bounce_rate.bounce_total += stat["count"]
 
     # calc bounce rate


### PR DESCRIPTION
# Summary | Résumé

We were not filtering on template_type when calculating bounce_rate. With this fix, if there are failed "sms" we will not count them under problem email_addresses
<img width="1146" alt="Screenshot 2023-07-07 at 1 28 59 PM" src="https://github.com/cds-snc/notification-admin/assets/8869623/08fc5a65-c511-4bda-8cb5-306956bb3841">

Testing:
1. locally set up a texting template
1. Use failed_sms_2.csv from here: https://drive.google.com/drive/u/0/folders/17RaYmvnVK1-opdjn71Ha72XkoGoK3YcQ
1. Run the following command on your local db:
```
update notifications set notification_status='permanent-failure' where "to"='4254147167' ;
update notifications set feedback_type='hard-bounce' where "to"='4254147167' ;
update notifications set feedback_subtype='on-account-suppression-list' where "to"='4254147167' ;
update notifications set provider_response='The email address is on the GC Notify suppression list' where "to"='4254147167' ;
```
1. Go to your local admin - you will see that the failed SMSs show up under "Failed email addresses"
1. Switch to this branch
1. You should see the above screenshot

