### PR TITLE
feat: add new cta to homepage + translations

### DIFF
--- a/app/templates/partials/page-content/cta.html
+++ b/app/templates/partials/page-content/cta.html
@@ -7,7 +7,10 @@
           <h2 class="heading-large">
             {{ _("Start sending test messages right away!") }}
           </h2>
-            {{ primary_button_blue_lighter(label=_("Try it now"), href=url_for('.register' )) }}
+            <div class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4">
+              {{ primary_button_blue_lighter(label=_("Try it now"), href=url_for('.register' )) }}
+              {{ primary_button_blue_lighter(label=_("Register for a demo"), href=gca_url_for('register_for_demo')) }}
+            </div>
           <p class="text-white">
             {{ _("Want to know more?") }}
             {{ secondary_button_transparent_white(

--- a/app/templates/partials/page-content/cta.html
+++ b/app/templates/partials/page-content/cta.html
@@ -7,18 +7,10 @@
           <h2 class="heading-large">
             {{ _("Start sending test messages right away!") }}
           </h2>
-            <div class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4">
-              {{ primary_button_blue_lighter(label=_("Try it now"), href=url_for('.register' )) }}
-              {{ primary_button_blue_lighter(label=_("Register for a demo"), href=gca_url_for('register_for_demo')) }}
-            </div>
-          <p class="text-white">
-            {{ _("Want to know more?") }}
-            {{ secondary_button_transparent_white(
-              label=_("Get in touch"), 
-              href=url_for('.contact'),
-              class="-ml-2"
-            ) }}
-          </p>
+          <div class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4">
+            {{ primary_button_blue_lighter(label=_("Try it now"), href=url_for('.register' )) }}
+            {{ primary_button_blue_lighter(label=_("Register for a demo"), href=gca_url_for('register_for_demo')) }}
+          </div>
     </div>
   </div>
 <!-- end section 7 -->

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1807,3 +1807,4 @@
 "Visit Register for a demo","Visitez la page S’inscrire à une démo"
 "For other questions about GC Notify, use this form.","Pour toute autre question, utilisez le formulaire ci-dessous."
 "We answer many questions on other GC Notify pages:","Nous répondons à de nombreuses questions sur les autres pages de Notification GC :"
+"Register for a demo","S’inscrire à une démo"


### PR DESCRIPTION
# Summary | Résumé

This PR updates the calls to action on the homepage by adding a new one to register for demos.

## Before & After

### Before
<img width="1121" alt="image" src="https://github.com/cds-snc/notification-admin/assets/823749/128731ca-5e79-48e9-9b9f-5a30ac5598a0">

### After
<img width="1053" alt="image" src="https://github.com/cds-snc/notification-admin/assets/823749/62927169-9f2f-4180-97dd-b63936da637f">
