### PR TITLE
Add h1 page title to admin organisations page

### DIFF
--- a/app/templates/views/organisations/index.html
+++ b/app/templates/views/organisations/index.html
@@ -11,9 +11,9 @@
 
   <div class="container contain-floats">
     <main role="main">
+      {{ page_header(_("Organisations")) }}
       <div class="grid-row contain-floats mt-8 block clear-both contain-floats">
         <div class="w-full float-left py-0 px-0 px-gutterHalf box-border">
-
           {{ live_search(target_selector='.browse-list-item', show=True, form=search_form, label=_('Search by name')) }}
 
           <nav class="browse-list">


### PR DESCRIPTION
# Summary | Résumé
This PR adds an `h1` to the organisations page in the platform admin view.

# Test instructions | Instructions pour tester la modification
1. Log in as admin
2. Naviagate to `Platform Admin` -> `Organisations`
3. Note that there is now an h1 page title

![image](https://github.com/cds-snc/notification-admin/assets/7444334/cbe9beec-6020-4c4e-a9b9-754c7a684584)
