### PR TITLE
Fix the bounce guidance links to articles

### DIFF
--- a/app/articles/routing.py
+++ b/app/articles/routing.py
@@ -4,7 +4,7 @@ from app.articles import get_current_locale
 
 GC_ARTICLES_ROUTES = {
     "accessibility": {"en": "/accessibility", "fr": "/accessibilite"},
-    "bounce_guidance": {"en": "/updating-contact-information", "fr": "/maintenir-a-jour-les-coordonnees"},
+    "bounce_guidance": {"en": "/keep-accurate-contact-information", "fr": "/maintenez-a-jour-les-coordonnees"},
     "delivery_failure": {"en": "/delivery-and-failure", "fr": "/livraison-reussie-et-echec"},
     "features": {"en": "/features", "fr": "/fonctionnalites"},
     "formatting_guide": {"en": "/formatting-emails", "fr": "/guide-mise-en-forme"},


### PR DESCRIPTION
# Summary | Résumé

The urls in GC Articles changed - this will fix the links from:
- the service dashboard
- the "Review email addresses" page

# Test instructions | Instructions pour tester la modification

1. log in to the review app linked in this PR
2. visit your service dashboard
3. click the link "Guide: keep accurate contact information"
4. verify that the link works
5. visit the service dashboard of a service that has sent some bad emails recently
6. visit the "Review email addresses" page
7. click the link: "Updating contact information"
8. verify that you are sent to the same page as before
9. repeat these steps with your language set to French