### PR TITLE
Remove integrity attributes on google fonts

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -659,8 +659,8 @@ def useful_headers_after_request(response):
             f"script-src-elem 'self' *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com 'nonce-{nonce}' 'unsafe-eval' data:;"
             "connect-src 'self' *.google-analytics.com *.googletagmanager.com *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com;"
             "object-src 'self';"
-            f"style-src 'self' *.googleapis.com https://tagmanager.google.com https://fonts.googleapis.com 'nonce-{nonce}' 'unsafe-inline';"
-            f"font-src 'self' {asset_domain} *.googleapis.com *.gstatic.com data:;"
+            f"style-src 'self' fonts.googleapis.com https://tagmanager.google.com https://fonts.googleapis.com 'unsafe-inline';"
+            f"font-src 'self' {asset_domain} fonts.googleapis.com fonts.gstatic.com *.gstatic.com data:;"
             f"img-src 'self' {asset_domain} *.canada.ca *.cdssandbox.xyz *.google-analytics.com *.googletagmanager.com *.notifications.service.gov.uk *.gstatic.com https://siteintercept.qualtrics.com data:;"  # noqa: E501
             "frame-ancestors 'self';"
             "form-action 'self' *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com;"

--- a/app/templates/main_template.html
+++ b/app/templates/main_template.html
@@ -26,12 +26,10 @@
   <link
     href="https://fonts.googleapis.com/css?family=Lato:400,700,900&display=swap"
     rel="stylesheet"
-    integrity="sha256-8UHCn8HdwwrFIG1pimLw1DpQRfkPvTq8jHZLXJwpPo4=" crossorigin="anonymous"
   />
   <link
     href="https://fonts.googleapis.com/css?family=Noto+Sans&display=swap"
     rel="stylesheet"
-    integrity="sha256-AueP75pGAtROGzX2BIyKoY/QBX+tH40az+OXhkTthKU=" crossorigin="anonymous"
   />
   <meta name="theme-color" content="#0b0c0c"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -71,8 +71,8 @@ def test_owasp_useful_headers_set(client, mocker, mock_get_service_and_organisat
         f"script-src-elem 'self' *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com 'nonce-{nonce}' 'unsafe-eval' data:;"
         "connect-src 'self' *.google-analytics.com *.googletagmanager.com *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com;"
         "object-src 'self';"
-        f"style-src 'self' *.googleapis.com https://tagmanager.google.com https://fonts.googleapis.com 'nonce-{nonce}' 'unsafe-inline';"
-        "font-src 'self' static.example.com *.googleapis.com *.gstatic.com data:;"
+        f"style-src 'self' fonts.googleapis.com https://tagmanager.google.com https://fonts.googleapis.com 'unsafe-inline';"
+        "font-src 'self' static.example.com fonts.googleapis.com fonts.gstatic.com *.gstatic.com data:;"
         "img-src 'self' static.example.com *.canada.ca *.cdssandbox.xyz *.google-analytics.com *.googletagmanager.com *.notifications.service.gov.uk *.gstatic.com https://siteintercept.qualtrics.com data:;"  # noqa: E501
         "frame-ancestors 'self';"
         "form-action 'self' *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com;"
@@ -135,8 +135,8 @@ def test_headers_non_ascii_characters_are_replaced(
         f"script-src-elem 'self' *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com 'nonce-{nonce}' 'unsafe-eval' data:;"
         "connect-src 'self' *.google-analytics.com *.googletagmanager.com *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com;"
         "object-src 'self';"
-        f"style-src 'self' *.googleapis.com https://tagmanager.google.com https://fonts.googleapis.com 'nonce-{nonce}' 'unsafe-inline';"
-        "font-src 'self' static.example.com *.googleapis.com *.gstatic.com data:;"
+        f"style-src 'self' fonts.googleapis.com https://tagmanager.google.com https://fonts.googleapis.com 'unsafe-inline';"
+        "font-src 'self' static.example.com fonts.googleapis.com fonts.gstatic.com *.gstatic.com data:;"
         "img-src 'self' static.example.com *.canada.ca *.cdssandbox.xyz *.google-analytics.com *.googletagmanager.com *.notifications.service.gov.uk *.gstatic.com https://siteintercept.qualtrics.com data:;"  # noqa: E501
         "frame-ancestors 'self';"
         "form-action 'self' *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com;"


### PR DESCRIPTION
# Summary | Résumé
- Remove integrity attributes on google fonts
- Add corresponding domains to the font-src and style-src csp headers