### PR TITLE
Revert PyYaml to 5.3.1

### DIFF
--- a/.github/workflows/test_endpoints.yaml
+++ b/.github/workflows/test_endpoints.yaml
@@ -58,7 +58,7 @@ jobs:
         echo "PYTHONPATH=/github/workspace/env/site-packages:${{ env.PYTHONPATH}}" >> $GITHUB_ENV
 
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@89592d2227aa59498262a5bb729f702d57189564 # 52.0.2
+      uses: cds-snc/notification-utils/.github/actions/waffles@a6648e95e64e10315a5aaaf3cc4a0081fd7e68a0 # 52.0.3
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/.github/workflows/test_endpoints.yaml
+++ b/.github/workflows/test_endpoints.yaml
@@ -58,7 +58,7 @@ jobs:
         echo "PYTHONPATH=/github/workspace/env/site-packages:${{ env.PYTHONPATH}}" >> $GITHUB_ENV
 
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@fbd73b322c7e868b6491bc07032af20550a12692 # 50.3.4
+      uses: cds-snc/notification-utils/.github/actions/waffles@11cea097d24c424b86478df7a42408e700bf675d # 52.0.1
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/.github/workflows/test_endpoints.yaml
+++ b/.github/workflows/test_endpoints.yaml
@@ -58,7 +58,7 @@ jobs:
         echo "PYTHONPATH=/github/workspace/env/site-packages:${{ env.PYTHONPATH}}" >> $GITHUB_ENV
 
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@11cea097d24c424b86478df7a42408e700bf675d # 52.0.1
+      uses: cds-snc/notification-utils/.github/actions/waffles@89592d2227aa59498262a5bb729f702d57189564 # 52.0.2
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/poetry.lock
+++ b/poetry.lock
@@ -1452,7 +1452,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "52.0.2"
+version = "52.0.3"
 description = "Shared python code for Notification - Provides logging utils etc."
 category = "main"
 optional = false
@@ -1486,8 +1486,8 @@ werkzeug = "2.3.3"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "52.0.2"
-resolved_reference = "89592d2227aa59498262a5bb729f702d57189564"
+reference = "52.0.3"
+resolved_reference = "1a1948fd882b90341c6817a87310a7314ed0498a"
 
 [[package]]
 name = "openpyxl"
@@ -2498,4 +2498,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.8"
-content-hash = "30f00e8cbfde96e811faec0bbe973ab7fc9ce40d3d371ac26530bee2eba5e9a5"
+content-hash = "9eebfc7b4976470944d81dafb82f77922ea1e1f244fd2eb974f42e97f403f402"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1452,7 +1452,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "52.0.1"
+version = "52.0.2"
 description = "Shared python code for Notification - Provides logging utils etc."
 category = "main"
 optional = false
@@ -1486,8 +1486,8 @@ werkzeug = "2.3.3"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "52.0.1"
-resolved_reference = "9f72224a1771a2f4bd84f4b8c1c0da0e9d5c7ed1"
+reference = "52.0.2"
+resolved_reference = "89592d2227aa59498262a5bb729f702d57189564"
 
 [[package]]
 name = "openpyxl"
@@ -2498,4 +2498,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.8"
-content-hash = "33743bd5e54b6b3be2888ae426e230074dcace582a0e00281a2b821b490a6144"
+content-hash = "30f00e8cbfde96e811faec0bbe973ab7fc9ce40d3d371ac26530bee2eba5e9a5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1452,7 +1452,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "52.0.0"
+version = "52.0.1"
 description = "Shared python code for Notification - Provides logging utils etc."
 category = "main"
 optional = false
@@ -1477,7 +1477,7 @@ py_w3c = "0.3.1"
 pypdf2 = "1.28.6"
 python-json-logger = "2.0.7"
 pytz = "2021.3"
-PyYAML = "5.4.1"
+PyYAML = "5.3.1"
 requests = "2.31.0"
 smartypants = "2.0.1"
 statsd = "3.3.0"
@@ -1486,8 +1486,8 @@ werkzeug = "2.3.3"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "52.0.0"
-resolved_reference = "72b30b85c30249d4676c68badc79a21052a210eb"
+reference = "52.0.1"
+resolved_reference = "9f72224a1771a2f4bd84f4b8c1c0da0e9d5c7ed1"
 
 [[package]]
 name = "openpyxl"
@@ -1984,41 +1984,25 @@ files = [
 
 [[package]]
 name = "pyyaml"
-version = "5.4.1"
+version = "5.3.1"
 description = "YAML parser and emitter for Python"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = "*"
 files = [
-    {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
-    {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
-    {file = "PyYAML-5.4.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8"},
-    {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
-    {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
-    {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
-    {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
-    {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
-    {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
-    {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
-    {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+    {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
+    {file = "PyYAML-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
+    {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 
 [[package]]
@@ -2514,4 +2498,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.8"
-content-hash = "a9a4e618cce62ba064112b0a966121a314e82594d708b200d3f86b56c9053986"
+content-hash = "33743bd5e54b6b3be2888ae426e230074dcace582a0e00281a2b821b490a6144"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Flask-Babel = "2.0.0"
 newrelic = "8.7.0"
 python-dotenv = "0.21.1"
 pwnedpasswords = "2.0.0"
-PyYAML = "5.4.1"
+PyYAML = "5.3.1"
 translate-toolkit = "3.7.4"
 ua-parser = "0.16.1"
 user-agents = "2.2.0"
@@ -60,7 +60,7 @@ awscli-cwlogs = "^1.4.6"
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous = "2.1.2"  # pyup: <1.0.0
 
-notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "52.0.0"}
+notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "52.0.1"}
 
 rsa = "^4.1" # not directly required, pinned by Snyk to avoid a vulnerability
 unidecode = "^1.3.6"
@@ -79,7 +79,7 @@ flake8 = "6.0.0"
 flake8-print = "5.0.0"
 requests-mock = "1.10.0"
 # used for creating manifest file locally
-jinja2-cli = {version = "^0.8.2", extras = ["yaml"]}
+jinja2-cli = { version = "^0.8.2", extras = ["yaml"] }
 black = "23.3.0"
 mypy = "1.4.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ awscli-cwlogs = "^1.4.6"
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous = "2.1.2"  # pyup: <1.0.0
 
-notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "52.0.1"}
+notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "52.0.2"}
 
 rsa = "^4.1" # not directly required, pinned by Snyk to avoid a vulnerability
 unidecode = "^1.3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ awscli-cwlogs = "^1.4.6"
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous = "2.1.2"  # pyup: <1.0.0
 
-notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "52.0.2"}
+notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "52.0.3"}
 
 rsa = "^4.1" # not directly required, pinned by Snyk to avoid a vulnerability
 unidecode = "^1.3.6"


### PR DESCRIPTION
# Summary | Résumé
CPython 3.0 released recently which appears to have [introduced a regression](https://github.com/yaml/pyyaml/issues/601#issuecomment-1011355313) that leads to [failures when installing PyYaml](https://github.com/yaml/pyyaml/issues/724) (and likely other packages). This PR reverts PyYaml to 5.3.1 for the time being until either the regression is corrected or a more appropriate work around is identified by us or the community.