### PR TITLE
chore: bump utils to 52.1.9

### DIFF
--- a/.github/workflows/test_endpoints.yaml
+++ b/.github/workflows/test_endpoints.yaml
@@ -58,7 +58,7 @@ jobs:
         echo "PYTHONPATH=/github/workspace/env/site-packages:${{ env.PYTHONPATH}}" >> $GITHUB_ENV
 
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@2da74685e0ffb220f0403e1f2584e783be99bbad # 52.1.0
+      uses: cds-snc/notification-utils/.github/actions/waffles@525721f8da23dd12c5183ffeb862cdcae45e1a4a # 52.1.9
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/poetry.lock
+++ b/poetry.lock
@@ -1442,7 +1442,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "52.1.8"
+version = "52.1.9"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.10.9"
@@ -1477,8 +1477,8 @@ werkzeug = "2.3.7"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "52.1.8"
-resolved_reference = "b81765b0d1a4ba437c92d64223a9ccb6015eb60d"
+reference = "52.1.9"
+resolved_reference = "525721f8da23dd12c5183ffeb862cdcae45e1a4a"
 
 [[package]]
 name = "openpyxl"
@@ -2475,4 +2475,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.9"
-content-hash = "916cf13b2e77c37c98b15c928144ad43f243e0c30645a8370683314dbf2e2d56"
+content-hash = "46058674fab2d0adb5ae5ac6db007121d3f6ee1c2f6fb18c83eae0f8dd3b3d64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ unidecode = "^1.3.6"
 
 # PaaS
 awscli-cwlogs = "^1.4.6"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "52.1.8" }
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "52.1.9" }
 
 
 # Pinned dependencies


### PR DESCRIPTION
# Summary | Résumé

This PR updates the notification-utils version to 52.1.8 so we can make use of recent changes.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1456
