### PR TITLE
Prevent naming variations of .env files to be submited to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ npm-debug.log
 environment.sh
 .env
 .envrc
+.env*
 venv-freeze/
 
 # IDEs


### PR DESCRIPTION
# Summary | Résumé

Prevent naming variations of .env files to be submited to git.

# Test instructions | Instructions pour tester la modification

Create a file named `.env.staging` locally and check if it can get submitted with git.