### PR TITLE
Revert "Owasp/add permissions policy header (#1707)"

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -641,12 +641,6 @@ def save_service_or_org_after_request(response):
 def useful_headers_after_request(response):
     response.headers.add("Referrer-Policy", "strict-origin-when-cross-origin")
     response.headers.add("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
-
-    perm_policy = "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(), gamepad=(), geolocation=(), gyroscope=(), layout-animations=(self), legacy-image-formats=(self), magnetometer=(), microphone=(), midi=(), oversized-images=(self), payment=(), picture-in-picture=(), publickey-credentials-get=(), speaker-selection=(), sync-xhr=(self), unoptimized-images=(self), unsized-media=(self), usb=(), screen-wake-lock=(), web-share=(), xr-spatial-tracking=()"
-    if current_app.config["PERMISSIONS_POLICY_DISABLE_DOCUMENT_DOMAIN"]:
-        perm_policy += ", document-domain=()"
-    response.headers.add("Permissions-Policy", perm_policy)
-
     response.headers.add("X-Frame-Options", "deny")
     response.headers.add("X-Content-Type-Options", "nosniff")
     response.headers.add("X-XSS-Protection", "1; mode=block")

--- a/app/config.py
+++ b/app/config.py
@@ -179,7 +179,6 @@ class Development(Config):
     SECRET_KEY = env.list("SECRET_KEY", ["dev-notify-secret-key"])
     SESSION_COOKIE_SECURE = False
     SESSION_PROTECTION = None
-    PERMISSIONS_POLICY_DISABLE_DOCUMENT_DOMAIN = False
     SYSTEM_STATUS_URL = "https://localhost:3000"
 
 
@@ -203,7 +202,6 @@ class Test(Development):
     WTF_CSRF_ENABLED = False
     GC_ARTICLES_API = "articles.alpha.canada.ca/notification-gc-notify"
     FF_SALESFORCE_CONTACT = False
-    PERMISSIONS_POLICY_DISABLE_DOCUMENT_DOMAIN = False
     SYSTEM_STATUS_URL = "https://localhost:3000"
 
 
@@ -212,27 +210,23 @@ class Production(Config):
     HTTP_PROTOCOL = "https"
     NOTIFY_ENVIRONMENT = "production"
     NOTIFY_LOG_LEVEL = "INFO"
-    PERMISSIONS_POLICY_DISABLE_DOCUMENT_DOMAIN = True
     SYSTEM_STATUS_URL = "https://status.notification.canada.ca"
 
 
 class Staging(Production):
     NOTIFY_ENVIRONMENT = "staging"
     NOTIFY_LOG_LEVEL = "INFO"
-    PERMISSIONS_POLICY_DISABLE_DOCUMENT_DOMAIN = False
     SYSTEM_STATUS_URL = "https://status.staging.notification.cdssandbox.xyz"
 
 
 class Scratch(Production):
     NOTIFY_ENVIRONMENT = "scratch"
     NOTIFY_LOG_LEVEL = "INFO"
-    PERMISSIONS_POLICY_DISABLE_DOCUMENT_DOMAIN = False
 
 
 class Dev(Production):
     NOTIFY_ENVIRONMENT = "dev"
     NOTIFY_LOG_LEVEL = "INFO"
-    PERMISSIONS_POLICY_DISABLE_DOCUMENT_DOMAIN = False
 
 
 configs = {

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -24,7 +24,7 @@ service = [
 ]
 
 
-def test_presence_of_security_headers(client, mocker, mock_calls_out_to_GCA, app_):
+def test_presence_of_security_headers(client, mocker, mock_calls_out_to_GCA):
     mocker.patch("app.service_api_client.get_live_services_data", return_value={"data": service})
     mocker.patch(
         "app.service_api_client.get_stats_by_month",
@@ -40,14 +40,6 @@ def test_presence_of_security_headers(client, mocker, mock_calls_out_to_GCA, app
 
     assert "Referrer-Policy" in response.headers
     assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
-
-    assert "Permissions-Policy" in response.headers
-    perm_policy = "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(), gamepad=(), geolocation=(), gyroscope=(), layout-animations=(self), legacy-image-formats=(self), magnetometer=(), microphone=(), midi=(), oversized-images=(self), payment=(), picture-in-picture=(), publickey-credentials-get=(), speaker-selection=(), sync-xhr=(self), unoptimized-images=(self), unsized-media=(self), usb=(), screen-wake-lock=(), web-share=(), xr-spatial-tracking=()"
-
-    # if document-domain is diabled, ensure its in there too
-    if app_.config["PERMISSIONS_POLICY_DISABLE_DOCUMENT_DOMAIN"]:
-        perm_policy += ", document-domain=()"
-    assert response.headers["Permissions-Policy"] == perm_policy
 
 
 def test_owasp_useful_headers_set(client, mocker, mock_get_service_and_organisation_counts, mock_calls_out_to_GCA):


### PR DESCRIPTION
This reverts commit 83d51256a6a1e6469d4dc477fbb505ab25c56146.

We'll look back into this later and make sure there are no warnings before updating this header.


