### PR TITLE
Removed all the admin requirements on the api

### DIFF
--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -45,7 +45,7 @@
       {% call field() %}
         <div class="file-list">
           {{ item.name }}
-          {% if (current_user.platform_admin and
+          {% if (
               'total_sends' in item and
               'email_sends' in item and
               'sms_sends' in item )  %}
@@ -54,9 +54,7 @@
             </div>
           {% endif %}
           <div class="hint">
-            {% if current_user.platform_admin %}
-              {{ _('Key type:') }}
-            {% endif %}
+            {{ _('Key type:') }}
             {% if item.key_type == 'normal' %}
               {{ _('Live – sends to anyone') }}
             {% elif item.key_type == 'team' %}
@@ -65,7 +63,6 @@
               {{ _('Test – pretends to send messages') }}
             {% endif %}
           </div>
-          {% if current_user.platform_admin %}
             <div class="hint">
               {{ _('Created:') }} <span class="local-datetime-full">{{ item.created_at }}</span>
             </div>
@@ -75,7 +72,6 @@
             <div class="hint">
               {{ _('Last used:') }} <span class="local-datetime-full">{{ item.last_send }}</span>
             </div>
-          {% endif %}
         </div>
       {% endcall %}
       {% if item.expiry_date %}

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -185,8 +185,8 @@ def test_should_show_api_keys_page(
     rows = [normalize_spaces(row.text) for row in page.select("main tr")]
 
     assert rows[0] == "API keys Action"
-    assert "another key name Revoked" in rows[1]
-    assert rows[2] == "some key name Revoke API key some key name"
+    assert "another key name 20 total sends (20 email, 0 sms)" in rows[1]
+    assert "Revoke API key some key name" in rows[2]
 
     mock_get_api_keys.assert_called_once_with(SERVICE_ONE_ID)
 


### PR DESCRIPTION
# Summary | Résumé

The api page now shows all the same information available to an admin user: created, expiry, last_used.

The last_used information used to cause a timeout - but we have already fixed and merged that on staging.


# Test
Go to staging.notification.canada.ca and navigate to the api keys -  by signing into a non-admin account
^ same as above but this time go to the preview url generated in this PR. see the difference between the two pages.