### PR TITLE
Task/fix email service limits

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -140,6 +140,7 @@ class Config(object):
     FF_SMS_PARTS_UI = env.bool("FF_SMS_PARTS_UI", False)
     FF_BOUNCE_RATE_V15 = env.bool("FF_BOUNCE_RATE_V15", False)
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
+    FF_EMAIL_DAILY_LIMITS = env.bool("FF_EMAIL_DAILY_LIMITS", False)
 
     @classmethod
     def get_sensitive_config(cls) -> list[str]:
@@ -200,6 +201,7 @@ class Test(Development):
     FF_SPIKE_SMS_DAILY_LIMIT = False
     FF_SMS_PARTS_UI = False
     FF_SALESFORCE_CONTACT = False
+    FF_EMAIL_DAILY_LIMITS = True
 
 
 class Production(Config):

--- a/app/config.py
+++ b/app/config.py
@@ -140,7 +140,7 @@ class Config(object):
     FF_SMS_PARTS_UI = env.bool("FF_SMS_PARTS_UI", False)
     FF_BOUNCE_RATE_V15 = env.bool("FF_BOUNCE_RATE_V15", False)
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
-    FF_EMAIL_DAILY_LIMITS = env.bool("FF_EMAIL_DAILY_LIMITS", False)
+    FF_EMAIL_DAILY_LIMIT = env.bool("FF_EMAIL_DAILY_LIMIT", True)
 
     @classmethod
     def get_sensitive_config(cls) -> list[str]:
@@ -201,7 +201,7 @@ class Test(Development):
     FF_SPIKE_SMS_DAILY_LIMIT = False
     FF_SMS_PARTS_UI = False
     FF_SALESFORCE_CONTACT = False
-    FF_EMAIL_DAILY_LIMITS = True
+    FF_EMAIL_DAILY_LIMIT = True
 
 
 class Production(Config):

--- a/app/config.py
+++ b/app/config.py
@@ -140,7 +140,7 @@ class Config(object):
     FF_SMS_PARTS_UI = env.bool("FF_SMS_PARTS_UI", False)
     FF_BOUNCE_RATE_V15 = env.bool("FF_BOUNCE_RATE_V15", False)
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
-    FF_EMAIL_DAILY_LIMIT = env.bool("FF_EMAIL_DAILY_LIMIT", True)
+    FF_EMAIL_DAILY_LIMIT = env.bool("FF_EMAIL_DAILY_LIMIT", False)
 
     @classmethod
     def get_sensitive_config(cls) -> list[str]:
@@ -201,7 +201,7 @@ class Test(Development):
     FF_SPIKE_SMS_DAILY_LIMIT = False
     FF_SMS_PARTS_UI = False
     FF_SALESFORCE_CONTACT = False
-    FF_EMAIL_DAILY_LIMIT = True
+    FF_EMAIL_DAILY_LIMIT = False
 
 
 class Production(Config):

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -272,18 +272,18 @@
           {{ text_field('')}}
         {% endcall %}
 
-        {% call settings_row(if_has_permission='sms', alt_cond=current_service.live) %}
         {% if config["FF_SPIKE_SMS_DAILY_LIMIT"] %}
-          {% set txt = _('Daily text fragments limit') %}
-          {{ text_field(txt)}}
-          {{ text_field(current_service.sms_daily_limit | format_number) }}
-          {{ edit_field(
-            change_txt,
-            url_for('.set_sms_message_limit', service_id=current_service.id),
-            for=txt
-          ) }}
+          {% call settings_row(if_has_permission='sms', alt_cond=current_service.live) %}
+            {% set txt = _('Daily text fragments limit') %}
+            {{ text_field(txt)}}
+            {{ text_field(current_service.sms_daily_limit | format_number) }}
+            {{ edit_field(
+              change_txt,
+              url_for('.set_sms_message_limit', service_id=current_service.id),
+              for=txt
+            ) }}
+          {% endcall %}
         {% endif %}
-        {% endcall %}
 
       {% endcall %}
 

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -95,7 +95,7 @@
           }}
         {% endcall %}
 
-        { %if config["FF_EMAIL_DAILY_LIMIT"] == false %}
+        {% if config["FF_EMAIL_DAILY_LIMIT"] == false %}
           {% call row() %}
             {% set txt = _('Daily message limit') %}
             {{ text_field(txt)}}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -95,7 +95,7 @@
           }}
         {% endcall %}
 
-        {%if config["FF_EMAIL_DAILY_LIMIT"] == false %}
+        { %if config["FF_EMAIL_DAILY_LIMIT"] == false %}
           {% call row() %}
             {% set txt = _('Daily message limit') %}
             {{ text_field(txt)}}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -104,16 +104,7 @@
             {{ text_field('') }}
           {% endcall %}
         {% endif %}
-        
-        {% if config["FF_SPIKE_SMS_DAILY_LIMIT"] %}
-          {% call row() %}
-            {% set txt = _('Daily text fragments limit') %}
-            {{ text_field(txt)}}
-            {% set sms_daily_limit = _('{} fragments').format(current_service.sms_daily_limit | format_number) %}
-            {{ text_field(sms_daily_limit) }}
-            {{ text_field('') }}
-          {% endcall %}
-        {% endif %}
+
         {% call row() %}
           {% set txt = _('API rate limit per minute') %}
           {{ text_field(txt) }}
@@ -280,8 +271,21 @@
           {{ text_field(txt_msg_limit) }}
           {{ text_field('')}}
         {% endcall %}
-      {% endcall %}
 
+        {% call settings_row(if_has_permission='sms', alt_cond=current_service.live) %}
+        {% if config["FF_SPIKE_SMS_DAILY_LIMIT"] %}
+          {% set txt = _('Daily text fragments limit') %}
+          {{ text_field(txt)}}
+          {{ text_field(current_service.sms_daily_limit | format_number) }}
+          {{ edit_field(
+            change_txt,
+            url_for('.set_sms_message_limit', service_id=current_service.id),
+            for=txt
+          ) }}
+        {% endif %}
+        {% endcall %}
+
+      {% endcall %}
 
       <p class="mt-12">
         {{ _("Problems, questions, or comments? <a href='{}'>Contact us</a>.").format(url_for('.contact')) }}
@@ -375,19 +379,6 @@
               for=txt
             ) }}
           {% endcall %}
-          
-          {% if config["FF_SPIKE_SMS_DAILY_LIMIT"] %}
-            {% call row() %}
-              {% set txt = _('Daily text fragments limit') %}
-              {{ text_field(txt)}}
-              {{ text_field(current_service.sms_daily_limit | format_number) }}
-              {{ edit_field(
-                change_txt, 
-                url_for('.set_sms_message_limit', service_id=current_service.id),
-                for=txt
-              ) }}
-            {% endcall %}
-          {% endif %}
 
           {% call row() %}
             {% set txt = _('API rate limit per minute') %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -205,6 +205,15 @@
           {{ text_field(annual_limit) }}
           {{ text_field('')}}
         {% endcall %}
+        {% if config["FF_EMAIL_DAILY_LIMITS"] %}
+          {% call settings_row(if_has_permission='email', alt_cond=current_service.live) %}
+            {% set txt = _('Daily message limit') %}
+            {{ text_field(txt)}}
+            {% set message_limit = _('{} notifications').format(current_service.message_limit | format_number) %}
+            {{ text_field(message_limit) }}
+            {{ text_field('') }}
+            {% endcall %}
+        {% endif %}
       {% endcall %}
 
       {% set caption = _('Text messages') %}
@@ -351,16 +360,18 @@
             ) }}
           {% endcall %}
 
-          {% call row() %}
-            {% set txt = _('Daily message limit') %}
-            {{ text_field(txt)}}
-            {{ text_field(current_service.message_limit | format_number) }}
-            {{ edit_field(
-              change_txt, 
-              url_for('.set_message_limit', service_id=current_service.id),
-              for=txt
-            ) }}
-          {% endcall %}
+          {%if not config["FF_EMAIL_DAILY_LIMITS"] %}
+            {% call row() %}
+              {% set txt = _('Daily message limit') %}
+              {{ text_field(txt)}}
+              {{ text_field(current_service.message_limit | format_number) }}
+              {{ edit_field(
+                change_txt,
+                url_for('.set_message_limit', service_id=current_service.id),
+                for=txt
+              ) }}
+            {% endcall %}
+          {% endif %}
           
           {% if config["FF_SPIKE_SMS_DAILY_LIMIT"] %}
             {% call row() %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -95,7 +95,7 @@
           }}
         {% endcall %}
 
-        {%if config["FF_EMAIL_DAILY_LIMIT"] == false] %}
+        {%if config["FF_EMAIL_DAILY_LIMIT"] == false %}
           {% call row() %}
             {% set txt = _('Daily message limit') %}
             {{ text_field(txt)}}
@@ -208,9 +208,9 @@
         {% endcall %}
         {% if config["FF_EMAIL_DAILY_LIMIT"] %}
           {% call settings_row(if_has_permission='email', alt_cond=current_service.live) %}
-            {% set txt = _('Daily message limit') %}
+            {% set txt = _('Daily email limit') %}
             {{ text_field(txt)}}
-            {% set message_limit = _('{} notifications').format(current_service.message_limit | format_number) %}
+            {% set message_limit = _('{} emails').format(current_service.message_limit | format_number) %}
             {{ text_field(message_limit) }}
             {{ text_field('') }}
             {% endcall %}
@@ -361,18 +361,20 @@
             ) }}
           {% endcall %}
 
-          {%if config["FF_EMAIL_DAILY_LIMIT"] == false %}
-            {% call row() %}
+          {% call row() %}
+            {%if config["FF_EMAIL_DAILY_LIMIT"] == false %}
               {% set txt = _('Daily message limit') %}
-              {{ text_field(txt)}}
-              {{ text_field(current_service.message_limit | format_number) }}
-              {{ edit_field(
-                change_txt,
-                url_for('.set_message_limit', service_id=current_service.id),
-                for=txt
-              ) }}
-            {% endcall %}
-          {% endif %}
+            {% else %}
+              {% set txt = _('Daily email limit') %}
+            {% endif %}
+            {{ text_field(txt)}}
+            {{ text_field(current_service.message_limit | format_number) }}
+            {{ edit_field(
+              change_txt,
+              url_for('.set_message_limit', service_id=current_service.id),
+              for=txt
+            ) }}
+          {% endcall %}
           
           {% if config["FF_SPIKE_SMS_DAILY_LIMIT"] %}
             {% call row() %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -95,14 +95,15 @@
           }}
         {% endcall %}
 
-        {% call row() %}
-        
-          {% set txt = _('Daily message limit') %}
-          {{ text_field(txt)}}
-          {% set message_limit = _('{} notifications').format(current_service.message_limit | format_number) %}
-          {{ text_field(message_limit) }}
-          {{ text_field('') }}
-        {% endcall %}
+        {%if config["FF_EMAIL_DAILY_LIMIT"] == false] %}
+          {% call row() %}
+            {% set txt = _('Daily message limit') %}
+            {{ text_field(txt)}}
+            {% set message_limit = _('{} notifications').format(current_service.message_limit | format_number) %}
+            {{ text_field(message_limit) }}
+            {{ text_field('') }}
+          {% endcall %}
+        {% endif %}
         
         {% if config["FF_SPIKE_SMS_DAILY_LIMIT"] %}
           {% call row() %}
@@ -205,7 +206,7 @@
           {{ text_field(annual_limit) }}
           {{ text_field('')}}
         {% endcall %}
-        {% if config["FF_EMAIL_DAILY_LIMITS"] %}
+        {% if config["FF_EMAIL_DAILY_LIMIT"] %}
           {% call settings_row(if_has_permission='email', alt_cond=current_service.live) %}
             {% set txt = _('Daily message limit') %}
             {{ text_field(txt)}}
@@ -360,7 +361,7 @@
             ) }}
           {% endcall %}
 
-          {%if not config["FF_EMAIL_DAILY_LIMITS"] %}
+          {%if config["FF_EMAIL_DAILY_LIMIT"] == false %}
             {% call row() %}
               {% set txt = _('Daily message limit') %}
               {{ text_field(txt)}}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1053,6 +1053,7 @@
 "Copy an existing template","Copier un gabarit existant"
 "Delete this folder","Supprimer ce dossier"
 "Daily message limit","Limite d'envoi quotidienne"
+"Daily email limit","Limite quotidienne d'envoi par courriel"
 "Daily email message limit","Limite quotidienne d'envoi par courriel"
 "Daily text fragments limit","Limite quotidienne de fragments de message texte"
 "Last edited","Dernière modification&nbsp;: "

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -153,6 +153,8 @@ def test_should_show_overview(
         rows = page.select("tr")
         for index, row in enumerate(expected_rows):
             formatted_row = row.format(sending_domain=sending_domain or app_.config["SENDING_DOMAIN"])
+            if app_.config["FF_EMAIL_DAILY_LIMIT"] and formatted_row == "Daily message limit 1,000 notifications":
+                formatted_row = "Daily email limit 1,000 notifications"
             visible = rows[index]
             sr_only = visible.find("span", "sr-only")
             if sr_only:


### PR DESCRIPTION
# Summary | Résumé
Update the settings page to change "Daily message limit" to "Daily email limit"

- [x] Moved the Daily message limit to Daily email limit -> and moved it to under "Emails"
- [x] Moved the Daily text limit -> and moved it to under "Text messages"
- [x] Under platform settings changed Daily message limit -> Daily email limit

Previously:
<img width="1043" alt="Screenshot 2023-07-11 at 2 56 17 PM" src="https://github.com/cds-snc/notification-admin/assets/8869623/23c06a2f-0fdc-457c-8b85-0eb6c3e1540d">
<img width="1117" alt="Screenshot 2023-07-11 at 2 56 07 PM" src="https://github.com/cds-snc/notification-admin/assets/8869623/1ad70e11-b45f-4925-8757-01202265e9b4">

With my change:
<img width="1136" alt="Screenshot 2023-07-11 at 3 39 52 PM" src="https://github.com/cds-snc/notification-admin/assets/8869623/284d33d9-76ec-48be-bb5d-d4066d6fd817">
<img width="1147" alt="Screenshot 2023-07-11 at 3 39 41 PM" src="https://github.com/cds-snc/notification-admin/assets/8869623/305b3a2a-d782-4b41-a645-763342909fc5">


Testing:

Change the config locally - you should be able to see the changes of "Daily email limit" vs "Daily notifications limit"

