### PR TITLE
task: update login process to handle new format of 2FA email

### DIFF
--- a/tests_cypress/cypress/Notify/Admin/Pages/LoginPage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/LoginPage.js
@@ -42,16 +42,16 @@ let Actions = {
             });
 
         // ensure code is received and enter it
-        cy.contains('p', "security code to log in").should('be.visible');
-        cy.contains('p', 'security code to log in').invoke('text').as('MFACode');
+        cy.get('blockquote').should('be.visible');
+        cy.get('blockquote p strong').invoke('text').as('MFACode');
         cy.get('@MFACode').then((text) => {
-            let code = text.slice(0, 5);
+            let code = text;
             cy.visit('/two-factor-email-sent');
             Actions.EnterCode(code);
         });
     
         // ensure we logged in correctly
-        cy.contains('h1', 'Sign-in history', { timeout: 10000 }).should('be.visible');
+        cy.contains('h1', 'Sign-in history').should('be.visible');
     }
 };
 


### PR DESCRIPTION
# Summary | Résumé
This PR updates the login code in the cypress tests to handle the new format of the 2FA code introduced in https://github.com/cds-snc/notification-api/pull/2161

## Login email before
![image](https://github.com/cds-snc/notification-api/assets/823749/7f6c3256-b9f4-49a7-baf2-9e0459adb7f8)

## Login email after
![image](https://github.com/cds-snc/notification-api/assets/823749/9c4250e6-aa0c-4df4-b18d-e8df935e0d32)

# Test instructions | Instructions pour tester la modification
- Run the cypress app pages tests and they should work.

# Release notes
- This PR should be merged at the same time as https://github.com/cds-snc/notification-api/pull/2161
