### PR TITLE
fix(footer): make system status page open in FR when app is in FR

### DIFF
--- a/app/templates/partials/nav/footer.html
+++ b/app/templates/partials/nav/footer.html
@@ -44,7 +44,7 @@
             {% endfor %}
           {% else %}
             {{ nav_link_dark(id_key='nav-footer-primary-contact', label=_('Contact us'), href=url_for('main.contact'), class="-ml-2") }}
-            {{ nav_link_dark(id_key='nav-footer-system-status', label=_('System status'), href=config["SYSTEM_STATUS_URL"], class="-ml-2") }}
+            {{ nav_link_dark(id_key='nav-footer-system-status', label=_('System status'), href=config["SYSTEM_STATUS_URL"] + ('/#fr' if current_lang == 'fr' else ''), class="-ml-2") }}
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
# Summary | Résumé

This PR updates the footer to make the system status link open in FR when admin is in FR.

# QA
- Open admin in EN, go to sign-on page, click system status link in footer
  - [ ] Staging system status site should open in English
- Open admin in FR, go to sign-on page, click system status link in footer
  - [ ] Staging system status site should open in French