### PR TITLE
Fix the AJAX auto update of dashboard stats

### DIFF
--- a/app/templates/views/dashboard/_totals.html
+++ b/app/templates/views/dashboard/_totals.html
@@ -8,14 +8,14 @@
 
 {% set address_single = _('address') %}
 {% set address_plural = _('addresses') %}
-<h2 class="heading-medium mt-8">
-  {% if config["FF_BOUNCE_RATE_V15"] %}
-    {{ _("Sent in the last week") }}
-  {% else %}
-    {{ _("Email in the last 24 hours") }}
-  {% endif %}
-</h2>
 <div class="ajax-block-container">
+  <h2 class="heading-medium mt-8">
+    {% if config["FF_BOUNCE_RATE_V15"] %}
+      {{ _("Sent in the last week") }}
+    {% else %}
+      {{ _("Email in the last 24 hours") }}
+    {% endif %}
+  </h2>
   <div class="grid-row contain-floats">
     <div id="total-email" class="{{column_width}}">
       {{ big_number_with_status(


### PR DESCRIPTION
# Summary | Résumé

Adding the `h2` back to the `ajax-block-container` somehow fixes the auto updating.

# Test instructions | Instructions pour tester la modification

Log into the review app, bulk send through the api, observe that the total email sent auto-updates within a few seconds.