### PR TITLE
Remove redundant title attribute from `text_field()` component

### DIFF
--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -103,9 +103,9 @@
       </ul>
     {% else %}
       {% if truncate %}
-        <div class="truncate-text" title="{{ text }}">{{text}}</div>
+        <div class="truncate-text">{{text}}</div>
       {% else %}
-        <div class="do-not-truncate-text" title="{{ text }}">{{text}}</div>
+        <div class="do-not-truncate-text">{{text}}</div>
       {% endif %}
     {% endif %}
   {% endcall %}

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -648,8 +648,8 @@ def test_upload_valid_csv_shows_preview_and_table(
     for row_index, row in enumerate(
         [
             (
-                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text" title="6502532223">6502532223</div> </td>',  # noqa: E501
-                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text" title="A">A</div> </td>',  # noqa: E501
+                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text">6502532223</div> </td>',  # noqa: E501
+                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text">A</div> </td>',  # noqa: E501
                 (
                     '<td class="table-field-left-aligned"> '
                     '<div class="table-field-status-default"> '
@@ -661,8 +661,8 @@ def test_upload_valid_csv_shows_preview_and_table(
                 ),
             ),
             (
-                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text" title="6502532224">6502532224</div> </td>',  # noqa: E501
-                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text" title="B">B</div> </td>',  # noqa: E501
+                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text">6502532224</div> </td>',  # noqa: E501
+                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text">B</div> </td>',  # noqa: E501
                 (
                     '<td class="table-field-left-aligned"> '
                     '<div class="table-field-status-default"> '
@@ -674,8 +674,8 @@ def test_upload_valid_csv_shows_preview_and_table(
                 ),
             ),
             (
-                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text" title="6502532225">6502532225</div> </td>',  # noqa: E501
-                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text" title="C">C</div> </td>',  # noqa: E501
+                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text">6502532225</div> </td>',  # noqa: E501
+                '<td class="table-field-left-aligned"> <div class="do-not-truncate-text">C</div> </td>',  # noqa: E501
                 (
                     '<td class="table-field-left-aligned"> '
                     '<div class="table-field-status-default"> '


### PR DESCRIPTION
# Summary | Résumé

Remove the redundant title attribute from the `<div>` element which just repeats the content of  the `<div>`.

## Impacts
This change affects the following pages which use this component:
- Review before sending (CSV send)
- Activity on GC Notify (/activity)
- Service settings (/service-settings)
- User profile (/user-profile)
- Callbacks for delivery receipts (/api/callbacks/delivery-status-callback)
- Errors page when sending notifications
- Confirmation page when sending notifications
- Email complaints (admin) (/platform-admin/complaints)
- Providers (admin) (/providers)
- Data retention (service settings) (/data-retention)
- Breaking change page (when you change variables in a template)
- Security keys page (user profile) (/user-profile/security_keys)