### PR TITLE
Remove contact us request for increasing API rate

### DIFF
--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -49,9 +49,6 @@
     <h2 class="heading-small">
       {{ _('Your API rate limit is {} calls per minute').format(current_service.rate_limit | format_number) }}
     </h2>
-    <p>
-      {{ _("To request an API rate increase, <a href='{}'>contact us</a>.").format(url_for('.contact')) }}
-    </p>
   </div>
 
   <div class="grid-row flex items-baseline">


### PR DESCRIPTION
# Summary | Résumé

Remove contact us line for API rate limit

> 1-3 sentence description of the changed you're proposing, including a link to
https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1497