### PR TITLE
Pin certifi to 2023.7.22

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2540,4 +2540,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.8"
-content-hash = "040dd5e5e36afab3c59a7145f34185de9bca2af9c705fbb4020696299638a364"
+content-hash = "67b742c50a2b1c7f92d0c213615cc92eb789ed4b0b120c3cbe6dc394dffc27bc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ itsdangerous = "2.1.2"  # pyup: <1.0.0
 notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "52.0.13"}
 
 rsa = "^4.1" # not directly required, pinned by Snyk to avoid a vulnerability
+certifi = "^2023.7.22" # not directly required: https://github.com/cds-snc/notification-admin/security/dependabot/169
 unidecode = "^1.3.6"
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
# Summary | Résumé
This PR pins `certifi` to version `2023.7.22`, which removes the e-Tugra root certificate from the root store. This is, in advance, preparation for the removal of the aforementioned certificate from Mozilla's trust store.

More info here:
https://github.com/cds-snc/notification-utils/security/dependabot/22