### PR TITLE
Show current folder hint when inside the root tempalate folder

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -262,7 +262,8 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
         allow_adding_letter_template=current_service.has_permission("letter"),
         allow_adding_copy_of_template=(current_service.all_templates or len(current_user.service_ids) > 1),
     )
-    option_hints = {template_folder_id: "current folder"}
+
+    option_hints = {template_folder_id if template_folder_id is not None else "__NONE__": "current folder"}
 
     if request.method == "POST" and templates_and_folders_form.validate_on_submit():
         if not current_user.has_permissions("manage_templates"):

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -263,7 +263,7 @@ def choose_template(service_id, template_type="all", template_folder_id=None):
         allow_adding_copy_of_template=(current_service.all_templates or len(current_user.service_ids) > 1),
     )
 
-    option_hints = {template_folder_id if template_folder_id is not None else "__NONE__": "current folder"}
+    option_hints = {template_folder_id if template_folder_id is not None else "__NONE__": _l("current folder")}
 
     if request.method == "POST" and templates_and_folders_form.validate_on_submit():
         if not current_user.has_permissions("manage_templates"):

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1770,3 +1770,4 @@
 "Sent by email","Envoyé par courriel"
 "Sent Time","Heure d’envoi"
 "Job","Tâche"
+"current folder","dossier actuel"

--- a/tests/app/main/views/test_template_folders.py
+++ b/tests/app/main/views/test_template_folders.py
@@ -1022,8 +1022,8 @@ def test_should_show_radios_and_buttons_for_move_destination_if_correct_permissi
         FOLDER_ONE_TWO_ID,
         FOLDER_TWO_ID,
     ]
-    assert [x.text.strip() for x in radio_div.select("label")] == [
-        "Templates",
+    assert [normalize_spaces(x) for x in radio_div.select("label")] == [
+        "Templates current folder",
         "folder_one",
         "folder_one_one",
         "folder_one_two",
@@ -1160,28 +1160,6 @@ def test_move_folder_form_shows_current_folder_hint_when_in_a_folder(
     assert len(move_form_labels) == 3
     assert normalize_spaces(move_form_labels[0].text) == "Templates"
     assert normalize_spaces(move_form_labels[1].text) == "parent_folder current folder"
-    assert normalize_spaces(move_form_labels[2].text) == "child_folder"
-
-
-def test_move_folder_form_does_not_show_current_folder_hint_at_the_top_level(
-    client_request,
-    service_one,
-    mock_get_service_templates,
-    mock_get_template_folders,
-):
-    mock_get_template_folders.return_value = [
-        _folder("parent_folder", PARENT_FOLDER_ID, None),
-        _folder("child_folder", CHILD_FOLDER_ID, PARENT_FOLDER_ID),
-    ]
-    page = client_request.get("main.choose_template", service_id=SERVICE_ONE_ID, _test_page_title=False)
-
-    page.find("input", attrs={"name": "move_to", "value": PARENT_FOLDER_ID})
-
-    move_form_labels = page.find("div", id="move_to_folder_radios").find_all("label")
-
-    assert len(move_form_labels) == 3
-    assert normalize_spaces(move_form_labels[0].text) == "Templates"
-    assert normalize_spaces(move_form_labels[1].text) == "parent_folder"
     assert normalize_spaces(move_form_labels[2].text) == "child_folder"
 
 


### PR DESCRIPTION
# Summary | Résumé
Show the current folder hint for the root `Templates` folder in addition to sub-folders when selecting a template to move to a different folder.

![image](https://github.com/cds-snc/notification-admin/assets/7444334/c9f8f752-1c58-48df-87de-95a456501479)

# Test instructions | Instructions pour tester la modification
1. Create a new templates folder
2. While in the root (default) template folder, select an existing template and click `Move`
3. Note that the `Current Folder` hint is displayed for the default `Templates` folder.