### PR TITLE
feat(magic-link): add routing and page for magic link based login

### DIFF
--- a/app/main/views/two_factor.py
+++ b/app/main/views/two_factor.py
@@ -68,6 +68,7 @@ def magic_login_link(code):
         title=title,
     )
 
+
 @main.route("/two-factor-sms-sent", methods=["GET", "POST"])
 @redirect_to_sign_in
 def two_factor_sms_sent():

--- a/app/templates/views/magic-link-expired.html
+++ b/app/templates/views/magic-link-expired.html
@@ -1,0 +1,20 @@
+{% extends  "admin_template.html" %}
+{% from "components/textbox.html" import textbox %}
+{% from "components/page-footer.html" import page_footer %}
+{% from "components/form.html" import form_wrapper %}
+
+{% block per_page_title %}
+{{ _('Magic link expired') }}
+{% endblock %}
+
+{% block maincolumn_content %}
+
+<div class="grid-row contain-floats">
+  <div class="md:w-2/3 float-left py-0 px-0 px-gutterHalf box-border">
+    <h1 class="heading-large">MAGIC LINK EXPIRED</h1>
+
+    <p>YOUR LINK EXPIRED :( Better luck next time!</p>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
# Summary | Résumé
This PR adds support for receiving a GET request to login via a "magic link" and adds a page to show if the link has expired before the user clicks it.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/603

# Test instructions | Instructions pour tester la modification

- Test this in conjunction with https://github.com/cds-snc/notification-api/pull/2170