### PR TITLE
Add SR label to identify which API key is being revoked

### DIFF
--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -84,7 +84,7 @@
         {% endcall %}
       {% else %}
         {% call field(align='right', status='error') %}
-          <a href='{{ url_for('.revoke_api_key', service_id=current_service.id, key_id=item.id) }}'>{{ _('Revoke') }}</a>
+          <a href='{{ url_for('.revoke_api_key', service_id=current_service.id, key_id=item.id) }}'>{{ _('Revoke') }}<span class="sr-only"> {{_('API key') + ' ' + item.name }}</span></a>
         {% endcall %}
       {% endif %}
     {% endcall %}

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -186,7 +186,7 @@ def test_should_show_api_keys_page(
 
     assert rows[0] == "API keys Action"
     assert "another key name Revoked" in rows[1]
-    assert rows[2] == "some key name Revoke"
+    assert rows[2] == "some key name Revoke API key some key name"
 
     mock_get_api_keys.assert_called_once_with(SERVICE_ONE_ID)
 


### PR DESCRIPTION
# Summary | Résumé
This PR adds a `sr-only` `span` tag along side the revoke link found on the API keys page. This will assist screen reader users identify which API key will be revoked.

# Test instructions | Instructions pour tester la modification
1. Create several API keys or use existing keys if you have them.
2. Turn on a screen reader (cmd + F5 to activate VoiceOver)
3. Put focus on the `Revoke` links
4. Note that the screen reader reads back `Revoke API key <API_Key_Name>` / `Révoquer Clé API <API_Key_Name>` for each Revoke link put in focus / selected
