### PR TITLE
Add language toggle cypress test for static pages

### DIFF
--- a/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
@@ -38,3 +38,16 @@ describe(`GCA a11y tests [${config.CONFIG_NAME}]`, () => {
         });
     }
 });
+
+describe('Language toggle works on all pages', () => {
+    for (const page of fullPageList) {
+        it(`${page.en}`, () => {
+            cy.visit(page.en);
+            cy.get('#header-lang').click();
+            cy.url().should('contain', page.fr);
+
+            cy.get('#header-lang').click();
+            cy.url().should('contain', page.en);
+        });
+    }
+});


### PR DESCRIPTION
# Summary | Résumé

This PR adds a new set of tests to ensure the language toggle on each GCA page works properly.
