### PR TITLE
Tweak 2fa form def in forms.py. Fix tests

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -183,7 +183,7 @@ class TwoFactorCode(StringField):
     ]
 
     def __call__(self, **kwargs):
-        return super().__call__(type="tel", pattern="[0-9]*", **kwargs)
+        return super().__call__(type="text", inputmode="numeric", autocomplete="one-time-code", pattern="[0-9]*", **kwargs)
 
 
 class ForgivingIntegerField(StringField):

--- a/app/templates/views/two-factor-email.html
+++ b/app/templates/views/two-factor-email.html
@@ -29,7 +29,6 @@
         form.two_factor_code,
         width='form-control-5em',
         autofocus=True,
-        autocomplete='one-time-code'
       ) }}
       {{ page_footer(
         continue,

--- a/tests/app/main/views/test_two_factor.py
+++ b/tests/app/main/views/test_two_factor.py
@@ -37,7 +37,9 @@ def test_should_render_sms_two_factor_page(
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
     assert page.select_one("main p").text.strip() == ("We’ve sent you a text message with a security code.")
     assert page.select_one("label").text.strip("Text message code")
-    assert page.select_one("input")["type"] == "tel"
+    assert page.select_one("input")["type"] == "text"
+    assert page.select_one("input")["autocomplete"] == "one-time-code"
+    assert page.select_one("input")["inputmode"] == "numeric"
     assert page.select_one("input")["pattern"] == "[0-9]*"
 
 
@@ -80,7 +82,9 @@ def test_should_render_email_two_factor_page(
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
     assert page.select_one("main p").text.strip() == ("We’ve sent you an email with a security code.")
     assert page.select_one("label").text.strip("Text message code")
-    assert page.select_one("input")["type"] == "tel"
+    assert page.select_one("input")["type"] == "text"
+    assert page.select_one("input")["autocomplete"] == "one-time-code"
+    assert page.select_one("input")["inputmode"] == "numeric"
     assert page.select_one("input")["pattern"] == "[0-9]*"
 
 


### PR DESCRIPTION
# Summary | Résumé

https://github.com/cds-snc/notification-planning/issues/1457

This fixes the issue and updates the 2fa field to a more modern pattern:

- type is text
- inputmode is numeric
- autocomplete is one-time-code
- pattern stays [0-9]*


I focused my changes in forms.py. I think its cleaner than in the (sms and email) templates since all 2fa inputs should behave the same. 

Edited the tests. 

# Test instructions | Instructions pour tester la modification

1. Sign in
2. Inspect 2fa code input. It should have all the props listed above. 
