### PR TITLE
Test/optional workflow experiment2

### DIFF
--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -151,6 +151,7 @@ jobs:
             })
     
   cypress-tests:
+    continue-on-error: true
     runs-on: ubuntu-latest
     needs: deploy-test-admin
     steps:

--- a/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
@@ -50,6 +50,7 @@ describe(`A11Y - App pages [${config.CONFIG_NAME}]`, () => {
                             cy.log('Checking accessibility compliance...')
                             cy.injectAxe();
                             cy.checkA11y();
+                            cy.get('#thing-that-doesnt-exist').should('be.visible');
                         });
                         it('HTML validation', () => {
                             cy.log('Validating HTML...');


### PR DESCRIPTION
# Summary | Résumé

Experiment to see the behaviour of the `continue-on-error` option in a github workflow job.