### PR TITLE
Change to weekly stats if v15 feature flag is true

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -264,6 +264,8 @@ def get_dashboard_partials(service_id):
     column_width, max_notifiction_count = get_column_properties(
         number_of_columns=(3 if current_service.has_permission("letter") else 2)
     )
+    stats_weekly = aggregate_notifications_stats(all_statistics_weekly)
+    dashboard_totals_weekly = (get_dashboard_totals(stats_weekly),)
     bounce_rate_data = (
         get_bounce_rate_data_from_redis(service_id)
         if current_app.config["FF_BOUNCE_RATE_V15"]
@@ -281,7 +283,7 @@ def get_dashboard_partials(service_id):
         "weekly_totals": render_template(
             "views/dashboard/_totals.html",
             service_id=service_id,
-            statistics=dashboard_totals_daily[0],
+            statistics=dashboard_totals_weekly[0] if current_app.config["FF_BOUNCE_RATE_V15"] else dashboard_totals_daily[0],
             column_width=column_width,
             smaller_font_size=(highest_notification_count_daily > max_notifiction_count),
             bounce_rate=bounce_rate_data,


### PR DESCRIPTION
# Summary | Résumé

We forgot to update the time period for "emails sent" and "text messages sent to 1 week. Thanks for catching this in your QA @andrewleith!

# Test instructions | Instructions pour tester la modification

Using the review app, visit Andrew's service (id: b9d1d40c-8029-48b9-b872-0c139812b7be) and observe that the number on the dashboard now match the details screen:

Dashboard:
<img width="1075" alt="Screenshot 2023-07-14 at 11 01 41 AM" src="https://github.com/cds-snc/notification-admin/assets/5498428/98f48726-2377-4cdf-8d58-ce57f149424d">

Details:
<img width="1105" alt="Screenshot 2023-07-14 at 11 10 41 AM" src="https://github.com/cds-snc/notification-admin/assets/5498428/0b609ece-ca0f-40ec-875b-77c1261aeb8d">

