### PR TITLE
Revert boto and awscli bumps

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1492,22 +1492,21 @@ version = "52.0.16"
 description = "Shared python code for Notification - Provides logging utils etc."
 category = "main"
 optional = false
-python-versions = ">=3.10,<3.11"
-files = [
-    {file = "notifications_utils-52.0.16.tar.gz", hash = "sha256:17c2233884072a20a5f54ea12c4bb333f674d709aa65f75e5585755c4a0f8305"},
-]
+python-versions = "~3.10"
+files = []
+develop = false
 
 [package.dependencies]
 awscli = "1.29.39"
 bleach = "6.0.0"
 boto3 = "1.28.39"
 cachetools = "4.2.4"
-certifi = ">=2023.7.22,<2024.0.0"
-cryptography = ">=41.0.2,<42.0.0"
+certifi = "^2023.7.22"
+cryptography = "^41.0.2"
 Flask = "2.3.3"
 Flask-Redis = "0.4.0"
 itsdangerous = "2.1.2"
-Jinja2 = ">=3.0.0,<4.0.0"
+Jinja2 = "^3.0.0"
 markupsafe = "2.1.3"
 mistune = "0.8.4"
 ordered-set = "4.1.0"
@@ -1523,8 +1522,10 @@ statsd = "3.3.0"
 werkzeug = "2.3.7"
 
 [package.source]
-type = "file"
-url = "../../nutils/notifications_utils-52.0.16.tar.gz"
+type = "git"
+url = "https://github.com/cds-snc/notifier-utils.git"
+reference = "52.0.16"
+resolved_reference = "f8de0602f5aa34ef1e62691c94b7d0764568f423"
 
 [[package]]
 name = "openpyxl"
@@ -2598,4 +2599,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.8"
-content-hash = "429984d10eaac252688c16e0d1274d9f2ceafea7b4075667ecdff89c6179d4da"
+content-hash = "5b7772f3af84d6b8351f877250361ec1b8197b3e43560ad15c545a86d099a4f4"

--- a/poetry.lock
+++ b/poetry.lock
@@ -14,23 +14,23 @@ files = [
 
 [[package]]
 name = "awscli"
-version = "1.29.84"
+version = "1.29.39"
 description = "Universal Command Line Environment for AWS."
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "awscli-1.29.84-py3-none-any.whl", hash = "sha256:bc8c86d6bc6c086b5db47b848f7261118571a38aba993cb62cf3a6ddcbb70a09"},
-    {file = "awscli-1.29.84.tar.gz", hash = "sha256:68245c32a6fce891d14b3fa4ce50c75a394db3a5ba7bab938ba704dadb9ae17d"},
+    {file = "awscli-1.29.39-py3-none-any.whl", hash = "sha256:917a4e6d63cca96bfaafd8c680b2d0c5b046ffd2921d1b34b0ab5ab7b0006d2f"},
+    {file = "awscli-1.29.39.tar.gz", hash = "sha256:e027120aea449b34dad91773caf3357a8dae52abf54c406f062dd90158c97c14"},
 ]
 
 [package.dependencies]
-botocore = "1.31.84"
+botocore = "1.31.39"
 colorama = ">=0.2.5,<0.4.5"
 docutils = ">=0.10,<0.17"
 PyYAML = ">=3.10,<6.1"
 rsa = ">=3.1.2,<4.8"
-s3transfer = ">=0.7.0,<0.8.0"
+s3transfer = ">=0.6.0,<0.7.0"
 
 [[package]]
 name = "awscli-cwlogs"
@@ -159,43 +159,43 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.28.84"
+version = "1.28.39"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.28.84-py3-none-any.whl", hash = "sha256:98b01bbea27740720a06f7c7bc0132ae4ce902e640aab090cfb99ad3278449c3"},
-    {file = "boto3-1.28.84.tar.gz", hash = "sha256:adfb915958d7b54d876891ea1599dd83189e35a2442eb41ca52b04ea716180b6"},
+    {file = "boto3-1.28.39-py3-none-any.whl", hash = "sha256:48d1ea0918088df0e59a37a88ce53de7f4500108638c81255f5b1cb8edea28f4"},
+    {file = "boto3-1.28.39.tar.gz", hash = "sha256:3ac38ad8afafc6ed6c8dd6cc58ddd22b6352c6a413b969aef928c6aacf555c56"},
 ]
 
 [package.dependencies]
-botocore = ">=1.31.84,<1.32.0"
+botocore = ">=1.31.39,<1.32.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.7.0,<0.8.0"
+s3transfer = ">=0.6.0,<0.7.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.31.84"
+version = "1.31.39"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.31.84-py3-none-any.whl", hash = "sha256:d65bc05793d1a8a8c191a739f742876b4b403c5c713dc76beef262d18f7984a2"},
-    {file = "botocore-1.31.84.tar.gz", hash = "sha256:8913bedb96ad0427660dee083aeaa675466eb662bbf1a47781956b5882aadcc5"},
+    {file = "botocore-1.31.39-py3-none-any.whl", hash = "sha256:8ce716925284c1c0d04c796016a1e0e9c29ca3e196afefacacc16bc4e80c978f"},
+    {file = "botocore-1.31.39.tar.gz", hash = "sha256:61aefac8b44f86a4581d4128cce30806f633357e8d8efc4f73367a8e62009e70"},
 ]
 
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = {version = ">=1.25.4,<2.1", markers = "python_version >= \"3.10\""}
+urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
-crt = ["awscrt (==0.19.10)"]
+crt = ["awscrt (==0.16.26)"]
 
 [[package]]
 name = "cachelib"
@@ -1488,25 +1488,26 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "52.0.15"
+version = "52.0.16"
 description = "Shared python code for Notification - Provides logging utils etc."
 category = "main"
 optional = false
-python-versions = "~3.10"
-files = []
-develop = false
+python-versions = ">=3.10,<3.11"
+files = [
+    {file = "notifications_utils-52.0.16.tar.gz", hash = "sha256:17c2233884072a20a5f54ea12c4bb333f674d709aa65f75e5585755c4a0f8305"},
+]
 
 [package.dependencies]
-awscli = "1.29.84"
+awscli = "1.29.39"
 bleach = "6.0.0"
-boto3 = "1.28.84"
+boto3 = "1.28.39"
 cachetools = "4.2.4"
-certifi = "^2023.7.22"
-cryptography = "^41.0.2"
+certifi = ">=2023.7.22,<2024.0.0"
+cryptography = ">=41.0.2,<42.0.0"
 Flask = "2.3.3"
 Flask-Redis = "0.4.0"
 itsdangerous = "2.1.2"
-Jinja2 = "^3.0.0"
+Jinja2 = ">=3.0.0,<4.0.0"
 markupsafe = "2.1.3"
 mistune = "0.8.4"
 ordered-set = "4.1.0"
@@ -1522,10 +1523,8 @@ statsd = "3.3.0"
 werkzeug = "2.3.7"
 
 [package.source]
-type = "git"
-url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "52.0.15"
-resolved_reference = "4a4ba9d51af71d493f873b977bc0561b121ae51e"
+type = "file"
+url = "../../nutils/notifications_utils-52.0.16.tar.gz"
 
 [[package]]
 name = "openpyxl"
@@ -2153,14 +2152,14 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "s3transfer"
-version = "0.7.0"
+version = "0.6.2"
 description = "An Amazon S3 Transfer Manager"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "s3transfer-0.7.0-py3-none-any.whl", hash = "sha256:10d6923c6359175f264811ef4bf6161a3156ce8e350e705396a7557d6293c33a"},
-    {file = "s3transfer-0.7.0.tar.gz", hash = "sha256:fd3889a66f5fe17299fe75b82eae6cf722554edca744ca5d5fe308b104883d2e"},
+    {file = "s3transfer-0.6.2-py3-none-any.whl", hash = "sha256:b014be3a8a2aab98cfe1abc7229cc5a9a0cf05eb9c1f2b86b230fd8df3f78084"},
+    {file = "s3transfer-0.6.2.tar.gz", hash = "sha256:cab66d3380cca3e70939ef2255d01cd8aece6a4907a9528740f668c4b0611861"},
 ]
 
 [package.dependencies]
@@ -2364,18 +2363,30 @@ files = [
 
 [[package]]
 name = "types-requests"
-version = "2.31.0.10"
+version = "2.31.0.2"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = "*"
 files = [
-    {file = "types-requests-2.31.0.10.tar.gz", hash = "sha256:dc5852a76f1eaf60eafa81a2e50aefa3d1f015c34cf0cba130930866b1b22a92"},
-    {file = "types_requests-2.31.0.10-py3-none-any.whl", hash = "sha256:b32b9a86beffa876c0c3ac99a4cd3b8b51e973fb8e3bd4e0a6bb32c7efad80fc"},
+    {file = "types-requests-2.31.0.2.tar.gz", hash = "sha256:6aa3f7faf0ea52d728bb18c0a0d1522d9bfd8c72d26ff6f61bfc3d06a411cf40"},
+    {file = "types_requests-2.31.0.2-py3-none-any.whl", hash = "sha256:56d181c85b5925cbc59f4489a57e72a8b2166f18273fd8ba7b6fe0c0b986f12a"},
 ]
 
 [package.dependencies]
-urllib3 = ">=2"
+types-urllib3 = "*"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.14"
+description = "Typing stubs for urllib3"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f"},
+    {file = "types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e"},
+]
 
 [[package]]
 name = "typing-extensions"
@@ -2415,21 +2426,20 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.7"
+version = "1.26.18"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
-    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
+    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
+    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "user-agents"
@@ -2588,4 +2598,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.8"
-content-hash = "221189e7f69db5f4d271411550866eb3b56ed0d7db7c3b8b113583647104443b"
+content-hash = "429984d10eaac252688c16e0d1274d9f2ceafea7b4075667ecdff89c6179d4da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ gevent = "23.9.1"
 notifications-python-client = "6.4.1"
 
 Babel = "2.12.1"
-boto3 = "1.28.84"
+boto3 = "1.28.39"
 Flask-Babel = "2.0.0"
 newrelic = "8.10.0"
 python-dotenv = "1.0.0"
@@ -55,7 +55,7 @@ unidecode = "^1.3.6"
 # PaaS
 awscli-cwlogs = "^1.4.6"
 
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", rev = "52.0.15" }
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", rev = "52.0.16" }
 
 # Pinned dependencies
 rsa = "^4.1" # not directly required, pinned by Snyk to avoid a vulnerability
@@ -87,5 +87,5 @@ mypy = "1.5.1"
 # stubs libraries to keep mypy happy
 types-python-dateutil = "2.8.19.14"
 types-pytz = "2021.3.8"
-types-requests = "2.31.0.10"
+types-requests = "2.31.0.2"
 types-beautifulsoup4 = "^4.12.0.6"


### PR DESCRIPTION
# Summary | Résumé
This PR reverts bumps to dependencies that may be the cause of smoke test auth issues in staging.

TODO: Regenerate lock file once the [Utils PR](https://github.com/cds-snc/notification-utils/pull/262) has been merged and tagged.