### PR TITLE
Task/fix filterin heartbeat

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -281,7 +281,7 @@ def welcome():
 
 @main.route("/activity", endpoint="activity")
 def activity():
-    return render_template("views/activity.html", **get_latest_stats(get_current_locale(current_app)))
+    return render_template("views/activity.html", **get_latest_stats(get_current_locale(current_app), filter_heartbeats=True))
 
 
 @main.route("/activity/download", endpoint="activity_download")
@@ -386,7 +386,7 @@ def _render_articles_page(response):
         nav_items=nav_items,
         slug=slug_en,
         lang_url=get_lang_url(response, bool(page_id)),
-        stats=get_latest_stats(get_current_locale(current_app)) if slug_en == "home" else None,
+        stats=get_latest_stats(get_current_locale(current_app), filter_heartbeats=True) if slug_en == "home" else None,
         isHome=True if slug_en == "home" else None,
     )
 

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -59,11 +59,11 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         return self.get("/service", params=params_dict)
 
-    def get_stats_by_month(self):
+    def get_stats_by_month(self, filter_heartbeats=False):
         """
         Retrieve notifications stats by month.
         """
-        return self.get("/service/delivered-notifications-stats-by-month-data")
+        return self.get("/service/delivered-notifications-stats-by-month-data", params={"filter_heartbeats": filter_heartbeats})
 
     def find_services_by_name(self, service_name):
         return self.get("/service/find-services-by-name", params={"service_name": service_name})

--- a/app/utils.py
+++ b/app/utils.py
@@ -92,8 +92,8 @@ def from_lambda_api(line):
 
 
 @cache.memoize(timeout=3600)
-def get_latest_stats(lang):
-    results = service_api_client.get_stats_by_month()["data"]
+def get_latest_stats(lang, filter_heartbeats=None):
+    results = service_api_client.get_stats_by_month(filter_heartbeats=filter_heartbeats)["data"]
 
     monthly_stats = {}
     emails_total = 0
@@ -119,7 +119,7 @@ def get_latest_stats(lang):
         elif notification_type == "email":
             emails_total += count
 
-    live_services = len(service_api_client.get_live_services_data()["data"])
+    live_services = len(service_api_client.get_live_services_data({"filter_heartbeats": True})["data"])
 
     return {
         "monthly_stats": monthly_stats,

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -59,6 +59,20 @@ def test_client_gets_service_statistics(mocker, today_only, limit_days):
     )
 
 
+@pytest.mark.parametrize("filter_heartbeat", [True, False])
+def test_client_gets_stats_by_month(mocker, filter_heartbeat):
+    client = ServiceAPIClient()
+    mock_get = mocker.patch.object(client, "get", return_value={"data": {"a": "b"}})
+
+    ret = client.get_stats_by_month(filter_heartbeat)
+
+    assert ret["data"] == {"a": "b"}
+    mock_get.assert_called_once_with(
+        "/service/delivered-notifications-stats-by-month-data",
+        params={"filter_heartbeats": filter_heartbeat},
+    )
+
+
 def test_client_only_updates_allowed_attributes(mocker):
     mocker.patch("app.notify_client.current_user", id="1")
     with pytest.raises(TypeError) as error:


### PR DESCRIPTION
# Summary | Résumé

This is the frontend code to filter_heartbeats out. We are going to filter notifications sent from our internal notification service (GC_Notify)

# Test instructions | Instructions pour tester la modification

Once this PR has been merged: https://github.com/cds-snc/notification-api/pull/2120
you can use the preview URL to test this PR. It will ensure that we are filtering out all notifications from our internal service.