### PR TITLE
fix: add media-src content security policy

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -666,6 +666,7 @@ def useful_headers_after_request(response):
             f"style-src 'self' fonts.googleapis.com https://tagmanager.google.com https://fonts.googleapis.com 'unsafe-inline';"
             f"font-src 'self' {asset_domain} fonts.googleapis.com fonts.gstatic.com *.gstatic.com data:;"
             f"img-src 'self' blob: {asset_domain} *.canada.ca *.cdssandbox.xyz *.google-analytics.com *.googletagmanager.com *.notifications.service.gov.uk *.gstatic.com https://siteintercept.qualtrics.com data:;"  # noqa: E501
+            "media-src 'self' *.alpha.canada.ca;"
             "frame-ancestors 'self';"
             "form-action 'self' *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com;"
             "frame-src 'self' www.googletagmanager.com https://cdssnc.qualtrics.com/;"

--- a/tests/app/main/views/test_headers.py
+++ b/tests/app/main/views/test_headers.py
@@ -74,6 +74,7 @@ def test_owasp_useful_headers_set(client, mocker, mock_get_service_and_organisat
         f"style-src 'self' fonts.googleapis.com https://tagmanager.google.com https://fonts.googleapis.com 'unsafe-inline';"
         f"font-src 'self' static.example.com fonts.googleapis.com fonts.gstatic.com *.gstatic.com data:;"
         f"img-src 'self' blob: static.example.com *.canada.ca *.cdssandbox.xyz *.google-analytics.com *.googletagmanager.com *.notifications.service.gov.uk *.gstatic.com https://siteintercept.qualtrics.com data:;"  # noqa: E501
+        "media-src 'self' *.alpha.canada.ca;"
         "frame-ancestors 'self';"
         "form-action 'self' *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com;"
         "frame-src 'self' www.googletagmanager.com https://cdssnc.qualtrics.com/;"
@@ -138,6 +139,7 @@ def test_headers_non_ascii_characters_are_replaced(
         f"style-src 'self' fonts.googleapis.com https://tagmanager.google.com https://fonts.googleapis.com 'unsafe-inline';"
         f"font-src 'self' static.example.com fonts.googleapis.com fonts.gstatic.com *.gstatic.com data:;"
         f"img-src 'self' blob: static.example.com *.canada.ca *.cdssandbox.xyz *.google-analytics.com *.googletagmanager.com *.notifications.service.gov.uk *.gstatic.com https://siteintercept.qualtrics.com data:;"  # noqa: E501
+        "media-src 'self' *.alpha.canada.ca;"
         "frame-ancestors 'self';"
         "form-action 'self' *.siteintercept.qualtrics.com https://siteintercept.qualtrics.com;"
         "frame-src 'self' www.googletagmanager.com https://cdssnc.qualtrics.com/;"


### PR DESCRIPTION
# Summary
Update the CSP to include `media-src` that allows content to be loaded from any `alpha.canada.ca` domain.

This will allow video hosted on GC Articles to load and play correctly.