### PR TITLE
Add aria-describedby to template links

### DIFF
--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -45,17 +45,18 @@
               {{- format_item_name(ancestor.name) -}}
             </a> <span class="message-name-separator"></span>
           {% endfor %}
+          {# TODO: Add Cypress test to ensure describedby is present and properly associated with the link #}
           {% if item.is_folder %}
-            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id, view='sending' if sending_view else None) }}" class="template-list-folder">
+            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id, view='sending' if sending_view else None) }}" aria-describedby="{{ item.id }}" class="template-list-folder">
               <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
             </a>
           {% else %}
-            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" class="template-list-template">
+            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" aria-describedby="{{ item.id }}" class="template-list-template">
               <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
             </a>
           {% endif %}
         </p>
-        <p class="message-type">
+        <p id="{{ item.id }}" class="message-type">
           {{ _(item.hint) }}
         </p>
       </div>

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -47,16 +47,16 @@
           {% endfor %}
           {# TODO: Add Cypress test to ensure describedby is present and properly associated with the link #}
           {% if item.is_folder %}
-            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id, view='sending' if sending_view else None) }}" aria-describedby="{{ item.id }}" class="template-list-folder">
+            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id, view='sending' if sending_view else None) }}" aria-describedby="{{ item.name + item.id }}" class="template-list-folder">
               <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
             </a>
           {% else %}
-            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" aria-describedby="{{ item.id }}" class="template-list-template">
+            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" aria-describedby="{{item.name}}{{ item.id }}" class="template-list-template">
               <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
             </a>
           {% endif %}
         </p>
-        <p id="{{ item.id }}" class="message-type">
+        <p id="{{item.name}}{{ item.id }}" class="message-type">
           {{ _(item.hint) }}
         </p>
       </div>

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -47,16 +47,16 @@
           {% endfor %}
           {# TODO: Add Cypress test to ensure describedby is present and properly associated with the link #}
           {% if item.is_folder %}
-            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id, view='sending' if sending_view else None) }}" aria-describedby="{{ item.name }}{{ item.id }}" class="template-list-folder">
+            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id, view='sending' if sending_view else None) }}" aria-describedby="sr-{{ item.id }}" class="template-list-folder">
               <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
             </a>
           {% else %}
-            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" aria-describedby="{{ item.name }}{{ item.id }}" class="template-list-template">
+            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" aria-describedby="sr-{{ item.id }}" class="template-list-template">
               <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
             </a>
           {% endif %}
         </p>
-        <p id="{{item.name}}{{ item.id }}" class="message-type">
+        <p id="sr-{{ item.id }}" class="message-type">
           {{ _(item.hint) }}
         </p>
       </div>

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -47,11 +47,11 @@
           {% endfor %}
           {# TODO: Add Cypress test to ensure describedby is present and properly associated with the link #}
           {% if item.is_folder %}
-            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id, view='sending' if sending_view else None) }}" aria-describedby="{{ item.name + item.id }}" class="template-list-folder">
+            <a href="{{ url_for('.choose_template', service_id=current_service.id, template_type=template_type, template_folder_id=item.id, view='sending' if sending_view else None) }}" aria-describedby="{{ item.name }}{{ item.id }}" class="template-list-folder">
               <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
             </a>
           {% else %}
-            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" aria-describedby="{{item.name}}{{ item.id }}" class="template-list-template">
+            <a href="{{ url_for('.view_template', service_id=current_service.id, template_id=item.id) }}" aria-describedby="{{ item.name }}{{ item.id }}" class="template-list-template">
               <span class="live-search-relevant">{{ format_item_name(item.name) }}</span>
             </a>
           {% endif %}


### PR DESCRIPTION
# Summary | Résumé
Screen readers should now read the template name, as well as the template type when selecting either the checkbox for the template, or the link to the template

# Test instructions | Instructions pour tester la modification
1. Navigate to the templates page
2. Turn on your screen reader
3. Put the focus on the checkbox for a template and note that the template name and type is read
4. Put the focus on the link to the template and note that the template name and type is read
5. Put the focus on a folder link, note that the folder name, and number of children in the folder is read

![image](https://github.com/cds-snc/notification-admin/assets/7444334/cbc9f455-cfb9-47a7-a671-fddc708ac44c)
![image](https://github.com/cds-snc/notification-admin/assets/7444334/b467563c-a86d-435d-be91-a2d21b181206)


