### PR TITLE
upgrade gunicorn

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -981,22 +981,23 @@ test = ["objgraph", "psutil"]
 
 [[package]]
 name = "gunicorn"
-version = "20.1.0"
+version = "22.0.0"
 description = "WSGI HTTP Server for UNIX"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 files = [
-    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
-    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
+    {file = "gunicorn-22.0.0-py3-none-any.whl", hash = "sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9"},
+    {file = "gunicorn-22.0.0.tar.gz", hash = "sha256:4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63"},
 ]
 
 [package.dependencies]
-setuptools = ">=3.0"
+packaging = "*"
 
 [package.extras]
-eventlet = ["eventlet (>=0.24.1)"]
+eventlet = ["eventlet (>=0.24.1,!=0.36.0)"]
 gevent = ["gevent (>=1.4.0)"]
 setproctitle = ["setproctitle"]
+testing = ["coverage", "eventlet", "gevent", "pytest", "pytest-cov"]
 tornado = ["tornado (>=0.2)"]
 
 [[package]]
@@ -2475,4 +2476,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.9"
-content-hash = "9d7a6b0cd111073cd9096558d16f625316054979596cc6fd570ea397954c2705"
+content-hash = "506abf3c2800023462c953f754f7e4a98ba50930d6783381d992f4767de2ddef"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ pyexcel-xls = "0.7.0"
 pyexcel-xlsx = "0.6.0"
 pyexcel-ods3 = "0.6.1"
 pytz = "2021.3"
-gunicorn = "20.1.0"
+gunicorn = "22.0.0"
 gevent = "23.9.1"
 notifications-python-client = "6.4.1"
 


### PR DESCRIPTION
# Summary | Résumé

Upgrade gunicorn (used to run flask in the docker images, not the devcontainer though).

# Test instructions | Instructions pour tester la modification

Tested by building the docker image locally and running. **Note**: you can't be running the admin devcontainer at the same time or you won't be able to bind to the port 😱 
- run api / celery locally if that's your jam
- `docker build -t testadmin -f ci/Dockerfile .`
- `docker run -p 127.0.0.1:6012:6012 --env-file .env testadmin`
