### PR TITLE
Task/fix update email branding

### DIFF
--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -50,13 +50,15 @@ def email_branding():
 def update_email_branding(branding_id, logo=None):
     all_organisations = organisations_client.get_organisations()
     email_branding = email_branding_client.get_email_branding(branding_id)["email_branding"]
+    import pdb
 
+    pdb.set_trace()
     form = ServiceUpdateEmailBranding(
         name=email_branding["name"],
         text=email_branding["text"],
         colour=email_branding["colour"],
         brand_type=email_branding["brand_type"],
-        organisation=email_branding["organisation_id"] if email_branding["organisation_id"] != '' else "-1",
+        organisation=email_branding["organisation_id"] if email_branding["organisation_id"] != "" else "-1"
         alt_text_en=email_branding["alt_text_en"],
         alt_text_fr=email_branding["alt_text_fr"],
     )

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -50,15 +50,12 @@ def email_branding():
 def update_email_branding(branding_id, logo=None):
     all_organisations = organisations_client.get_organisations()
     email_branding = email_branding_client.get_email_branding(branding_id)["email_branding"]
-    import pdb
-
-    pdb.set_trace()
     form = ServiceUpdateEmailBranding(
         name=email_branding["name"],
         text=email_branding["text"],
         colour=email_branding["colour"],
         brand_type=email_branding["brand_type"],
-        organisation=email_branding["organisation_id"] if email_branding["organisation_id"] != "" else "-1"
+        organisation=email_branding["organisation_id"] if email_branding["organisation_id"] != "" else "-1",
         alt_text_en=email_branding["alt_text_en"],
         alt_text_fr=email_branding["alt_text_fr"],
     )

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -62,6 +62,7 @@ def update_email_branding(branding_id, logo=None):
 
     form.organisation.choices = [(org["id"], org["name"]) for org in all_organisations]
     # add the option for no org
+    form.organisation.choices.append(("", "No organisation"))
     form.organisation.choices.append(("-1", "No organisation"))
 
     logo = logo if logo else email_branding.get("logo") if email_branding else None

--- a/app/main/views/email_branding.py
+++ b/app/main/views/email_branding.py
@@ -56,7 +56,7 @@ def update_email_branding(branding_id, logo=None):
         text=email_branding["text"],
         colour=email_branding["colour"],
         brand_type=email_branding["brand_type"],
-        organisation="-1",
+        organisation=email_branding["organisation_id"] if email_branding["organisation_id"] != '' else "-1",
         alt_text_en=email_branding["alt_text_en"],
         alt_text_fr=email_branding["alt_text_fr"],
     )
@@ -96,7 +96,7 @@ def update_email_branding(branding_id, logo=None):
             text=form.text.data,
             colour=form.colour.data,
             brand_type=form.brand_type.data,
-            organisation_id=form.organisation.data,
+            organisation_id=form.organisation.data if form.organisation.data != "-1" else None,
             alt_text_en=form.alt_text_en.data,
             alt_text_fr=form.alt_text_fr.data,
         )

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -304,7 +304,7 @@ def test_update_existing_branding(
         text=data["text"],
         colour=data["colour"],
         brand_type=data["brand_type"],
-        organisation_id="-1",
+        organisation_id=data["organisation_id"],
         alt_text_en=data["alt_text_en"],
         alt_text_fr=data["alt_text_fr"],
     )

--- a/tests/app/main/views/test_email_branding.py
+++ b/tests/app/main/views/test_email_branding.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from unittest import mock
 from unittest.mock import call
 
 import pytest
@@ -254,7 +255,6 @@ def test_update_existing_branding(
     platform_admin_client,
     mocker,
     fake_uuid,
-    mock_get_email_branding,
     mock_update_email_branding,
     mock_get_organisations,
 ):
@@ -266,48 +266,64 @@ def test_update_existing_branding(
         "colour": "#0000ff",
         "text": "new text",
         "name": "new name",
+        "organisation_id": None,
         "brand_type": "both_english",
         "alt_text_en": "Alt text english",
-        "alt_text_fr": "Alt text french",
+        "alt_text_fr": "Alt text french yolo",
     }
 
-    temp_filename = EMAIL_LOGO_LOCATION_STRUCTURE.format(
-        temp=TEMP_TAG.format(user_id=user_id),
-        unique_id=fake_uuid,
-        filename=data["logo"],
-    )
+    with mock.patch("app.main.views.email_branding.email_branding_client.get_email_branding") as mock_get_email_branding:
+        mock_get_email_branding.return_value = {
+            "email_branding": {
+                "logo": "example.png",
+                "name": "Organisation name",
+                "text": "Organisation text",
+                "id": fake_uuid,
+                "colour": "#f00",
+                "brand_type": "custom_logo",
+                "organisation_id": "",  # Test that we can set alt text when no org is set
+                "alt_text_en": "Alt text english",
+                "alt_text_fr": "Alt text french",
+            }
+        }
 
-    mocker.patch("app.main.views.email_branding.persist_logo")
-    mocker.patch("app.main.views.email_branding.delete_email_temp_files_created_by")
+        temp_filename = EMAIL_LOGO_LOCATION_STRUCTURE.format(
+            temp=TEMP_TAG.format(user_id=user_id),
+            unique_id=fake_uuid,
+            filename=data["logo"],
+        )
 
-    platform_admin_client.post(
-        url_for(".update_email_branding", logo=temp_filename, branding_id=fake_uuid),
-        content_type="multipart/form-data",
-        data={
-            "colour": data["colour"],
-            "name": data["name"],
-            "text": data["text"],
-            "cdn_url": get_logo_cdn_domain(),
-            "brand_type": data["brand_type"],
-            "alt_text_en": data["alt_text_en"],
-            "alt_text_fr": data["alt_text_fr"],
-        },
-    )
+        mocker.patch("app.main.views.email_branding.persist_logo")
+        mocker.patch("app.main.views.email_branding.delete_email_temp_files_created_by")
 
-    updated_logo_name = "{}-{}".format(fake_uuid, data["logo"])
+        platform_admin_client.post(
+            url_for(".update_email_branding", logo=temp_filename, branding_id=fake_uuid),
+            content_type="multipart/form-data",
+            data={
+                "colour": data["colour"],
+                "name": data["name"],
+                "text": data["text"],
+                "cdn_url": get_logo_cdn_domain(),
+                "brand_type": data["brand_type"],
+                "alt_text_en": data["alt_text_en"],
+                "alt_text_fr": data["alt_text_fr"],
+            },
+        )
 
-    assert mock_update_email_branding.called
-    assert mock_update_email_branding.call_args == call(
-        branding_id=fake_uuid,
-        logo=updated_logo_name,
-        name=data["name"],
-        text=data["text"],
-        colour=data["colour"],
-        brand_type=data["brand_type"],
-        organisation_id=data["organisation_id"],
-        alt_text_en=data["alt_text_en"],
-        alt_text_fr=data["alt_text_fr"],
-    )
+        updated_logo_name = "{}-{}".format(fake_uuid, data["logo"])
+
+        assert mock_update_email_branding.called
+        assert mock_update_email_branding.call_args == call(
+            branding_id=fake_uuid,
+            logo=updated_logo_name,
+            name=data["name"],
+            text=data["text"],
+            colour=data["colour"],
+            brand_type=data["brand_type"],
+            organisation_id=data["organisation_id"],
+            alt_text_en=data["alt_text_en"],
+            alt_text_fr=data["alt_text_fr"],
+        )
 
 
 def test_temp_logo_is_shown_after_uploading_logo(


### PR DESCRIPTION
# Summary | Résumé

This is the bug:
```
This may be unrelated to this work, but when I try to update an existing branding to add en/fr alt text with No organisation  selected SQLAlchemy in API complains about the organisation_id being -1:

sqlalchemy.exc.DataError: (psycopg2.errors.InvalidTextRepresentation) invalid input syntax for type uuid: "-1"
LINE 1: ...E email_branding SET colour=NULL, organisation_id='-1', alt_...
                                                             ^
[SQL: UPDATE email_branding SET colour=%(colour)s, organisation_id=%(organisation_id)s, alt_text_en=%(alt_text_en)s, alt_text_fr=%(alt_text_fr)s WHERE email_branding.id = %(email_branding_id)s]
[parameters: {'colour': None, 'organisation_id': '-1', 'alt_text_en': 'abc', 'alt_text_fr': 'bcb', 'email_branding_id': UUID('c90eff6c-fa2f-48f6-ac58-a589442b27ae')}]
```

# Test instructions | Instructions pour tester la modification

1. Go to admin - edit an existing email brand
2. Ensure the org of that email brand is "No organisation"
3. Update information about that email brand