### PR TITLE
Add route for archived terms of use

### DIFF
--- a/app/articles/routing.py
+++ b/app/articles/routing.py
@@ -23,6 +23,7 @@ GC_ARTICLES_ROUTES = {
     "service-level-objectives": {"en": "/service-level-objectives", "fr": "/objectifs-niveau-de-service"},
     "spreadsheets": {"en": "/using-a-spreadsheet", "fr": "/utiliser-une-feuille-de-calcul"},
     "terms-202104": {"en": "/terms-202104", "fr": "/conditions-dutilisation-202104"},
+    "terms-202304": {"en": "/terms-202304", "fr": "/conditions-dutilisation-202304"},
     "terms": {"en": "/terms", "fr": "/conditions-dutilisation"},
     "whynotify": {"en": "/why-gc-notify", "fr": "/pourquoi-notification-gc"},
     "incidents": {"en": "/system-status", "fr": "/etat-du-systeme"},


### PR DESCRIPTION
# Summary | Résumé

Added a new route for another archived version of the terms of use.

> **Note**: Are you adding a new page from GC Articles? Make sure you add the endpoint to the [WAF rules](https://github.com/cds-snc/notification-utils/tree/main/.github/actions/waffles#supporting-a-new-url-within-gcnotify).

Yes. I think the WAF rules already cover this pattern. 


# Test instructions | Instructions pour tester la modification

1. Go to review app
2. Navigate to /terms-202304
3. Check that the h1 is correct. Should be the archived version from April 2023
4. Click the language toggle
5. Check that you get the same archived date in the title
