### PR TITLE
Calculate job percent complete only when the job has rows in the notification table

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -430,7 +430,7 @@ def get_job_partials(job, template):
             "partials/jobs/notifications_header.html",
             notifications=list(add_preview_of_content_to_notifications(notifications["notifications"])),
             percentage_complete=0
-            if job["job_status"] == "scheduled"
+            if job["notification_count"] == 0
             else (job["notifications_requested"] / job["notification_count"] * 100),
             download_link=url_for(
                 ".view_job_csv",
@@ -451,7 +451,7 @@ def get_job_partials(job, template):
             notifications=list(add_preview_of_content_to_notifications(notifications["notifications"])),
             more_than_one_page=bool(notifications.get("links", {}).get("next")),
             percentage_complete=0
-            if job["job_status"] == "scheduled"
+            if job["notification_count"] == 0
             else (job["notifications_requested"] / job["notification_count"] * 100),
             download_link=url_for(
                 ".view_job_csv",

--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -429,7 +429,9 @@ def get_job_partials(job, template):
         "notifications_header": render_template(
             "partials/jobs/notifications_header.html",
             notifications=list(add_preview_of_content_to_notifications(notifications["notifications"])),
-            percentage_complete=(job["notifications_requested"] / job["notification_count"] * 100),
+            percentage_complete=0
+            if job["job_status"] == "scheduled"
+            else (job["notifications_requested"] / job["notification_count"] * 100),
             download_link=url_for(
                 ".view_job_csv",
                 service_id=current_service.id,
@@ -448,7 +450,9 @@ def get_job_partials(job, template):
             "partials/jobs/notifications.html",
             notifications=list(add_preview_of_content_to_notifications(notifications["notifications"])),
             more_than_one_page=bool(notifications.get("links", {}).get("next")),
-            percentage_complete=(job["notifications_requested"] / job["notification_count"] * 100),
+            percentage_complete=0
+            if job["job_status"] == "scheduled"
+            else (job["notifications_requested"] / job["notification_count"] * 100),
             download_link=url_for(
                 ".view_job_csv",
                 service_id=current_service.id,

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -408,6 +408,28 @@ def test_should_show_scheduled_job(
 
 
 @freeze_time("2016-01-01T00:00:00.061258")
+def test_percent_complete_zero_if_job_is_scheduled_and_send_time_has_not_elapsed(
+    client_request,
+    mock_get_service_template,
+    mock_get_scheduled_job,
+    mock_get_service_data_retention,
+    mock_get_no_notifications,
+    fake_uuid,
+):
+    page = client_request.get(
+        "main.view_job",
+        service_id=SERVICE_ONE_ID,
+        job_id=fake_uuid,
+    )
+
+    # These elements are not rendered if we're sending a scheduled job. Is also indicative of
+    # percentage complete being 0 as notifications are not added to the DB until the time of send
+    assert page.find(id="pe_filter") is None
+    assert page.find("a[text='Download this report']") is None
+    assert page.find("table") is None
+
+
+@freeze_time("2016-01-01T00:00:00.061258")
 def test_should_show_job_from_api(
     client_request,
     mock_get_service_template,


### PR DESCRIPTION
# Summary | Résumé
This PR adds a defensive check to `get_job_partials` to prevent a `DivisionByZeroError` that occurred when attempting to view a scheduled job. This issue was [uncovered when investigating an alarm](https://gcdigital.slack.com/archives/CNWA63606/p1694545734519119)

# Test instructions | Instructions pour tester la modification
1. Schedule a bulk send via the api
2. Navigate to your service's dashboard and click the link to the job under the `Scheduled Jobs` section
3. Note that the page loads without any errors