### PR TITLE
a11y: change`banner` macro to not render h1's

### DIFF
--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -11,7 +11,7 @@
     {% endif %}
   >
     {% if subhead -%}
-      <h1 class='banner-title'>{{ subhead }}</h1>
+      <h2 class='banner-title'>{{ subhead }}</h2>
     {%- endif -%}
     {{ body }}
     {% if context %}


### PR DESCRIPTION
# Summary | Résumé

This PR updates the `banner` macro to use an `h2` instead of an `h1`, the latter causing an a11y issue since it can render 2 h1's on the same page.

## Notes

- The `banner()` macro draws an `h1` when the parameter `subhead` is passed with a string of text.
- `banner()` with a `subhead` param is only called via `banner_wrapper()` from template.html when `show_redaction_message=True` - which should be the only case we are interested in for this card
- The only place I can find where this would actually get used, is when a user clicks on 'Redact personalised variable content after sending' on the template screen. In this case, we do end up with 2 h1s on the page.

## Related card
cds-snc/notification-planning/issues/816