### PR TITLE
bug: fix stats info

### DIFF
--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -50,7 +50,7 @@
               'email_sends' in item and
               'sms_sends' in item )  %}
             <div class="hint">
-              {{ "{:,}".format(item.total_sends) }} {{ _('total sends') }} ({{ "{:,}".format(item.email_sends) }} {{ _('email') }}, {{ "{:,}".format(item.sms_sends) }} {{ _('sms') }})
+              {{ "{:,}".format(item.total_sends) }} {{ _('total sends in the last 7 days') }} ({{ "{:,}".format(item.email_sends) }} {{ _('email') }}, {{ "{:,}".format(item.sms_sends) }} {{ _('sms') }})
             </div>
           {% endif %}
           <div class="hint">

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1887,4 +1887,4 @@
 "Enter the alternative text in French","Entrez le texte alternatif en français"
 "You have been signed out.","Déconnexion réussie"
 "Your session ends after 8 hours of inactivity","Votre session se termine au bout de 8 heures d’inactivité"
-"total sends in the last 7 days", "total des envois au cours des 7 derniers jours"
+"total sends in the last 7 days","total des envois au cours des 7 derniers jours"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1887,3 +1887,4 @@
 "Enter the alternative text in French","Entrez le texte alternatif en français"
 "You have been signed out.","Déconnexion réussie"
 "Your session ends after 8 hours of inactivity","Votre session se termine au bout de 8 heures d’inactivité"
+"total sends in the last 7 days", "total des envois au cours des 7 derniers jours"

--- a/tests/app/main/views/test_api_integration.py
+++ b/tests/app/main/views/test_api_integration.py
@@ -185,7 +185,7 @@ def test_should_show_api_keys_page(
     rows = [normalize_spaces(row.text) for row in page.select("main tr")]
 
     assert rows[0] == "API keys Action"
-    assert "another key name 20 total sends (20 email, 0 sms)" in rows[1]
+    assert "another key name 20 total sends in the last 7 days (20 email, 0 sms)" in rows[1]
     assert "Revoke API key some key name" in rows[2]
 
     mock_get_api_keys.assert_called_once_with(SERVICE_ONE_ID)


### PR DESCRIPTION
# Summary | Résumé

We are calculating stats for api key usage on the notifications table. If the key has been used, before 7 days, we do not indicate that.

This is the func that gets the stat: https://github.com/cds-snc/notification-api/blob/main/app/dao/fact_notification_status_dao.py#L325-L343

as you can see it only calls notifications. We do not want this query to also call notification_history. Changing the wording to in

Problem:
<img width="352" alt="Screenshot 2024-05-15 at 11 08 10 AM" src="https://github.com/cds-snc/notification-admin/assets/8869623/f3f71187-e3b9-47af-8427-039a170a07d1">
dicate its only for the last 7 days


