### PR TITLE
Make cypress-tests job optional

### DIFF
--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -152,6 +152,7 @@ jobs:
   cypress-tests:
     runs-on: ubuntu-latest
     needs: deploy-test-admin
+    continue-on-error: true
     steps:
       - env: 
           CYPRESS_BASE_URL: ${{needs.deploy-test-admin.outputs.LAMBDA_URL}}


### PR DESCRIPTION
# Summary | Résumé

This PR updates the `cypress-tests` job to be optional so that if they fail the PR can still merge.  Once we are comfortable with the `cypress-tests` job we can turn this back off.