### PR TITLE
Moving K8s Staging Rollout To Manifests

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -27,13 +27,6 @@ jobs:
         unzip -q awscliv2.zip
         sudo ./aws/install --update
         aws --version
-    - name: Install kubectl
-      run: |
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl
-        chmod +x ./kubectl
-        sudo mv ./kubectl /usr/local/bin/kubectl
-        kubectl version --client
-        mkdir -p $HOME/.kube
 
     - name: Configure credentials to CDS public ECR using OIDC
       uses: aws-actions/configure-aws-credentials@master
@@ -60,19 +53,14 @@ jobs:
       run: |
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:${GITHUB_SHA::7}
 
-    - name: Configure credentials to Notify account using OIDC
-      uses: aws-actions/configure-aws-credentials@master
-      with:
-        role-to-assume: arn:aws:iam::239043911459:role/notification-admin-apply
-        role-session-name: NotifyAdminGitHubActions
-        aws-region: "ca-central-1"
-
-    - name: Get Kubernetes configuration
+    - name: Rollout in Kubernetes
       run: |
-        aws eks --region $AWS_REGION update-kubeconfig --name notification-canada-ca-staging-eks-cluster --kubeconfig $HOME/.kube/config
-    - name: Update image in staging
-      run: |
-        kubectl set image deployment.apps/admin admin=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+        PAYLOAD={\"ref\":\"main\",\"inputs\":{\"docker_sha\":\"${GITHUB_SHA::7}\"}}
+        curl -L -X POST -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer $WORKFLOW_PAT" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/cds-snc/notification-manifests/actions/workflows/admin-rollout-k8s-staging.yaml/dispatches \
+          -d $PAYLOAD
 
     - name: my-app-install token
       id: notify-pr-bot

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,7 +8,6 @@ env:
   AWS_REGION: ca-central-1
   DOCKER_ORG: public.ecr.aws/v6b8u5o6
   DOCKER_SLUG: public.ecr.aws/v6b8u5o6/notify-admin
-  KUBECTL_VERSION: '1.18.0'
 
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT


### PR DESCRIPTION
# Summary | Résumé

This will replace the K8s rollout code in the docker build and push GitHub action with a remote call to the manifests repository, which now has the admin rollout github action. This is in preparation for the move to a private EKS endpoint.

# Test instructions | Instructions pour tester la modification

This unfortunately can't be tested until after merge.
- [ ]  Verify that this Github action and the corresponding github action in Notification-Manifests works as expected.

# Release Instructions
- [ ] [Ensure that this PR is merged before merging this PR](https://github.com/cds-snc/notification-manifests/pull/2443)
