### PR TITLE
Task/add sri to fingerprinter

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -265,6 +265,7 @@ def init_app(application):
         return {
             "admin_base_url": application.config["ADMIN_BASE_URL"],
             "asset_url": asset_fingerprinter.get_url,
+            "sri_hash": asset_fingerprinter.get_sri,
             "asset_s3_url": asset_fingerprinter.get_s3_url,
             "current_lang": get_current_locale(application),
             "documentation_url": documentation_url,

--- a/app/asset_fingerprinter.py
+++ b/app/asset_fingerprinter.py
@@ -1,5 +1,5 @@
 import hashlib
-
+import base64
 
 class AssetFingerprinter(object):
     """
@@ -21,6 +21,7 @@ class AssetFingerprinter(object):
 
     def __init__(self, asset_root="/static/", filesystem_path="app/static/", cdn_domain=None):
         self._cache = {}
+        self._sri_cache = {}
         self._cdn_domain = cdn_domain
         self._asset_root = asset_root
         self._filesystem_path = filesystem_path
@@ -31,6 +32,11 @@ class AssetFingerprinter(object):
                 self._asset_root + asset_path + "?" + self.get_asset_fingerprint(self._filesystem_path + asset_path)
             )
         return self._cache[asset_path]
+    
+    def get_sri(self, asset_path):
+        if asset_path not in self._sri_cache:
+            self._sri_cache[asset_path] =  self.get_asset_sri(self._filesystem_path + asset_path)
+        return self._sri_cache[asset_path]
 
     def get_s3_url(self, asset_path):
         if asset_path not in self._cache:
@@ -39,6 +45,11 @@ class AssetFingerprinter(object):
 
     def get_asset_fingerprint(self, asset_file_path):
         return hashlib.md5(self.get_asset_file_contents(asset_file_path)).hexdigest()
+    
+    def get_asset_sri(self, asset_file_path):
+        hash = hashlib.sha256(self.get_asset_file_contents(asset_file_path)).digest()
+        hash_base64 = base64.b64encode(hash).decode()
+        return 'sha256-{}'.format(hash_base64)
 
     def get_asset_file_contents(self, asset_file_path):
         with open(asset_file_path, "rb") as asset_file:

--- a/tests/app/main/test_asset_fingerprinter.py
+++ b/tests/app/main/test_asset_fingerprinter.py
@@ -96,6 +96,54 @@ class TestAssetFingerprint(object):
         assert fingerprinter.is_static_asset("https://example.com/static/image.png")
         assert not fingerprinter.is_static_asset("https://assets.example.com/image.png")
         assert not fingerprinter.is_static_asset("https://example.com/robots.txt")
+    
+    def test_sris_are_consistent(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
+        get_file_content_mock.return_value = """
+            body {
+                font-family: nta;
+            }
+        """.encode(
+            "utf-8"
+        )
+        asset_fingerprinter = AssetFingerprinter()
+        assert asset_fingerprinter.get_asset_sri("application.css") == asset_fingerprinter.get_asset_sri(
+            "same_contents.css"
+        )
+
+    def test_sris_are_different_for_different_files(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
+        asset_fingerprinter = AssetFingerprinter()
+        get_file_content_mock.return_value = """
+            body {
+                font-family: nta;
+            }
+        """.encode(
+            "utf-8"
+        )
+        css_hash = asset_fingerprinter.get_asset_sri("application.css")
+        get_file_content_mock.return_value = """
+            document.write('Hello world!');
+        """.encode(
+            "utf-8"
+        )
+        js_hash = asset_fingerprinter.get_asset_sri("application.js")
+        assert js_hash != css_hash
+
+    def test_sri_gets_cached(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
+        get_file_content_mock.return_value = """
+            body {
+                font-family: nta;
+            }
+        """.encode(
+            "utf-8"
+        )
+        fingerprinter = AssetFingerprinter()
+        assert fingerprinter.get_sri("application.css") == "sha256-m6bbawn+w6J+skW4rZ8bVBUodfZDxY30ZY84rGICL3Q="
+        fingerprinter._sri_cache["application.css"] = "a1a1a1"
+        assert fingerprinter.get_sri("application.css") == "a1a1a1"
+        fingerprinter.get_asset_file_contents.assert_called_once_with("app/static/application.css")
 
 
 class TestAssetFingerprintWithUnicode(object):


### PR DESCRIPTION
# Summary | Résumé

This PR extends the `asset_fingerprinter` so that it can compute integrity hashes for local scripts and stylesheets.

