### PR TITLE
Fix the less than 0.1% translation

### DIFF
--- a/app/templates/components/big-number.html
+++ b/app/templates/components/big-number.html
@@ -93,7 +93,7 @@
             <div class="review-email-label p-6 flex justify-between items-end border-0">
               <span>
                 {% if problem_percentage < 0.1 %}
-                  {{ _('Less than')}} {{'0.1%' if session["userlang"] == 'en' else '0,1 %' }}
+                  {{ _('Less than {}').format( '0.1%' if session['userlang'] == 'en' else "0,1&nbsp;%"|safe) }}
                 {% else %}
                   {{ problem_percentage|round(1)|string + "%" if session["userlang"] == 'en' else problem_percentage|round(1)|replace('.', ',')|string + " %"}}
                 {% endif %}


### PR DESCRIPTION
# Summary | Résumé

Bug:
![Screenshot 2023-07-26 at 2 40 40 PM](https://github.com/cds-snc/notification-admin/assets/5498428/76b6a085-8496-45d8-9018-cd8e48178613)

This is fixed in the problem addresses screen so we can grab the code from there:
![Screenshot 2023-07-26 at 2 40 55 PM](https://github.com/cds-snc/notification-admin/assets/5498428/60d4b863-959c-4ac6-967c-97ac2e5f873b)

# Test instructions | Instructions pour tester la modification

Visit this service and verify that the translation is correct: https://jecdvlhsyux3ksknhrnwxmia6m0abbyb.lambda-url.ca-central-1.on.aws/services/a2ab2d38-3edb-4316-987f-33792ecc7b7f

<img width="534" alt="Screenshot 2023-07-26 at 3 05 48 PM" src="https://github.com/cds-snc/notification-admin/assets/5498428/edd5cd93-0446-432c-95c2-4752d2d808cf">
