### PR TITLE
Remove a public endpoint that is unused and is causing 500 errors

### DIFF
--- a/app/main/views/agreement.py
+++ b/app/main/views/agreement.py
@@ -63,19 +63,3 @@ def service_confirm_agreement(service_id):
         return redirect(url_for("main.request_to_go_live", service_id=current_service.id))
 
     return render_template("views/agreement/agreement-confirm.html")
-
-
-@main.route("/agreement/<variant>", endpoint="public_agreement")
-@main.route("/agreement/<variant>.pdf", endpoint="public_download_agreement")
-def public_agreement(variant):
-    if variant not in {"crown", "non-crown"}:
-        abort(404)
-
-    if request.endpoint == "main.public_download_agreement":
-        return send_file(**get_mou(organisation_is_crown=(variant == "crown")))
-
-    return render_template(
-        "views/agreement/agreement-public.html",
-        owner=current_user.default_organisation.name,
-        download_link=url_for(".public_download_agreement", variant=variant),
-    )

--- a/tests/app/main/views/test_agreement.py
+++ b/tests/app/main/views/test_agreement.py
@@ -478,35 +478,3 @@ def test_confirm_agreement_page_persists(
         agreement_signed_at="2012-01-01 01:01:00",
         agreement_signed_by_id=fake_uuid,
     )
-
-
-@pytest.mark.parametrize(
-    "endpoint",
-    (
-        "main.public_agreement",
-        "main.public_download_agreement",
-    ),
-)
-@pytest.mark.parametrize(
-    "variant, expected_status",
-    (
-        ("crown", 200),
-        ("non-crown", 200),
-        ("foo", 404),
-    ),
-)
-def test_show_public_agreement_page(
-    client,
-    mocker,
-    endpoint,
-    variant,
-    expected_status,
-):
-    mocker.patch("app.s3_client.s3_mou_client.get_s3_object", return_value=_MockS3Object())
-    response = client.get(
-        url_for(
-            endpoint,
-            variant=variant,
-        )
-    )
-    assert response.status_code == expected_status


### PR DESCRIPTION
# Summary | Résumé

We are no longer using this endpoint. It is available to the public, and clicking the link on the page causes 500 errors.

# Test instructions | Instructions pour tester la modification

## Reproducing the bug
Navigate to https://staging.notification.cdssandbox.xyz/agreement/crown and click the "Download the agreement" link. You should see a 500 error page.

## Testing the fix
Navigate to the `/agreement/crown` page on the review app. You should now get a "Page not found" error.