### PR TITLE
Remove bad articles link, switch to the correct one

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -535,7 +535,7 @@ def format_notification_status_as_field_status(status, notification_type):
 
 def format_notification_status_as_url(status, notification_type):
     def url(_anchor):
-        return gca_url_for("delivery_failure") + "#" + _anchor
+        return gca_url_for("message_delivery_status") + "#" + _anchor
 
     if status not in {
         "technical-failure",

--- a/app/articles/routing.py
+++ b/app/articles/routing.py
@@ -5,7 +5,6 @@ from app.articles import get_current_locale
 GC_ARTICLES_ROUTES = {
     "accessibility": {"en": "/accessibility", "fr": "/accessibilite"},
     "bounce_guidance": {"en": "/updating-contact-information", "fr": "/maintenir-a-jour-les-coordonnees"},
-    "delivery_failure": {"en": "/delivery-and-failure", "fr": "/livraison-reussie-et-echec"},
     "features": {"en": "/features", "fr": "/fonctionnalites"},
     "formatting_guide": {"en": "/formatting-emails", "fr": "/guide-mise-en-forme"},
     "guidance": {"en": "/guidance", "fr": "/guides-reference"},

--- a/tests/app/main/test_formatters.py
+++ b/tests/app/main/test_formatters.py
@@ -14,32 +14,32 @@ from app import format_notification_status, format_notification_status_as_url
         (
             "temporary-failure",
             "email",
-            "/delivery-and-failure#email-statuses",
+            "/understanding-delivery-and-failure#email-statuses",
         ),
         (
             "permanent-failure",
             "email",
-            "/delivery-and-failure#email-statuses",
+            "/understanding-delivery-and-failure#email-statuses",
         ),
         (
             "technical-failure",
             "email",
-            "/delivery-and-failure#email-statuses",
+            "/understanding-delivery-and-failure#email-statuses",
         ),
         (
             "temporary-failure",
             "sms",
-            "/delivery-and-failure#sms-statuses",
+            "/understanding-delivery-and-failure#sms-statuses",
         ),
         (
             "permanent-failure",
             "sms",
-            "/delivery-and-failure#sms-statuses",
+            "/understanding-delivery-and-failure#sms-statuses",
         ),
         (
             "technical-failure",
             "sms",
-            "/delivery-and-failure#sms-statuses",
+            "/understanding-delivery-and-failure#sms-statuses",
         ),
         # Letter statuses are never linked
         ("technical-failure", "letter", None),

--- a/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
@@ -5,7 +5,7 @@ import config from "../../../../config";
 const pages = [
     { en: "/accessibility", fr: "/accessibilite" },
     { en: "/keep-accurate-contact-information", fr: "/maintenez-a-jour-les-coordonnees"},
-    { en: "/delivery-and-failure", fr: "/livraison-reussie-et-echec"},
+    { en: "/understanding-delivery-and-failure", fr: "/comprendre-statut-de-livraison"},
     { en: "/features", fr: "/fonctionnalites" },
     { en: "/formatting-guide", fr: "/guide-mise-en-forme" },
     { en: "/guidance", fr: "/guides-reference" },


### PR DESCRIPTION
# Summary | Résumé

Remove bad articles link, switch to the correct one

# Test instructions | Instructions pour tester la 

On the "Emails in the past week" page, these links in red should now work:

<img width="345" alt="Screenshot 2023-08-11 at 11 21 19 AM" src="https://github.com/cds-snc/notification-admin/assets/5498428/ca6c7db2-3056-4816-8ca9-375ce0a50546">
modification

