### PR TITLE
Use SHA256 hash instead of 384

### DIFF
--- a/app/templates/main_template.html
+++ b/app/templates/main_template.html
@@ -26,14 +26,12 @@
   <link
     href="https://fonts.googleapis.com/css?family=Lato:400,700,900&display=swap"
     rel="stylesheet"
-    integrity="sha384-kVxP/aXwg+PkN511FuqryM/THiiQlE94Vnv1Su+pNFJY+4yvw+4vncZFNZbgY7UL"
-    crossorigin="anonymous"
+    integrity="sha256-8UHCn8HdwwrFIG1pimLw1DpQRfkPvTq8jHZLXJwpPo4=" crossorigin="anonymous"
   />
   <link
     href="https://fonts.googleapis.com/css?family=Noto+Sans&display=swap"
     rel="stylesheet"
-    integrity="sha384-tGeHQVuE+OkHZJbt49ODye8E3Hz+UVXmOBzwDcGwcab8YQer8siRT442XmkDqYpp"
-    crossorigin="anonymous"
+    integrity="sha256-AueP75pGAtROGzX2BIyKoY/QBX+tH40az+OXhkTthKU=" crossorigin="anonymous"
   />
   <meta name="theme-color" content="#0b0c0c"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>


### PR DESCRIPTION
# Summary | Résumé
Switch from SHA384 to SHA256 hash for Google fonts.