### PR TITLE
Show message limits for trial services

### DIFF
--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -181,7 +181,7 @@
           )}}
         {% endcall %}
 
-        {% call settings_row(if_has_permission='email', alt_cond=current_service.live) %}
+        {% call settings_row(if_has_permission='email') %}
           {% set txt = _('Daily maximum') %}
           {{ text_field(txt)}}
           {% set message_limit = _('{} emails').format(current_service.message_limit | format_number) %}
@@ -189,7 +189,7 @@
           {{ text_field('') }}
         {% endcall %}
 
-        {% call settings_row(if_has_permission='email', alt_cond=current_service.live) %}
+        {% call settings_row(if_has_permission='email') %}
           {% set txt = _('Yearly maximum') %}
           {{ text_field(txt) }}
           {% set annual_limit = _('{} million emails').format((limits.free_yearly_email//1000000) | format_number) %}
@@ -255,7 +255,7 @@
           }}
         {% endcall %}
 
-        {% call settings_row(if_has_permission='sms', alt_cond=current_service.live) %}
+        {% call settings_row(if_has_permission='sms') %}
           {% set txt = _('Daily maximum') %}
           {{ text_field(txt)}}
           {% set txt_msg_limit = _('{} text messages').format(current_service.sms_daily_limit | format_number) %}
@@ -263,7 +263,7 @@
           {{ text_field('') }}
         {% endcall %}
 
-        {% call settings_row(if_has_permission='sms', alt_cond=current_service.live) %}
+        {% call settings_row(if_has_permission='sms') %}
           {% set txt = _('Yearly maximum') %}
           {{ text_field(txt) }}
           {% set txt_msg_limit = _('{} text messages').format(limits.free_yearly_sms | format_number) %}
@@ -305,7 +305,7 @@
             {% else %}
               {{ boolean_field(not current_service.trial_mode) }}
               {{ edit_field(
-                change_txt, 
+                change_txt,
                 url_for('.service_switch_live', service_id=current_service.id),
                 for=txt
               ) }}
@@ -319,7 +319,7 @@
             {{ text_field(txt)}}
             {{ text_field(yes_txt if current_service.count_as_live else no_txt) }}
             {{ edit_field(
-              change_txt, 
+              change_txt,
               url_for('.service_switch_count_as_live', service_id=current_service.id),
               for=txt
             ) }}
@@ -344,8 +344,8 @@
               {% endif %}
             {% endcall %}
             {{ edit_field(
-              change_txt, 
-              url_for('.link_service_to_organisation', 
+              change_txt,
+              url_for('.link_service_to_organisation',
               service_id=current_service.id),
               for=txt
             ) }}
@@ -421,7 +421,7 @@
             {{ text_field(txt)}}
             {{ text_field(current_service.free_sms_fragment_limit | format_number) }}
             {{ edit_field(
-              change_txt, 
+              change_txt,
               url_for('.set_free_sms_allowance', service_id=current_service.id),
               for=txt
             ) }}
@@ -431,7 +431,7 @@
             {{ text_field(txt)}}
             {{ text_field(_(current_service.email_branding_name)) }}
             {{ edit_field(
-              change_txt, 
+              change_txt,
               url_for('.service_set_email_branding', service_id=current_service.id),
               for=txt
             ) }}
@@ -443,7 +443,7 @@
                 {{ current_service.data_retention | join(', ', attribute='notification_type') }}
             {% endcall %}
             {{ edit_field(
-              change_txt, 
+              change_txt,
               url_for('.data_retention', service_id=current_service.id),
               for=txt
             ) }}
@@ -455,8 +455,8 @@
                 {{ text_field(_(service_permissions[permission].title))}}
                 {{ boolean_field(current_service.has_permission(permission)) }}
                 {{ edit_field(
-                  change_txt, 
-                  url_for(service_permissions[permission].endpoint or '.service_set_permission', service_id=current_service.id, permission=permission if not service_permissions[permission].endpoint else None), 
+                  change_txt,
+                  url_for(service_permissions[permission].endpoint or '.service_set_permission', service_id=current_service.id, permission=permission if not service_permissions[permission].endpoint else None),
                   for=_(service_permissions[permission].title)
                 ) }}
               {% endcall %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -176,10 +176,17 @@ def test_no_go_live_link_for_service_without_organisation(
     client_request.login(platform_admin_user)
     page = client_request.get("main.service_settings", service_id=SERVICE_ONE_ID)
 
+    live_row_text = normalize_spaces(page.css.select("tr:contains('No (organisation must be set first)')")[0].text)
+    org_row_text = normalize_spaces(page.css.select("tr > td > span:-soup-contains('Not set')")[0].text)
+    default_org = normalize_spaces(
+        page.css.select("tr:-soup-contains('Organisation') > td > div:-soup-contains('Government of Canada')")[0].text
+    )
+
     assert page.find("h1").text == "Settings"
 
-    assert normalize_spaces(page.select("tr")[15].text) == ("Live No (organisation must be set first)")
-    assert normalize_spaces(page.select("tr")[17].text) == ("Organisation Not set Government of Canada Change Organisation")
+    assert live_row_text == ("Live No (organisation must be set first)")
+    assert org_row_text == ("Not set")
+    assert default_org == ("Government of Canada")
 
 
 def test_organisation_name_links_to_org_dashboard(
@@ -200,7 +207,7 @@ def test_organisation_name_links_to_org_dashboard(
     client_request.login(platform_admin_user, service_one)
     response = client_request.get("main.service_settings", service_id=SERVICE_ONE_ID)
 
-    org_row = response.select("tr")[17]
+    org_row = response.css.select("tr:-soup-contains('Organisation')")[0]
 
     assert org_row.find("a")["href"] == url_for("main.organisation_dashboard", org_id=ORGANISATION_ID)
     assert normalize_spaces(org_row.find("a").text) == "Test Organisation"
@@ -221,10 +228,14 @@ def test_organisation_name_links_to_org_dashboard(
                 "Reply-to addresses test@example.com Manage",
                 "Email branding Your branding (Organisation name) Change",
                 "Send files by email Off (API-only) Change",
+                "Daily maximum 1,000 emails",
+                "Yearly maximum 10 million emails",
                 "Label Value Action",
                 "Send text messages On Change",
                 "Start text messages with service name On Change",
                 "Send international text messages On Change",
+                "Daily maximum 1,000 text messages",
+                "Yearly maximum 25,000 text messages",
             ],
         ),
         (
@@ -239,10 +250,14 @@ def test_organisation_name_links_to_org_dashboard(
                 "Reply-to addresses test@example.com Manage",
                 "Email branding Your branding (Organisation name) Change",
                 "Send files by email Off (API-only) Change",
+                "Daily maximum 1,000 emails",
+                "Yearly maximum 10 million emails",
                 "Label Value Action",
                 "Send text messages On Change",
                 "Start text messages with service name On Change",
                 "Send international text messages Off Change",
+                "Daily maximum 1,000 text messages",
+                "Yearly maximum 25,000 text messages",
             ],
         ),
     ],


### PR DESCRIPTION
# Summary | Résumé
This PR updates the service settings page so that daily / yearly message limits for email and sms are displayed for trial services. 
It also improves a couple of tests that relied on hard coded indexes to find specific rows in the service settings page. These tests should no longer fail and need attention whenever a new row is added to the service settings.

# Test instructions | Instructions pour tester la modification
1. Create a trial service
2. Navigate to the service settings page
3. Note that daily and yearly limits are now displayed under the `Emails` and `Text Messages` sections