### PR TITLE
fix: update how 2fa code is parsed in verify email

### DIFF
--- a/tests_cypress/cypress/Notify/Admin/Pages/LoginPage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/LoginPage.js
@@ -43,7 +43,7 @@ let Actions = {
 
         // ensure code is received and enter it
         cy.get('blockquote').should('be.visible');
-        cy.get('blockquote p strong').invoke('text').as('MFACode');
+        cy.get('blockquote p').invoke('text').as('MFACode');
         cy.get('@MFACode').then((text) => {
             let code = text;
             cy.visit('/two-factor-email-sent');


### PR DESCRIPTION
# Summary | Résumé

This updates the 2fa code extraction logic for changes made in https://github.com/cds-snc/notification-api/pull/2168
