### PR TITLE
Make copy template links clearer for all and for SR

### DIFF
--- a/app/templates/views/templates/copy.html
+++ b/app/templates/views/templates/copy.html
@@ -4,13 +4,13 @@
 {% extends "admin_template.html" %}
 
 {% block service_page_title %}
-  {{ _('Copy an existing template') }}
+  {{ _('Copy an existing template') }} {{ _("into") }} {{ current_service.name }}
 {% endblock %}
 
 {% block maincolumn_content %}
 
     <div class="mb-12 clear-both contain-floats">
-      <h1 class="heading-large">{{ _('Copy an existing template') }}</h1>
+      <h1 class="heading-large">{{ _('Copy an existing template') }} {{ _("into") }} {{ current_service.name }}</h1>
       {{ copy_folder_path(template_folder_path, current_service.id, from_service, current_user) }}
     </div>
     {% if not services_templates_and_folders.templates_to_show %}
@@ -42,7 +42,7 @@
                 </a>
               {% else %}
                 <a href="{{ url_for('.copy_template', service_id=current_service.id, template_id=item.id, from_service=item.service_id) }}">
-                  <span class="live-search-relevant">{{ item.name }}</span>
+                  {{ _("Copy") }} <span class="live-search-relevant">{{ item.name }}</span> <span class="sr-only">{{ _("into") }} {{ current_service.name }}</span>
                 </a>
               {% endif %}
             </h2>

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -9,6 +9,8 @@
 "From","De"
 "from","de"
 "To","À"
+"into","vers"
+"Into","Vers"
 "Subject","Objet"
 "Reply to","Répondre à"
 "From:","De&nbsp;:"

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -887,19 +887,19 @@ def test_choose_a_template_to_copy(
 
     expected = [
         ("Service 1 " "6 templates"),
-        ("Service 1 sms_template_one " "Text message template"),
-        ("Service 1 sms_template_two " "Text message template"),
-        ("Service 1 email_template_one " "Email template"),
-        ("Service 1 email_template_two " "Email template"),
-        ("Service 1 letter_template_one " "Letter template"),
-        ("Service 1 letter_template_two " "Letter template"),
+        ("Service 1 Copy sms_template_one into service one " "Text message template"),
+        ("Service 1 Copy sms_template_two into service one " "Text message template"),
+        ("Service 1 Copy email_template_one into service one " "Email template"),
+        ("Service 1 Copy email_template_two into service one " "Email template"),
+        ("Service 1 Copy letter_template_one into service one " "Letter template"),
+        ("Service 1 Copy letter_template_two into service one " "Letter template"),
         ("Service 2 " "6 templates"),
-        ("Service 2 sms_template_one " "Text message template"),
-        ("Service 2 sms_template_two " "Text message template"),
-        ("Service 2 email_template_one " "Email template"),
-        ("Service 2 email_template_two " "Email template"),
-        ("Service 2 letter_template_one " "Letter template"),
-        ("Service 2 letter_template_two " "Letter template"),
+        ("Service 2 Copy sms_template_one into service one " "Text message template"),
+        ("Service 2 Copy sms_template_two into service one " "Text message template"),
+        ("Service 2 Copy email_template_one into service one " "Email template"),
+        ("Service 2 Copy email_template_two into service one " "Email template"),
+        ("Service 2 Copy letter_template_one into service one " "Letter template"),
+        ("Service 2 Copy letter_template_two into service one " "Letter template"),
     ]
     actual = page.select(".template-list-item")
 
@@ -941,12 +941,12 @@ def test_choose_a_template_to_copy_when_user_has_one_service(
     assert page.select(".folder-heading") == []
 
     expected = [
-        ("sms_template_one " "Text message template"),
-        ("sms_template_two " "Text message template"),
-        ("email_template_one " "Email template"),
-        ("email_template_two " "Email template"),
-        ("letter_template_one " "Letter template"),
-        ("letter_template_two " "Letter template"),
+        ("Copy sms_template_one into service one " "Text message template"),
+        ("Copy sms_template_two into service one " "Text message template"),
+        ("Copy email_template_one into service one " "Email template"),
+        ("Copy email_template_two into service one " "Email template"),
+        ("Copy letter_template_one into service one " "Letter template"),
+        ("Copy letter_template_two into service one " "Letter template"),
     ]
     actual = page.select(".template-list-item")
 
@@ -1015,8 +1015,8 @@ def test_choose_a_template_to_copy_from_folder_within_service(
     expected = [
         ("Child folder empty " "Empty"),
         ("Child folder non-empty " "1 template"),
-        ("Child folder non-empty Should appear in list (nested) " "Text message template"),
-        ("Should appear in list (at same level) " "Text message template"),
+        ("Child folder non-empty Copy Should appear in list (nested) into service one " "Text message template"),
+        ("Copy Should appear in list (at same level) into service one " "Text message template"),
     ]
     actual = page.select(".template-list-item")
 


### PR DESCRIPTION
# Summary | Résumé

For https://github.com/cds-snc/notification-planning/issues/1462

To fix this issue, I did:

1. Add details to the title: "Copy existing templates into {service name}" Hopefully this makes the destination clear for everyone.
2. Add a "Copy {template name}" prefix to make the action clear for all.
3. Add a hidden suffix "into {service name}" so that each link is extra clear for SR users. Maybe too verbose, so Id like to test if the h1 was sufficient for SR users too... We can safely merge this is and test later. 


# Test instructions | Instructions pour tester la modification
1. Get into the copy template flow
2. Navigate through services and folders
3. It helps to have many services and folders
4. Notice the added context 
5. Inspect the hidden context
6. Test with voice over on chrome. 
