### PR TITLE
fix(cypress): update config to point to staging instead of local

### DIFF
--- a/tests_cypress/config.js
+++ b/tests_cypress/config.js
@@ -72,6 +72,6 @@ const config = {
 };
 
 // choose which config to use here
-const ConfigToUse = config.LOCAL;
+const ConfigToUse = config.STAGING;
 
 module.exports = ConfigToUse;


### PR DESCRIPTION
# Summary | Résumé

This PR updates the cypress config to point to staging instead of localhost.

