### PR TITLE
Fix/cypress extend timeout add retries

### DIFF
--- a/tests_cypress/cypress.config.js
+++ b/tests_cypress/cypress.config.js
@@ -46,6 +46,7 @@ module.exports = defineConfig({
     blockHosts: ['*google-analytics.com', 'stats.g.doubleclick.net', 'bam.nr-data.net', '*newrelic.com'],
     viewportWidth: 1280,
     viewportHeight: 850,
-    testIsolation: false
+    testIsolation: false,
+    retries: 3
   },
 });

--- a/tests_cypress/cypress/Notify/Admin/Pages/LoginPage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/LoginPage.js
@@ -31,8 +31,8 @@ let Actions = {
             Cypress._.isObject, // keep retrying until the task returns an object
             {
                 log: true,
-                limit: 50, // max number of iterations
-                timeout: 30000, // time limit in ms
+                limit: 250, // max number of iterations
+                timeout: 120000, // time limit in ms
                 delay: 500, // delay before next iteration, ms
             },
         )

--- a/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
@@ -39,17 +39,9 @@ describe(`A11Y - App pages [${config.CONFIG_NAME}]`, () => {
     });
 
     for (const page of pages) {
-        it(`${page.name}`,
-            {
-                retries: {
-                    runMode: 2,
-                    openMode: 1,
-                },
-            },
-            () => {
-                cy.a11yScan(page.route, { a11y: true, htmlValidate: true, mimeTypes: false, deadLinks: false });
-            }
-        );
+        it(`${page.name}`, () => {
+            cy.a11yScan(page.route, { a11y: true, htmlValidate: true, mimeTypes: false, deadLinks: false });
+        });
     }
 });
 

--- a/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
@@ -5,7 +5,7 @@ import { LoginPage } from "../../../Notify/Admin/Pages/all";
 
 
 const pages = [
-    { name: "Landing page", route: "/accounts" }, 
+    { name: "Landing page", route: "/accounts" },
     { name: "Your profile", route: "/user-profile" },
     { name: "Dashboard", route: `/services/${config.Services.Cypress}` },
     { name: "Dashboard > Notification reports", route: `/services/${config.Services.Cypress}/notifications/email?status=sending,delivered,failed` },
@@ -33,14 +33,57 @@ const pages = [
 ];
 
 describe(`A11Y - App pages [${config.CONFIG_NAME}]`, () => {
-    before(() => {
+    retryableBefore(() => {
         LoginPage.Login(Cypress.env('NOTIFY_USER'), Cypress.env('NOTIFY_PASSWORD'));
         cy.task('log', "Running against:" + Cypress.config('baseUrl'))
     });
-    
+
     for (const page of pages) {
-        it(`${page.name}`, () => {
-            cy.a11yScan(page.route, { a11y: true, htmlValidate: true, mimeTypes: false, deadLinks: false });
-        });
+        it(`${page.name}`,
+            {
+                retries: {
+                    runMode: 2,
+                    openMode: 1,
+                },
+            },
+            () => {
+                cy.a11yScan(page.route, { a11y: true, htmlValidate: true, mimeTypes: false, deadLinks: false });
+            }
+        );
     }
 });
+
+
+/**
+ * A `before()` alternative that gets run when a failing test is retried.
+ *
+ * By default cypress `before()` isn't run when a test below it fails
+ * and is retried. Because we use `before()` as a place to setup state
+ * before running assertions inside `it()` this means we can't make use
+ * of cypress retry functionality to make our suites more reliable.
+ *
+ * https://github.com/cypress-io/cypress/issues/19458
+ * https://stackoverflow.com/questions/71285827/cypress-e2e-before-hook-not-working-on-retries
+ */
+function retryableBefore(fn) {
+    let shouldRun = true;
+
+    // we use beforeEach as cypress will run this on retry attempt
+    // we just abort early if we detected that it's already run
+    beforeEach(() => {
+      if (!shouldRun) return;
+      shouldRun = false;
+      fn();
+    });
+
+    // When a test fails we flip the `shouldRun` flag back to true
+    // so when cypress retries and runs the `beforeEach()` before
+    // the test that failed, we'll run the `fn()` logic once more.
+    Cypress.on('test:after:run', (result) => {
+      if (result.state === 'failed') {
+        if (result.currentRetry < result.retries) {
+          shouldRun = true;
+        }
+      }
+    });
+  };


### PR DESCRIPTION
# Summary | Résumé

This PR increases the login timeout for cypress tests to 120s and adds automatic retries (3) in case any test fails.