### PR TITLE
Feat/add link checking to gca cypress suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ dump.rdb
 cypress.env.json
 node_modules/
 tests_cypress/cypress/videos/
+tests_cypress/cypress/screenshots/

--- a/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
@@ -2,71 +2,78 @@
 
 import config from "../../../../config";
 
-const pages = [
-    { en: "/accessibility", fr: "/accessibilite" },
-    { en: "/keep-accurate-contact-information", fr: "/maintenez-a-jour-les-coordonnees"},
-    { en: "/understanding-delivery-and-failure", fr: "/comprendre-statut-de-livraison"},
-    { en: "/features", fr: "/fonctionnalites" },
-    { en: "/formatting-guide", fr: "/guide-mise-en-forme" },
-    { en: "/guidance", fr: "/guides-reference" },
-    { en: "/home", fr: "/accueil" },
-    { en: "/message-delivery-status", fr: "/etat-livraison-messages" },
-    { en: "/other-services", fr: "/autres-services" },
-    { en: "/personalisation-guide", fr: "/guide-personnalisation" },
-    { en: "/privacy", fr: "/confidentialite" },
-    { en: "/privacy-old", fr: "/confidentialite-old" },
-    { en: "/security", fr: "/securite" },
-    { en: "/security-old", fr: "/securite-old" },
-    { en: "/spreadsheets", fr: "/feuille-de-calcul" },
-    { en: "/terms", fr: "/conditions-dutilisation" },
-    { en: "/why-gc-notify", fr: "/pourquoi-gc-notification" },
+const langs = ['en', 'fr'];
+
+const fullPageList = [
+    { en: '/accessibility', fr: '/accessibilite' },
+    { en: '/features', fr: '/fonctionnalites' },
+    { en: '/formatting-emails', fr: '/guide-mise-en-forme' },
+    { en: '/service-level-agreement', fr: '/accord-niveaux-de-service' },
+    { en: '/terms', fr: '/conditions-dutilisation' },
+    { en: '/guidance', fr: '/guides-reference' },
+    { en: '/home', fr: '/accueil' },
+    { en: '/message-delivery-status', fr: '/etat-livraison-messages' },
+    { en: '/other-services', fr: '/autres-services' },
+    { en: '/privacy', fr: '/confidentialite' },
+    { en: '/security', fr: '/securite' },
+    { en: '/sending-custom-content', fr: '/envoyer-contenu-personnalise' },
+    { en: '/service-level-objectives', fr: '/objectifs-niveau-de-service' },
+    { en: '/system-status', fr: '/etat-du-systeme' },
+    { en: '/understanding-delivery-and-failure', fr: '/comprendre-statut-de-livraison' },
+    { en: '/updating-contact-information', fr: '/maintenir-a-jour-les-coordonnees' },
+    { en: '/using-a-spreadsheet', fr: '/utiliser-une-feuille-de-calcul' },
+    { en: '/why-gc-notify', fr: '/pourquoi-notification-gc' },
 ];
 
 describe('GCA static pages', () => {
-    afterEach(() => {
-        // cy.get('main').htmlvalidate({
-        //     rules: {
-        //         "no-redundant-role": "off",
-        //     },
-        // });
+    context("Check for dead links", () => {
+        for (const lang of langs) {
+            const currentLang = (lang === 'en' ? 'English' : 'Francais');
+            context(currentLang, () => {
+                for (const page of fullPageList) {
+                    it(`${page[lang]} contains no dead links`, () => {
+                        if (lang === 'fr') {
+                            cy.visit('/set-lang');
+                        }
+                        cy.visit(page[lang]);
+
+                        cy.get('body').within(() => {
+                            cy.get('a').each((link) => {
+                                if (link.prop('href').startsWith('mailto') || link.prop('href').startsWith('/set-lang') || link.prop('href').startsWith('#')) return;
+                                cy.request(link.prop('href'));
+                            });
+                        });
+                    });
+                }
+            });
+        }
+
     });
-    console.log(config.viewports)
+
     for (const viewport of config.viewports) {
-        context(`Viewport: ${viewport}px x 660px`, () => {
-            context('English', () => {
-                for (const page of pages) {
-                    it(`${page.en} passes a11y checks`, () => {
-                        cy.viewport(viewport, 660);
-                        cy.visit(page.en);
-                        cy.get('main').should('be.visible');
-        
-                        // check for a11y compliance
-                        cy.injectAxe();
-                        cy.checkA11y();
+        context('A11y and HTML validation test', () => {
+            context(`Viewport: ${viewport}px x 660px`, () => {
+                for (const lang of langs) {
+                    const currentLang = (lang === 'en' ? 'English' : 'Francais');
+                    context(currentLang, () => {
+                        for (const page of fullPageList) {
+                            it(`${page[lang]} passes a11y checks`, () => {
+                                // cy.viewport(viewport, 660);
+                                if (lang === 'fr') {
+                                    cy.visit('/set-lang');
+                                }
+                                cy.visit(page[lang]);
+
+                                cy.get('main').should('be.visible');
+
+                                // check for a11y compliance
+                                cy.injectAxe();
+                                cy.checkA11y();
+                            });
+                        }
                     });
                 }
             });
-        
-            context('Francais', () => {
-                // switch to french before getting french pages
-                before(() => {
-                    cy.visit('/set-lang');
-                });
-        
-                for (const page of pages) {
-                    it(`can load ${page.fr} page`, () => {
-                        cy.viewport(viewport, 660);
-        
-                        cy.visit(page.fr);
-                        cy.get('main').should('be.visible');
-                        // check for a11y compliance
-                        cy.injectAxe();
-                        cy.checkA11y();
-                    
-                    });
-                }
-            });
-        })
+        });
     }
-    
 });


### PR DESCRIPTION
# Summary | Résumé

This PR improves the the cypress GCA test suite by:
1. Adding missing routes
2. Adding checks for dead links across all pages
3. Refactoring the a11y tests to keep code DRY