### PR TITLE
Add organisation id filter when getting email brands

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -208,6 +208,7 @@ class Test(Development):
     GC_ARTICLES_API = "articles.alpha.canada.ca/notification-gc-notify"
     FF_SALESFORCE_CONTACT = False
     SYSTEM_STATUS_URL = "https://localhost:3000"
+    NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
 
 
 class Production(Config):
@@ -216,12 +217,14 @@ class Production(Config):
     NOTIFY_ENVIRONMENT = "production"
     NOTIFY_LOG_LEVEL = "INFO"
     SYSTEM_STATUS_URL = "https://status.notification.canada.ca"
+    NO_BRANDING_ID = "760c802a-7762-4f71-b19e-f93c66c92f1a"
 
 
 class Staging(Production):
     NOTIFY_ENVIRONMENT = "staging"
     NOTIFY_LOG_LEVEL = "INFO"
     SYSTEM_STATUS_URL = "https://status.staging.notification.cdssandbox.xyz"
+    NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
 
 
 class Scratch(Production):

--- a/app/config.py
+++ b/app/config.py
@@ -145,6 +145,7 @@ class Config(object):
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
     FF_NEW_BRANDING = env.bool("FF_NEW_BRANDING", False)
+    NO_BRANDING_ID = env.bool("NO_BRANDING_ID", "0af93cf1-2c49-485f-878f-f3e662e651ef")
 
     @classmethod
     def get_sensitive_config(cls) -> list[str]:
@@ -185,6 +186,7 @@ class Development(Config):
     SESSION_COOKIE_SECURE = False
     SESSION_PROTECTION = None
     SYSTEM_STATUS_URL = "https://localhost:3000"
+    NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
 
 
 class Test(Development):

--- a/app/config.py
+++ b/app/config.py
@@ -145,7 +145,7 @@ class Config(object):
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
     FF_NEW_BRANDING = env.bool("FF_NEW_BRANDING", False)
-    NO_BRANDING_ID = env.bool("NO_BRANDING_ID", "0af93cf1-2c49-485f-878f-f3e662e651ef")
+    NO_BRANDING_ID = os.environ.get("NO_BRANDING_ID", "0af93cf1-2c49-485f-878f-f3e662e651ef")
 
     @classmethod
     def get_sensitive_config(cls) -> list[str]:

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -176,7 +176,8 @@ def edit_branding_settings(service_id):
 @main.route("/services/<service_id>/review-pool", methods=["GET", "POST"])
 @user_has_permissions("manage_service")
 def review_branding_pool(service_id):
-    logos = email_branding_client.get_all_email_branding()
+    organisation_id = current_service.organisation_id
+    logos = email_branding_client.get_all_email_branding(organisation_id=organisation_id)
     custom_logos = [logo for logo in logos if logo["brand_type"] in ["custom_logo", "custom_logo_with_background_colour"]]
 
     form = BrandingPoolForm()

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -1,6 +1,14 @@
 from collections import OrderedDict
 
-from flask import flash, redirect, render_template, request, session, url_for
+from flask import (
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 from flask_babel import _
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
@@ -273,6 +281,10 @@ def edit_organisation_agreement(org_id):
 @user_is_platform_admin
 def edit_organisation_email_branding(org_id):
     email_branding = email_branding_client.get_all_email_branding(organisation_id=org_id)
+    # As the user is a platform admin, we want the user to be able to get the no branding option
+    no_branding = email_branding_client.get_email_branding(current_app.config["NO_BRANDING_ID"])
+    if no_branding and "email_branding" in no_branding:
+        email_branding.append(no_branding["email_branding"])
 
     current_branding = current_organisation.email_branding_id
 

--- a/app/main/views/organisations.py
+++ b/app/main/views/organisations.py
@@ -272,7 +272,7 @@ def edit_organisation_agreement(org_id):
 @main.route("/organisations/<org_id>/settings/set-email-branding", methods=["GET", "POST"])
 @user_is_platform_admin
 def edit_organisation_email_branding(org_id):
-    email_branding = email_branding_client.get_all_email_branding()
+    email_branding = email_branding_client.get_all_email_branding(organisation_id=org_id)
 
     current_branding = current_organisation.email_branding_id
 

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1129,10 +1129,10 @@ def set_free_sms_allowance(service_id):
 )
 @user_is_platform_admin
 def service_set_email_branding(service_id):
-    email_branding = email_branding_client.get_all_email_branding()
+    organisation_id = current_service.organisation_id
+    email_branding = email_branding_client.get_all_email_branding(organisation_id=organisation_id)
 
     current_branding = current_service.email_branding_id
-
     if current_branding is None:
         current_branding = (
             FieldWithLanguageOptions.FRENCH_OPTION_VALUE

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -1131,6 +1131,10 @@ def set_free_sms_allowance(service_id):
 def service_set_email_branding(service_id):
     organisation_id = current_service.organisation_id
     email_branding = email_branding_client.get_all_email_branding(organisation_id=organisation_id)
+    # As the user is a platform admin, we want the user to be able to get the no branding option
+    no_branding = email_branding_client.get_email_branding(current_app.config["NO_BRANDING_ID"])
+    if no_branding and "email_branding" in no_branding:
+        email_branding.append(no_branding["email_branding"])
 
     current_branding = current_service.email_branding_id
     if current_branding is None:

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -7,8 +7,8 @@ class EmailBrandingClient(NotifyAdminAPIClient):
         return self.get(url="/email-branding/{}".format(branding_id))
 
     @cache.set("email_branding")
-    def get_all_email_branding(self, sort_key=None):
-        brandings = self.get(url="/email-branding")["email_branding"]
+    def get_all_email_branding(self, sort_key=None, organisation_id=None):
+        brandings = self.get(url="/email-branding", params={"organisation_id": organisation_id})["email_branding"]
 
         if len(brandings) > 0:
             if sort_key and sort_key in brandings[0]:

--- a/app/notify_client/email_branding_client.py
+++ b/app/notify_client/email_branding_client.py
@@ -6,7 +6,7 @@ class EmailBrandingClient(NotifyAdminAPIClient):
     def get_email_branding(self, branding_id):
         return self.get(url="/email-branding/{}".format(branding_id))
 
-    @cache.set("email_branding")
+    @cache.set("email_branding-{organisation_id}")
     def get_all_email_branding(self, sort_key=None, organisation_id=None):
         brandings = self.get(url="/email-branding", params={"organisation_id": organisation_id})["email_branding"]
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2733,6 +2733,7 @@ def test_service_preview_letter_branding_saves(
                 "org 3",
                 "org 4",
                 "org 5",
+                "Organisation name",
             ],
         ),
         (
@@ -2754,6 +2755,7 @@ def test_service_preview_letter_branding_saves(
                 "org 2",
                 "org 3",
                 "org 4",
+                "Organisation name",
             ],
         ),
     ],
@@ -2779,6 +2781,8 @@ def test_should_show_branding_styles(
     platform_admin_user,
     service_one,
     mock_get_all_email_branding,
+    mock_get_email_branding,
+    app_,
     current_branding,
     expected_values,
     expected_labels,
@@ -2805,8 +2809,7 @@ def test_should_show_branding_styles(
         page.find("label", attrs={"for": branding_style_choices[idx]["id"]}).get_text().strip()
         for idx, element in enumerate(branding_style_choices)
     ]
-
-    assert len(branding_style_choices) == 7
+    assert len(branding_style_choices) == 8
 
     for index, expected_value in enumerate(expected_values):
         assert branding_style_choices[index]["value"] == expected_value
@@ -2823,6 +2826,7 @@ def test_should_show_branding_styles(
     assert "checked" not in branding_style_choices[6].attrs
 
     app.email_branding_client.get_all_email_branding.assert_called_once_with(organisation_id=organisation_id)
+    app.email_branding_client.get_email_branding.assert_called_once_with(app_.config["NO_BRANDING_ID"])
     app.service_api_client.get_service.assert_called_once_with(service_one["id"])
 
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2853,6 +2853,8 @@ def test_should_send_branding_and_organisations_to_preview(
     service_one,
     mock_get_organisation,
     mock_get_all_email_branding,
+    mock_get_email_branding,
+    app_,
     mock_update_service,
     endpoint,
     extra_args,
@@ -2869,6 +2871,7 @@ def test_should_send_branding_and_organisations_to_preview(
     )
 
     mock_get_all_email_branding.assert_called_once_with(organisation_id=organisation_id)
+    mock_get_email_branding.assert_called_once_with(app_.config["NO_BRANDING_ID"])
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -2759,15 +2759,17 @@ def test_service_preview_letter_branding_saves(
     ],
 )
 @pytest.mark.parametrize(
-    "endpoint, extra_args",
+    "endpoint, extra_args, organisation_id",
     (
         (
             "main.service_set_email_branding",
             {"service_id": SERVICE_ONE_ID},
+            None,
         ),
         (
             "main.edit_organisation_email_branding",
             {"org_id": ORGANISATION_ID},
+            ORGANISATION_ID,
         ),
     ),
 )
@@ -2782,6 +2784,7 @@ def test_should_show_branding_styles(
     expected_labels,
     endpoint,
     extra_args,
+    organisation_id,
 ):
     service_one["email_branding"] = current_branding
     mocker.patch(
@@ -2819,22 +2822,24 @@ def test_should_show_branding_styles(
     assert "checked" not in branding_style_choices[5].attrs
     assert "checked" not in branding_style_choices[6].attrs
 
-    app.email_branding_client.get_all_email_branding.assert_called_once_with()
+    app.email_branding_client.get_all_email_branding.assert_called_once_with(organisation_id=organisation_id)
     app.service_api_client.get_service.assert_called_once_with(service_one["id"])
 
 
 @pytest.mark.parametrize(
-    "endpoint, extra_args, expected_redirect",
+    "endpoint, extra_args, expected_redirect, organisation_id",
     (
         (
             "main.service_set_email_branding",
             {"service_id": SERVICE_ONE_ID},
             "main.service_preview_email_branding",
+            None,
         ),
         (
             "main.edit_organisation_email_branding",
             {"org_id": ORGANISATION_ID},
             "main.organisation_preview_email_branding",
+            ORGANISATION_ID,
         ),
     ),
 )
@@ -2848,6 +2853,7 @@ def test_should_send_branding_and_organisations_to_preview(
     endpoint,
     extra_args,
     expected_redirect,
+    organisation_id,
 ):
     client_request.login(platform_admin_user)
     client_request.post(
@@ -2858,7 +2864,7 @@ def test_should_send_branding_and_organisations_to_preview(
         **extra_args,
     )
 
-    mock_get_all_email_branding.assert_called_once_with()
+    mock_get_all_email_branding.assert_called_once_with(organisation_id=organisation_id)
 
 
 @pytest.mark.parametrize(

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -47,6 +47,28 @@ def test_get_all_email_branding(mocker):
     )
 
 
+def test_get_all_email_branding_filter_organisation(mocker):
+    mock_get = mocker.patch(
+        "app.notify_client.email_branding_client.EmailBrandingClient.get",
+        return_value={"email_branding": [1, 2, 3]},
+    )
+    mock_redis_get = mocker.patch(
+        "app.extensions.RedisClient.get",
+        return_value=None,
+    )
+    mock_redis_set = mocker.patch(
+        "app.extensions.RedisClient.set",
+    )
+    EmailBrandingClient().get_all_email_branding(organisation_id="org_1")
+    mock_get.assert_called_once_with(url="/email-branding", params={"organisation_id": "org_1"})
+    mock_redis_get.assert_called_once_with("email_branding")
+    mock_redis_set.assert_called_once_with(
+        "email_branding",
+        "[1, 2, 3]",
+        ex=604800,
+    )
+
+
 def test_create_email_branding(mocker):
     org_data = {
         "logo": "test.png",

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -38,7 +38,7 @@ def test_get_all_email_branding(mocker):
         "app.extensions.RedisClient.set",
     )
     EmailBrandingClient().get_all_email_branding()
-    mock_get.assert_called_once_with(url="/email-branding", params={'organisation_id': None})
+    mock_get.assert_called_once_with(url="/email-branding", params={"organisation_id": None})
     mock_redis_get.assert_called_once_with("email_branding-None")
     mock_redis_set.assert_called_once_with(
         "email_branding-None",

--- a/tests/app/notify_client/test_email_branding_client.py
+++ b/tests/app/notify_client/test_email_branding_client.py
@@ -38,10 +38,10 @@ def test_get_all_email_branding(mocker):
         "app.extensions.RedisClient.set",
     )
     EmailBrandingClient().get_all_email_branding()
-    mock_get.assert_called_once_with(url="/email-branding")
-    mock_redis_get.assert_called_once_with("email_branding")
+    mock_get.assert_called_once_with(url="/email-branding", params={'organisation_id': None})
+    mock_redis_get.assert_called_once_with("email_branding-None")
     mock_redis_set.assert_called_once_with(
-        "email_branding",
+        "email_branding-None",
         "[1, 2, 3]",
         ex=604800,
     )
@@ -61,9 +61,9 @@ def test_get_all_email_branding_filter_organisation(mocker):
     )
     EmailBrandingClient().get_all_email_branding(organisation_id="org_1")
     mock_get.assert_called_once_with(url="/email-branding", params={"organisation_id": "org_1"})
-    mock_redis_get.assert_called_once_with("email_branding")
+    mock_redis_get.assert_called_once_with("email_branding-org_1")
     mock_redis_set.assert_called_once_with(
-        "email_branding",
+        "email_branding-org_1",
         "[1, 2, 3]",
         ex=604800,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3190,7 +3190,7 @@ def create_email_brandings(number_of_brandings, non_standard_values={}, shuffle=
 
 @pytest.fixture(scope="function")
 def mock_get_all_email_branding(mocker):
-    def _get_all_email_branding(sort_key=None):
+    def _get_all_email_branding(sort_key=None, organisation_id=None):
         non_standard_values = [
             {"idx": 1, "colour": "red"},
             {"idx": 2, "colour": "orange"},


### PR DESCRIPTION
# Summary | Résumé

Add an organisation id filter so that you can fetch email_brands associated with a single organisation.
Added tests.

## Testing
you can test through the preview app after you this PR is merged: https://github.com/cds-snc/notification-api/pull/2137
