### PR TITLE
Add current page indicators to main menu and platform admin menu

### DIFF
--- a/app/templates/components/nav_menu_item.html
+++ b/app/templates/components/nav_menu_item.html
@@ -14,6 +14,7 @@
           href="{{ url }}"
           class="text-smaller text-blue bg-gray py-5 font-bold no-underline self-center hover:underline line-under border-b-4 border-transparent visited:text-blue link:text-blue focus:border-b-4 focus:bg-yellow focus:border-blue focus:outline-none {{ css_classes }}"
           {% if is_external_link %}target="_blank"{% endif %}
+          {% if css_classes and "header--active" in css_classes %}aria-current="page"{% endif %}
         >{{ localised_txt }}
           {% if is_external_link %}<i aria-hidden="true" class="pl-2 fa-solid fa-arrow-up-right-from-square"></i>{% endif %}
         </a>

--- a/app/templates/views/platform-admin/_base_template.html
+++ b/app/templates/views/platform-admin/_base_template.html
@@ -26,8 +26,11 @@
             <a
               aria-label="{{ _(link_text) }}" 
               href="{{ url_for('main.'+view) }}"
-              class="no-underline text-blue visited:text-blue link:text-blue text-smaller">
+              class="no-underline text-blue visited:text-blue link:text-blue text-smaller"
+              {% if admin_navigation.is_selected(view) %}aria-current="page"{% endif %}
+              >
               {{ _(link_text) }}
+              
             </a>
           </div>
         {% endfor %}


### PR DESCRIPTION
# Summary | Résumé
This PR adds current page indications using the `aria-current` attribute.  It updates the main menu for all users as well as the menu on the platform admin page.

# Test instructions | Instructions pour tester la modification
- Inspect the source of the main menu on the site and ensure `aria-current="page"` is set on the active menu item
- Inspect the source of the platform admin menu and ensure `aria-current="page"` is set on the active menu item
