### PR TITLE
Added an exception for CompDocError

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -209,7 +209,7 @@ def send_messages(service_id, template_id):
                 ).format(form.file.data.filename)
             )
         except CompDocError:
-            flash(_("{} is password protected").format(form.file.data.filename))
+            flash(_("Try creating {} in a different application").format(form.file.data.filename))
 
     column_headings = get_spreadsheet_column_headings_from_template(template)
 

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -31,6 +31,7 @@ from notifications_utils.recipients import (
 from notifications_utils.sanitise_text import SanitiseASCII
 from ordered_set import OrderedSet
 from xlrd.biffh import XLRDError
+from xlrd.compdoc import CompDocError
 from xlrd.xldate import XLDateError
 
 from app import (
@@ -207,6 +208,8 @@ def send_messages(service_id, template_id):
                     "Try formatting all columns as ‘text’ or export your file as CSV."
                 ).format(form.file.data.filename)
             )
+        except CompDocError:
+            flash(_("{} is password protected").format(form.file.data.filename))
 
     column_headings = get_spreadsheet_column_headings_from_template(template)
 

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1771,3 +1771,4 @@
 "Sent Time","Heure d’envoi"
 "Job","Tâche"
 "Current folder","Dossier actuel"
+"Try creating {} in a different application","Essayez de créer {} dans une application différente."


### PR DESCRIPTION
# Summary | Résumé

This is the ticket: https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1380 
Certain Excel spreadsheet formats are being flagged by xlrd as corrupt, resulting in 500 errors when we try to process these spreadsheet types.

Certain tools for creating spreadsheets, [such as PHPExcel](https://stackoverflow.com/questions/16618672/xlrd-crashes-when-reading-xls-file-modified-by-phpexcel), can result in the "corruption" we are seeing.

We are gracefully catching the error and returning a message.

# The error we are seeing in logs:

```
Traceback (most recent call last):
  File \"/usr/local/lib/python3.10/site-packages/flask/app.py\", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File \"/usr/local/lib/python3.10/site-packages/flask/app.py\", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File \"/usr/local/lib/python3.10/site-packages/newrelic/hooks/framework_flask.py\", line 82, in _nr_wrapper_handler_
    return wrapped(*args, **kwargs)
  File \"/app/app/utils.py\", line 141, in wrap_func
    return func(*args, **kwargs)
  File \"/app/app/main/views/send.py\", line 189, in send_messages
    Spreadsheet.from_file(form.file.data, filename=form.file.data.filename).as_dict,
  File \"/app/app/utils.py\", line 425, in from_file
    instance = cls.from_rows(pyexcel.iget_array(file_type=extension, file_stream=file_content), filename)
  File \"/usr/local/lib/python3.10/site-packages/pyexcel/core.py\", line 191, in iget_array
    sheet_stream = sources.get_sheet_stream(on_demand=True, **keywords)
  File \"/usr/local/lib/python3.10/site-packages/pyexcel/internal/core.py\", line 21, in get_sheet_stream
    sheets = a_source.get_data()
  File \"/usr/local/lib/python3.10/site-packages/pyexcel/plugins/sources/memory_input.py\", line 36, in get_data
    sheets = self.__parser.parse_file_stream(
  File \"/usr/local/lib/python3.10/site-packages/pyexcel/plugins/parsers/excel.py\", line 22, in parse_file_stream
    return self._parse_any(
  File \"/usr/local/lib/python3.10/site-packages/pyexcel/plugins/parsers/excel.py\", line 35, in _parse_any
    sheets, reader = iget_data(
  File \"/usr/local/lib/python3.10/site-packages/pyexcel_io/io.py\", line 52, in iget_data
    data, reader = _get_data(
  File \"/usr/local/lib/python3.10/site-packages/pyexcel_io/io.py\", line 105, in _get_data
    return load_data(**keywords)
  File \"/usr/local/lib/python3.10/site-packages/pyexcel_io/io.py\", line 195, in load_data
    reader.open_stream(file_stream, **keywords)
  File \"/usr/local/lib/python3.10/site-packages/pyexcel_io/reader.py\", line 69, in open_stream
    self.reader = self.reader_class(
  File \"/usr/local/lib/python3.10/site-packages/pyexcel_xls/xlsr.py\", line 190, in __init__
    super().__init__(
  File \"/usr/local/lib/python3.10/site-packages/pyexcel_xls/xlsr.py\", line 146, in __init__
    self.xls_book = self.get_xls_book(**xlrd_params)
  File \"/usr/local/lib/python3.10/site-packages/pyexcel_xls/xlsr.py\", line 165, in get_xls_book
    xls_book = xlrd.open_workbook(**xlrd_params)
  File \"/usr/local/lib/python3.10/site-packages/xlrd/__init__.py\", line 148, in open_workbook
    bk = book.open_workbook_xls(
  File \"/usr/local/lib/python3.10/site-packages/xlrd/book.py\", line 82, in open_workbook_xls
    bk.biff2_8_load(
  File \"/usr/local/lib/python3.10/site-packages/xlrd/book.py\", line 636, in biff2_8_load
    cd.locate_named_stream(UNICODE_LITERAL(qname))
  File \"/usr/local/lib/python3.10/site-packages/xlrd/compdoc.py\", line 397, in locate_named_stream
    result = self._locate_stream(
  File \"/usr/local/lib/python3.10/site-packages/xlrd/compdoc.py\", line 427, in _locate_stream
    raise CompDocError(\"%s corruption: seen[%d] == %d\" % (qname, s, self.seen[s]))
xlrd.compdoc.CompDocError: Workbook corruption: seen[2] == 4
```

## NEEDED:
Please check the french translation of the error message/ or thoughts around the english/fr error message

# Test:
To Reproduce
Download a sample [corrupted xls spreadsheet](https://github.com/python-excel/xlrd/blob/master/tests/samples/corrupted_error.xls)

# Another issue:
A more sound solution is to update xlrd to version 2.0.0 or greater, which gives us access to the ignore_workbook_corruption flag, on the open_workbook method .

xlrd.open_workbook("corrupted_error.xls", ignore_workbook_corruption=True)
However where this gets tricky is xlrd >= 2.0.0 [only provides support for xls files](https://xlrd.readthedocs.io/en/latest/)

<img width="1199" alt="Screenshot 2023-11-16 at 2 06 00 PM" src="https://github.com/cds-snc/notification-admin/assets/8869623/ab17e8d7-9560-47b3-a444-deefc27eb601">

<img width="1142" alt="Screenshot 2023-11-16 at 2 12 39 PM" src="https://github.com/cds-snc/notification-admin/assets/8869623/6859083b-6237-4450-8ae3-f2c26b081c3d">


