### PR TITLE
Task/improve cypress ci

### DIFF
--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -179,4 +179,4 @@ jobs:
           build: npx cypress info
           working-directory: tests_cypress
           spec: |
-            cypress/e2e/admin/a11y/ci.cy.js
+            cypress/e2e/admin/ci.cy.js

--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -179,4 +179,4 @@ jobs:
           build: npx cypress info
           working-directory: tests_cypress
           spec: |
-            cypress/e2e/admin/a11y/app_pages.cy.js
+            cypress/e2e/admin/a11y/ci.cy.js

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ format:
 	flake8 ./app ./tests
 	isort --check-only ./app ./tests
 	mypy ./
-	npx prettier --write app/assets/javascripts app/assets/stylesheets
+	npx prettier --write app/assets/javascripts app/assets/stylesheets tests_cypress/cypress/e2e
 
 .PHONY: tailwind
 tailwind:

--- a/tests_cypress/cypress/e2e/admin/a11y/all.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/all.cy.js
@@ -1,3 +1,3 @@
 // import './gca_pages.cy';
-import './app_pages.cy';
-import './gca_pages.cy';
+import "./app_pages.cy";
+import "./gca_pages.cy";

--- a/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
@@ -3,46 +3,98 @@
 import config from "../../../../config";
 
 const pages = [
-    { name: "Landing page", route: "/accounts" },
-    { name: "Your profile", route: "/user-profile" },
-    { name: "Dashboard", route: `/services/${config.Services.Cypress}` },
-    { name: "Dashboard > Notification reports", route: `/services/${config.Services.Cypress}/notifications/email?status=sending,delivered,failed` },
-    { name: "Dashboard > Problem emails", route: `/services/${config.Services.Cypress}/problem-emails` },
-    { name: "Dashboard > Monthly usage", route: `/services/${config.Services.Cypress}/monthly` },
-    { name: "Dashboard > Template usage", route: `/services/${config.Services.Cypress}/template-usage` },
-    { name: "Dashboard > Create template", route: `/services/${config.Services.Cypress}/templates/create?source=dashboard` },
-    { name: "Dashboard > Select template", route: `/services/${config.Services.Cypress}/templates?view=sending` },
-    { name: "API", route: `/services/${config.Services.Cypress}/api` },
-    { name: "API > Keys", route: `/services/${config.Services.Cypress}/api/keys` },
-    { name: "API > Keys > Create", route: `/services/${config.Services.Cypress}/api/keys/create` },
-    { name: "API > Safelist", route: `/services/${config.Services.Cypress}/api/safelist` },
-    { name: "API > Callbacks", route: `/services/${config.Services.Cypress}/api/callbacks/delivery-status-callback` },
-    { name: "Team members", route: `/services/${config.Services.Cypress}/users` },
-    { name: "Settings", route: `/services/${config.Services.Cypress}/service-settings` },
-    { name: "Settings > Change service name", route: `/services/${config.Services.Cypress}/service-settings/name` },
-    { name: "Templates", route: `/services/${config.Services.Cypress}/templates` },
-    { name: "Template > View template", route: `/services/${config.Services.Cypress}/templates/${config.Templates.SMOKE_TEST_EMAIL}` },
-    { name: "Template > Edit template", route: `/services/${config.Services.Cypress}/templates/${config.Templates.SMOKE_TEST_EMAIL}/edit` },
-    { name: "Template > Preview template", route: `/services/${config.Services.Cypress}/templates/${config.Templates.SMOKE_TEST_EMAIL}/preview` },
-    { name: "GC Notify Activity", route: '/activity' },
-    { name: "Contact us", route: '/contact' },
-    { name: "Create an account", route: '/register' },
-    { name: "Sign in", route: '/sign-in' },
+  { name: "Landing page", route: "/accounts" },
+  { name: "Your profile", route: "/user-profile" },
+  { name: "Dashboard", route: `/services/${config.Services.Cypress}` },
+  {
+    name: "Dashboard > Notification reports",
+    route: `/services/${config.Services.Cypress}/notifications/email?status=sending,delivered,failed`,
+  },
+  {
+    name: "Dashboard > Problem emails",
+    route: `/services/${config.Services.Cypress}/problem-emails`,
+  },
+  {
+    name: "Dashboard > Monthly usage",
+    route: `/services/${config.Services.Cypress}/monthly`,
+  },
+  {
+    name: "Dashboard > Template usage",
+    route: `/services/${config.Services.Cypress}/template-usage`,
+  },
+  {
+    name: "Dashboard > Create template",
+    route: `/services/${config.Services.Cypress}/templates/create?source=dashboard`,
+  },
+  {
+    name: "Dashboard > Select template",
+    route: `/services/${config.Services.Cypress}/templates?view=sending`,
+  },
+  { name: "API", route: `/services/${config.Services.Cypress}/api` },
+  {
+    name: "API > Keys",
+    route: `/services/${config.Services.Cypress}/api/keys`,
+  },
+  {
+    name: "API > Keys > Create",
+    route: `/services/${config.Services.Cypress}/api/keys/create`,
+  },
+  {
+    name: "API > Safelist",
+    route: `/services/${config.Services.Cypress}/api/safelist`,
+  },
+  {
+    name: "API > Callbacks",
+    route: `/services/${config.Services.Cypress}/api/callbacks/delivery-status-callback`,
+  },
+  { name: "Team members", route: `/services/${config.Services.Cypress}/users` },
+  {
+    name: "Settings",
+    route: `/services/${config.Services.Cypress}/service-settings`,
+  },
+  {
+    name: "Settings > Change service name",
+    route: `/services/${config.Services.Cypress}/service-settings/name`,
+  },
+  {
+    name: "Templates",
+    route: `/services/${config.Services.Cypress}/templates`,
+  },
+  {
+    name: "Template > View template",
+    route: `/services/${config.Services.Cypress}/templates/${config.Templates.SMOKE_TEST_EMAIL}`,
+  },
+  {
+    name: "Template > Edit template",
+    route: `/services/${config.Services.Cypress}/templates/${config.Templates.SMOKE_TEST_EMAIL}/edit`,
+  },
+  {
+    name: "Template > Preview template",
+    route: `/services/${config.Services.Cypress}/templates/${config.Templates.SMOKE_TEST_EMAIL}/preview`,
+  },
+  { name: "GC Notify Activity", route: "/activity" },
+  { name: "Contact us", route: "/contact" },
+  { name: "Create an account", route: "/register" },
+  { name: "Sign in", route: "/sign-in" },
 ];
 
 describe(`A11Y - App pages [${config.CONFIG_NAME}]`, () => {
-    retryableBefore(() => {
-        cy.login(Cypress.env('NOTIFY_USER'), Cypress.env('NOTIFY_PASSWORD'));
-        cy.task('log', "Running against:" + Cypress.config('baseUrl'))
+  retryableBefore(() => {
+    cy.login(Cypress.env("NOTIFY_USER"), Cypress.env("NOTIFY_PASSWORD"));
+    cy.task("log", "Running against:" + Cypress.config("baseUrl"));
+  });
+
+  for (const page of pages) {
+    it(`${page.name}`, () => {
+      cy.a11yScan(page.route, {
+        a11y: true,
+        htmlValidate: true,
+        mimeTypes: false,
+        deadLinks: false,
+      });
     });
-
-    for (const page of pages) {
-        it(`${page.name}`, () => {
-            cy.a11yScan(page.route, { a11y: true, htmlValidate: true, mimeTypes: false, deadLinks: false });
-        });
-    }
+  }
 });
-
 
 /**
  * A `before()` alternative that gets run when a failing test is retried.
@@ -56,24 +108,24 @@ describe(`A11Y - App pages [${config.CONFIG_NAME}]`, () => {
  * https://stackoverflow.com/questions/71285827/cypress-e2e-before-hook-not-working-on-retries
  */
 function retryableBefore(fn) {
-    let shouldRun = true;
+  let shouldRun = true;
 
-    // we use beforeEach as cypress will run this on retry attempt
-    // we just abort early if we detected that it's already run
-    beforeEach(() => {
-      if (!shouldRun) return;
-      shouldRun = false;
-      fn();
-    });
+  // we use beforeEach as cypress will run this on retry attempt
+  // we just abort early if we detected that it's already run
+  beforeEach(() => {
+    if (!shouldRun) return;
+    shouldRun = false;
+    fn();
+  });
 
-    // When a test fails we flip the `shouldRun` flag back to true
-    // so when cypress retries and runs the `beforeEach()` before
-    // the test that failed, we'll run the `fn()` logic once more.
-    Cypress.on('test:after:run', (result) => {
-      if (result.state === 'failed') {
-        if (result.currentRetry < result.retries) {
-          shouldRun = true;
-        }
+  // When a test fails we flip the `shouldRun` flag back to true
+  // so when cypress retries and runs the `beforeEach()` before
+  // the test that failed, we'll run the `fn()` logic once more.
+  Cypress.on("test:after:run", (result) => {
+    if (result.state === "failed") {
+      if (result.currentRetry < result.retries) {
+        shouldRun = true;
       }
-    });
-  };
+    }
+  });
+}

--- a/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
@@ -1,8 +1,6 @@
 /// <reference types="cypress" />
 
 import config from "../../../../config";
-import { LoginPage } from "../../../Notify/Admin/Pages/all";
-
 
 const pages = [
     { name: "Landing page", route: "/accounts" },
@@ -34,7 +32,7 @@ const pages = [
 
 describe(`A11Y - App pages [${config.CONFIG_NAME}]`, () => {
     retryableBefore(() => {
-        LoginPage.Login(Cypress.env('NOTIFY_USER'), Cypress.env('NOTIFY_PASSWORD'));
+        cy.login(Cypress.env('NOTIFY_USER'), Cypress.env('NOTIFY_PASSWORD'));
         cy.task('log', "Running against:" + Cypress.config('baseUrl'))
     });
 

--- a/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
@@ -2,52 +2,58 @@
 
 import config from "../../../../config";
 
-const langs = ['en', 'fr'];
+const langs = ["en", "fr"];
 
 const fullPageList = [
-    { en: '/accessibility', fr: '/accessibilite' },
-    { en: '/features', fr: '/fonctionnalites' },
-    { en: '/formatting-emails', fr: '/guide-mise-en-forme' },
-    { en: '/service-level-agreement', fr: '/accord-niveaux-de-service' },
-    { en: '/terms', fr: '/conditions-dutilisation' },
-    { en: '/guidance', fr: '/guides-reference' },
-    { en: '/home', fr: '/accueil' },
-    { en: '/message-delivery-status', fr: '/etat-livraison-messages' },
-    { en: '/other-services', fr: '/autres-services' },
-    { en: '/privacy', fr: '/confidentialite' },
-    { en: '/security', fr: '/securite' },
-    { en: '/sending-custom-content', fr: '/envoyer-contenu-personnalise' },
-    { en: '/service-level-objectives', fr: '/objectifs-niveau-de-service' },
-    { en: '/system-status', fr: '/etat-du-systeme' },
-    { en: '/understanding-delivery-and-failure', fr: '/comprendre-statut-de-livraison' },
-    { en: '/updating-contact-information', fr: '/maintenir-a-jour-les-coordonnees' },
-    { en: '/using-a-spreadsheet', fr: '/utiliser-une-feuille-de-calcul' },
-    { en: '/why-gc-notify', fr: '/pourquoi-notification-gc' },
-    { en: '/new-features', fr: '/nouvelles-fonctionnalites' },
+  { en: "/accessibility", fr: "/accessibilite" },
+  { en: "/features", fr: "/fonctionnalites" },
+  { en: "/formatting-emails", fr: "/guide-mise-en-forme" },
+  { en: "/service-level-agreement", fr: "/accord-niveaux-de-service" },
+  { en: "/terms", fr: "/conditions-dutilisation" },
+  { en: "/guidance", fr: "/guides-reference" },
+  { en: "/home", fr: "/accueil" },
+  { en: "/message-delivery-status", fr: "/etat-livraison-messages" },
+  { en: "/other-services", fr: "/autres-services" },
+  { en: "/privacy", fr: "/confidentialite" },
+  { en: "/security", fr: "/securite" },
+  { en: "/sending-custom-content", fr: "/envoyer-contenu-personnalise" },
+  { en: "/service-level-objectives", fr: "/objectifs-niveau-de-service" },
+  { en: "/system-status", fr: "/etat-du-systeme" },
+  {
+    en: "/understanding-delivery-and-failure",
+    fr: "/comprendre-statut-de-livraison",
+  },
+  {
+    en: "/updating-contact-information",
+    fr: "/maintenir-a-jour-les-coordonnees",
+  },
+  { en: "/using-a-spreadsheet", fr: "/utiliser-une-feuille-de-calcul" },
+  { en: "/why-gc-notify", fr: "/pourquoi-notification-gc" },
+  { en: "/new-features", fr: "/nouvelles-fonctionnalites" },
 ];
 
 describe(`GCA a11y tests [${config.CONFIG_NAME}]`, () => {
-    for (const lang of langs) {
-        const currentLang = (lang === 'en' ? 'English' : 'Francais');
-        context(currentLang, () => {
-            for (const page of fullPageList) {
-                it(`${page[lang]}`, () => {
-                    cy.a11yScan(page[lang]);
-                });
-            }
+  for (const lang of langs) {
+    const currentLang = lang === "en" ? "English" : "Francais";
+    context(currentLang, () => {
+      for (const page of fullPageList) {
+        it(`${page[lang]}`, () => {
+          cy.a11yScan(page[lang]);
         });
-    }
+      }
+    });
+  }
 });
 
-describe('Language toggle works on all pages', () => {
-    for (const page of fullPageList) {
-        it(`${page.en}`, () => {
-            cy.visit(page.en);
-            cy.get('#header-lang').click();
-            cy.url().should('contain', page.fr);
+describe("Language toggle works on all pages", () => {
+  for (const page of fullPageList) {
+    it(`${page.en}`, () => {
+      cy.visit(page.en);
+      cy.get("#header-lang").click();
+      cy.url().should("contain", page.fr);
 
-            cy.get('#header-lang').click();
-            cy.url().should('contain', page.en);
-        });
-    }
+      cy.get("#header-lang").click();
+      cy.url().should("contain", page.en);
+    });
+  }
 });

--- a/tests_cypress/cypress/e2e/admin/all.cy.js
+++ b/tests_cypress/cypress/e2e/admin/all.cy.js
@@ -1,4 +1,4 @@
 // import './gca_pages.cy';
-import './login.cy';
-import './register.cy';
-import './qualtrics.cy';
+import "./login.cy";
+import "./register.cy";
+import "./qualtrics.cy";

--- a/tests_cypress/cypress/e2e/admin/ci.cy.js
+++ b/tests_cypress/cypress/e2e/admin/ci.cy.js
@@ -1,0 +1,2 @@
+import './a11y/app_pages.cy';
+import './sign_out/sign_out.cy';

--- a/tests_cypress/cypress/e2e/admin/ci.cy.js
+++ b/tests_cypress/cypress/e2e/admin/ci.cy.js
@@ -1,2 +1,2 @@
-import './a11y/app_pages.cy';
-import './sign_out/sign_out.cy';
+import "./a11y/app_pages.cy";
+import "./sign_out/sign_out.cy";

--- a/tests_cypress/cypress/e2e/admin/login.cy.js
+++ b/tests_cypress/cypress/e2e/admin/login.cy.js
@@ -3,37 +3,36 @@
 import config from "../../../config";
 import { LoginPage } from "../../Notify/Admin/Pages/all";
 
-describe('Basic login', () => {
+describe("Basic login", () => {
+  // Login to notify before the test suite starts
+  before(() => {
+    LoginPage.Login(Cypress.env("NOTIFY_USER"), Cypress.env("NOTIFY_PASSWORD"));
 
-    // Login to notify before the test suite starts
-    before(() => {
-        LoginPage.Login(Cypress.env('NOTIFY_USER'), Cypress.env('NOTIFY_PASSWORD'));
+    // ensure we logged in correctly
+    cy.contains("h1", "Sign-in history").should("be.visible");
+  });
 
-        // ensure we logged in correctly
-        cy.contains('h1', 'Sign-in history').should('be.visible');
-    });
+  // Before each test, persist the auth cookie so we don't have to login again
+  beforeEach(() => {
+    // stop the recurring dashboard fetch requests
+    cy.intercept("GET", "**/dashboard.json", {});
+  });
 
-    // Before each test, persist the auth cookie so we don't have to login again
-    beforeEach(() => {
-        // stop the recurring dashboard fetch requests
-        cy.intercept('GET', '**/dashboard.json', {});
-    });
+  // Clear cookies for the next suite of tests
+  after(() => {
+    cy.clearCookie("notify_admin_session");
+  });
 
-    // Clear cookies for the next suite of tests
-    after(() => {
-        cy.clearCookie('notify_admin_session');
-    });
+  it("succeeds and ADMIN displays accounts page", () => {
+    cy.visit("/accounts");
 
-    it('succeeds and ADMIN displays accounts page', () => {
-        cy.visit("/accounts");
+    cy.injectAxe();
+    cy.checkA11y();
+    cy.contains("h1", "Your services").should("be.visible");
+  });
 
-        cy.injectAxe();
-        cy.checkA11y();
-        cy.contains('h1', 'Your services').should('be.visible');
-    });
-
-    it('displays notify service page', () => {
-        cy.visit(`/services/${config.Services.Notify}`);
-        cy.contains('h1', 'Dashboard').should('be.visible');
-    });
+  it("displays notify service page", () => {
+    cy.visit(`/services/${config.Services.Notify}`);
+    cy.contains("h1", "Dashboard").should("be.visible");
+  });
 });

--- a/tests_cypress/cypress/e2e/admin/qualtrics.cy.js
+++ b/tests_cypress/cypress/e2e/admin/qualtrics.cy.js
@@ -3,25 +3,24 @@
 import config from "../../../config";
 import { LoginPage } from "../../Notify/Admin/Pages/all";
 
-describe('Qualtrics', () => {
+describe("Qualtrics", () => {
+  // Login to notify before the test suite starts
+  before(() => {
+    Cypress.config("baseUrl", config.Hostnames.Admin); // use hostname for this environment
+    LoginPage.Login(Cypress.env("NOTIFY_USER"), Cypress.env("NOTIFY_PASSWORD"));
+  });
 
-    // Login to notify before the test suite starts
-    before(() => {
-        Cypress.config('baseUrl', config.Hostnames.Admin); // use hostname for this environment
-        LoginPage.Login(Cypress.env('NOTIFY_USER'), Cypress.env('NOTIFY_PASSWORD'));
-    });
+  // Before each test, persist the auth cookie so we don't have to login again
+  beforeEach(() => {
+    // stop the recurring dashboard fetch requests
+    cy.intercept("GET", "**/dashboard.json", {});
+  });
 
-    // Before each test, persist the auth cookie so we don't have to login again
-    beforeEach(() => {
-        // stop the recurring dashboard fetch requests
-        cy.intercept('GET', '**/dashboard.json', {});
-    });
-
-    it('survey button appears and survey opens', () => {
-        cy.visit(`/services/${config.Services.Notify}`);
-        cy.contains('h1', 'Dashboard').should('be.visible');
-        cy.get('#QSIFeedbackButton-btn').should('be.visible'); // qualtrics survey button
-        cy.get('#QSIFeedbackButton-btn').click(); // click the button
-        cy.get('#QSIFeedbackButton-survey-iframe').should('be.visible'); // 
-    });
+  it("survey button appears and survey opens", () => {
+    cy.visit(`/services/${config.Services.Notify}`);
+    cy.contains("h1", "Dashboard").should("be.visible");
+    cy.get("#QSIFeedbackButton-btn").should("be.visible"); // qualtrics survey button
+    cy.get("#QSIFeedbackButton-btn").click(); // click the button
+    cy.get("#QSIFeedbackButton-survey-iframe").should("be.visible"); //
+  });
 });

--- a/tests_cypress/cypress/e2e/admin/register.cy.js
+++ b/tests_cypress/cypress/e2e/admin/register.cy.js
@@ -3,69 +3,97 @@
 import { CreateAccountPage } from "../../Notify/Admin/Pages/all";
 import { Utilities, Admin } from "../../Notify/NotifyAPI";
 
-describe('Create Account Page', () => {
-
+describe("Create Account Page", () => {
   beforeEach(() => {
     CreateAccountPage.VisitPage();
   });
 
   // Clear cookies for the next suite of tests
   after(() => {
-    cy.clearCookie('notify_admin_session');
+    cy.clearCookie("notify_admin_session");
   });
 
-  it('Display the correct title', () => {
-    cy.contains('h1', 'Create an account').should('be.visible');
+  it("Display the correct title", () => {
+    cy.contains("h1", "Create an account").should("be.visible");
   });
 
-  it('Display error  when submitting an empty form', () => {
+  it("Display error  when submitting an empty form", () => {
     CreateAccountPage.EmptySubmit();
-    cy.contains('span', 'This cannot be empty').should('be.visible');
-    cy.contains('span', 'Enter an email address').should('be.visible');
+    cy.contains("span", "This cannot be empty").should("be.visible");
+    cy.contains("span", "Enter an email address").should("be.visible");
   });
 
-  it('Display an error when submitting and invalid phone number and non-government email', () => {
-    CreateAccountPage.Submit('John Doe', 'john.doe@not-a-gov-email.ca', '123', 'password123')
-    cy.contains('span', "not-a-gov-email.ca is not on our list of government domains").should('be.visible');
-    cy.contains('span', "Not a valid phone number").should('be.visible');
+  it("Display an error when submitting and invalid phone number and non-government email", () => {
+    CreateAccountPage.Submit(
+      "John Doe",
+      "john.doe@not-a-gov-email.ca",
+      "123",
+      "password123",
+    );
+    cy.contains(
+      "span",
+      "not-a-gov-email.ca is not on our list of government domains",
+    ).should("be.visible");
+    cy.contains("span", "Not a valid phone number").should("be.visible");
   });
 
-  it('Display an error if password is shorter than 8 characters', () => {
-    CreateAccountPage.Submit("john doe", "john.doe@cds-snc.ca", "1234567890", "1234567");
-    cy.contains('span', 'Must be at least 8 characters').should('be.visible');
+  it("Display an error if password is shorter than 8 characters", () => {
+    CreateAccountPage.Submit(
+      "john doe",
+      "john.doe@cds-snc.ca",
+      "1234567890",
+      "1234567",
+    );
+    cy.contains("span", "Must be at least 8 characters").should("be.visible");
   });
 
-  it('Display an error if password is not strong enough', () => {
-    CreateAccountPage.Submit("john doe", "john.doe@cds-snc.ca", "1234567890", "123456789");
-    cy.contains('span', 'A password that is hard to guess contains:').should('be.visible');
-    cy.contains('li', 'Uppercase and lowercase letters.').should('be.visible');
-    cy.contains('li', 'Numbers and special characters.').should('be.visible');
-    cy.contains('li', 'Words separated by a space.').should('be.visible');
+  it("Display an error if password is not strong enough", () => {
+    CreateAccountPage.Submit(
+      "john doe",
+      "john.doe@cds-snc.ca",
+      "1234567890",
+      "123456789",
+    );
+    cy.contains("span", "A password that is hard to guess contains:").should(
+      "be.visible",
+    );
+    cy.contains("li", "Uppercase and lowercase letters.").should("be.visible");
+    cy.contains("li", "Numbers and special characters.").should("be.visible");
+    cy.contains("li", "Words separated by a space.").should("be.visible");
   });
 
-  it('Succeeds with a valid form', () => {
+  it("Succeeds with a valid form", () => {
     let email = `notify-ui-tests+${Utilities.GenerateID()}@cds-snc.ca`;
 
-    CreateAccountPage.CreateAccount("john doe", email, "16132532223", "BestPassword123!");
-    cy.contains('h1', 'Check your email').should('be.visible');
-    cy.contains('p', `An email has been sent to ${email}.`).should('be.visible');
+    CreateAccountPage.CreateAccount(
+      "john doe",
+      email,
+      "16132532223",
+      "BestPassword123!",
+    );
+    cy.contains("h1", "Check your email").should("be.visible");
+    cy.contains("p", `An email has been sent to ${email}.`).should(
+      "be.visible",
+    );
 
     CreateAccountPage.WaitForConfirmationEmail();
     // Ensure registration email is received and click registration link
-    cy.contains('p', 'To complete your registration for GC Notify, please click the link:').should('be.visible');
-    cy.get('a')
-      .should('have.attr', 'href')
-      .and('include', 'verify-email')
+    cy.contains(
+      "p",
+      "To complete your registration for GC Notify, please click the link:",
+    ).should("be.visible");
+    cy.get("a")
+      .should("have.attr", "href")
+      .and("include", "verify-email")
       .then((href) => {
         cy.visit(href);
       });
 
-    cy.contains('h1', 'Check your phone messages').should('be.visible')
+    cy.contains("h1", "Check your phone messages").should("be.visible");
 
     Admin.GetUserByEmail({ email: email }).then((user) => {
       // TODO: Ideally we'd want the ability to completely delete the test user rather than archive it.
-      Admin.ArchiveUser({ userId: user.body.data.id })
+      Admin.ArchiveUser({ userId: user.body.data.id });
     });
   });
-
 });

--- a/tests_cypress/cypress/e2e/admin/sign_out/sign_out.cy.js
+++ b/tests_cypress/cypress/e2e/admin/sign_out/sign_out.cy.js
@@ -1,5 +1,3 @@
-import { LoginPage } from "../../../Notify/Admin/Pages/AllPages";
-
 const REDIRECT_LOCATION = '/sign-in?timeout=true';
 const SESSION_TIMEOUT_MS = 7 * 60 * 60 * 1000 + 55 * 60 * 1000; // 7 hours 55 minutes
 const vistPageAndFastForwardTime = (page = '/') => {
@@ -20,7 +18,7 @@ describe('Sign out', () => {
 
   it('Redirects to session timeout page when logged in (multiple pages)', () => {
     ['/home', '/features'].forEach((page) => {
-      LoginPage.Login(Cypress.env('NOTIFY_USER'), Cypress.env('NOTIFY_PASSWORD'));
+      cy.login(Cypress.env('NOTIFY_USER'), Cypress.env('NOTIFY_PASSWORD'));
       vistPageAndFastForwardTime(page);
 
       // asserts

--- a/tests_cypress/cypress/e2e/admin/sign_out/sign_out.cy.js
+++ b/tests_cypress/cypress/e2e/admin/sign_out/sign_out.cy.js
@@ -1,44 +1,43 @@
-const REDIRECT_LOCATION = '/sign-in?timeout=true';
+const REDIRECT_LOCATION = "/sign-in?timeout=true";
 const SESSION_TIMEOUT_MS = 7 * 60 * 60 * 1000 + 55 * 60 * 1000; // 7 hours 55 minutes
-const vistPageAndFastForwardTime = (page = '/') => {
+const vistPageAndFastForwardTime = (page = "/") => {
   cy.clock();
   cy.visit(page);
   cy.tick(SESSION_TIMEOUT_MS);
 };
 
-describe('Sign out', () => {
-
-  it('Does not redirect to session timeout page when logged out', () => {
-    cy.clearCookie('notify_admin_session'); 
+describe("Sign out", () => {
+  it("Does not redirect to session timeout page when logged out", () => {
+    cy.clearCookie("notify_admin_session");
     vistPageAndFastForwardTime();
 
     // asserts
-    cy.url().should('not.include', REDIRECT_LOCATION);
+    cy.url().should("not.include", REDIRECT_LOCATION);
   });
 
-  it('Redirects to session timeout page when logged in (multiple pages)', () => {
-    ['/home', '/features'].forEach((page) => {
-      cy.login(Cypress.env('NOTIFY_USER'), Cypress.env('NOTIFY_PASSWORD'));
+  it("Redirects to session timeout page when logged in (multiple pages)", () => {
+    ["/home", "/features"].forEach((page) => {
+      cy.login(Cypress.env("NOTIFY_USER"), Cypress.env("NOTIFY_PASSWORD"));
       vistPageAndFastForwardTime(page);
 
       // asserts
-      cy.url().should('include', REDIRECT_LOCATION);
-      cy.get('h1').should('contain', 'You need to sign in again');
+      cy.url().should("include", REDIRECT_LOCATION);
+      cy.get("h1").should("contain", "You need to sign in again");
     });
   });
 
-  it('Displays banner on explicit logout', () => {
-    cy.visit('/sign-out');
+  it("Displays banner on explicit logout", () => {
+    cy.visit("/sign-out");
 
     // asserts
-    cy.url().should('include', '/sign-in');
-    cy.get('.banner-default-with-tick').should('be.visible');
+    cy.url().should("include", "/sign-in");
+    cy.get(".banner-default-with-tick").should("be.visible");
   });
 
-  it('Displays session timeout info on login page', () => {
-    cy.visit('/sign-in');
-    
+  it("Displays session timeout info on login page", () => {
+    cy.visit("/sign-in");
+
     // asserts
-    cy.getByTestId('session_timeout_info').should('be.visible');
+    cy.getByTestId("session_timeout_info").should("be.visible");
   });
 });

--- a/tests_cypress/cypress/support/commands.js
+++ b/tests_cypress/cypress/support/commands.js
@@ -1,4 +1,5 @@
 import config from "../../config";
+import LoginPage from "../Notify/Admin/Pages/LoginPage";
 
 // ***********************************************
 // This example commands.js shows you how to
@@ -116,6 +117,12 @@ Cypress.Commands.add('a11yScan', (url, options={ a11y: true, htmlValidate: true,
     }
  })
 
- Cypress.Commands.add('getByTestId', (selector, ...args) => {
+Cypress.Commands.add('getByTestId', (selector, ...args) => {
     return cy.get(`[data-testid=${selector}]`, ...args)
+});
+
+Cypress.Commands.add('login', (username, password) => {
+    cy.session([username, password], () => {
+        LoginPage.Login(username, password);
+    });
 });


### PR DESCRIPTION
# Summary | Résumé

This PR:
- updates our CI workflow regarding cypress to make it easier to add tests as we build them
- updates our `make format` command to also run prettier on our cypress test code
- updates our login logic with a re-usable command that caches session between tests where it can to avoid extraneous logins
- re-names the sign_out tests so they are picked up by cypress

# Test instructions | Instructions pour tester la modification
- Verify that 2 cypress test suites run and pass in this PR:
   - [ ] A11Y App pages
   - [ ] Sign out