### PR TITLE
Remove unused gulp-css-url-adjuster dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,6 @@ plugins.addSrc = require("gulp-add-src");
 plugins.babel = require("gulp-babel");
 plugins.base64 = require("gulp-base64-inline");
 plugins.concat = require("gulp-concat");
-plugins.cssUrlAdjuster = require("gulp-css-url-adjuster");
 plugins.faMinify = require("gulp-fa-minify");
 plugins.jshint = require("gulp-jshint");
 plugins.prettyerror = require("gulp-prettyerror");

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "gulp-babel": "8.0.0",
         "gulp-base64-inline": "1.0.6",
         "gulp-concat": "2.6.1",
-        "gulp-css-url-adjuster": "0.2.3",
         "gulp-fa-minify": "^6.0.1",
         "gulp-include": "2.4.1",
         "gulp-jshint": "2.1.0",
@@ -5240,18 +5239,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
-      }
-    },
     "node_modules/css-declaration-sorter": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
@@ -7635,70 +7622,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/gulp-css-url-adjuster": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/gulp-css-url-adjuster/-/gulp-css-url-adjuster-0.2.3.tgz",
-      "integrity": "sha512-HUIhwWxnlRwMeQjJyVbGQMFra2A4F/1WiSvW+Y2pi8QougeMb3TTNXdseS8rijPgAjT5YwGFzrW0vgcLLot+nw==",
-      "dev": true,
-      "dependencies": {
-        "gulp-util": "latest",
-        "rework": "~1.0.1",
-        "rework-plugin-url": "~1.0.1",
-        "through2": "~1.0.0"
-      }
-    },
-    "node_modules/gulp-css-url-adjuster/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
-    "node_modules/gulp-css-url-adjuster/node_modules/object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
-      "dev": true
-    },
-    "node_modules/gulp-css-url-adjuster/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/gulp-css-url-adjuster/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true
-    },
-    "node_modules/gulp-css-url-adjuster/node_modules/through2": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-1.0.0.tgz",
-      "integrity": "sha512-c0/VHHaVPY2007PCtr6AY7BIOx1yvLzO9rPlCuT2qFKYed0bQIJGixLA9xATHfRwXpd1IoorvwMinLJOAIzw9A==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "~1.1.10",
-        "xtend": "~2.1.1"
-      }
-    },
-    "node_modules/gulp-css-url-adjuster/node_modules/xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
-      "dev": true,
-      "dependencies": {
-        "object-keys": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/gulp-fa-minify": {
@@ -14841,46 +14764,6 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/rework": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
-      "integrity": "sha512-eEjL8FdkdsxApd0yWVZgBGzfCQiT8yqSc2H1p4jpZpQdtz7ohETiDMoje5PlM8I9WgkqkreVxFUKYOiJdVWDXw==",
-      "dev": true,
-      "dependencies": {
-        "convert-source-map": "^0.3.3",
-        "css": "^2.0.0"
-      }
-    },
-    "node_modules/rework-plugin-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rework-plugin-function/-/rework-plugin-function-1.0.2.tgz",
-      "integrity": "sha512-kyIphbC2Kuc3iFz1CSAQ5zmt4o/IHquhO+uG0kK0FQTjs4Z5eAxrqmrv3rZMR1KXa77SesaW9KwKyfbYoLMEqw==",
-      "dev": true,
-      "dependencies": {
-        "rework-visit": "^1.0.0"
-      }
-    },
-    "node_modules/rework-plugin-url": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rework-plugin-url/-/rework-plugin-url-1.0.1.tgz",
-      "integrity": "sha512-ancJA2AG8gI9mCFbfldhKIYoq5pRq/gnNMcjHmLMagnd3f0BVBmXsryW+G6rdkl0cdc+y7PvRLugL0zauoMRKQ==",
-      "dev": true,
-      "dependencies": {
-        "rework-plugin-function": "^1.0.0"
-      }
-    },
-    "node_modules/rework-visit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz",
-      "integrity": "sha512-W6V2fix7nCLUYX1v6eGPrBOZlc03/faqzP4sUxMAJMBMOPYhfV/RyLegTufn5gJKaOITyi+gvf0LXDZ9NzkHnQ==",
-      "dev": true
-    },
-    "node_modules/rework/node_modules/convert-source-map": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
-      "integrity": "sha512-+4nRk0k3oEpwUB7/CalD7xE2z4VmtEnnq0GO2IPTkrooTrAhEsWvuLF5iWP1dXrwluki/azwXV1ve7gtYuPldg==",
-      "dev": true
     },
     "node_modules/rimraf": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "gulp-babel": "8.0.0",
     "gulp-base64-inline": "1.0.6",
     "gulp-concat": "2.6.1",
-    "gulp-css-url-adjuster": "0.2.3",
     "gulp-fa-minify": "^6.0.1",
     "gulp-include": "2.4.1",
     "gulp-jshint": "2.1.0",


### PR DESCRIPTION
# Summary | Résumé
This PR is part 2 of 2 ([part 1](https://github.com/cds-snc/notification-admin/pull/1667)) to resolve a [critical security vulnerability](https://github.com/cds-snc/notification-admin/security/dependabot/41) with versions of `lodash` that are < 4.5.0.

## Why?
The dependency tree:
```
gulp-css-url-adjuster
|__ gulp-util
|____ lodash (< v4.5.0)
```
`gulp-css-url-adjuster` is dependent on [`gulp-util`](https://www.npmjs.com/package/gulp-util) which has been deprecated. The authors [recommend moving away from using it](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5). Additionally the authors ask that if your project has a dependency which uses `gulp-util` to create an issue in the dep's repo recommending it's removal and offering replacements for certain API calls.

Initially this was my plan, however, there has not been a commit in the repo for [over 8 years](https://github.com/trentearl/gulp-css-url-adjuster) and there are issues that have been open for 6+ years. I expect that if we opened an issue it would receive the same treatment as maintenance of the dep seems to have halted.

Lastly, while we require the dependency in our `gulp.js` we do not appear to call or utilize it, and removing it has had no apparent affect on functionality.

# Testing
- Build the dev container, there should be no errors.
- Run the app and poke around the site for anything CSS related that seems out of place or incorrect.