### PR TITLE
fix: update sitemap tests with new string

### DIFF
--- a/tests_cypress/cypress/e2e/admin/sitemap/sitemap.cy.js
+++ b/tests_cypress/cypress/e2e/admin/sitemap/sitemap.cy.js
@@ -6,8 +6,7 @@ const path = "/sitemap";
 const sitemap_footer_id = "nav-footer-sitemap";
 
 describe(`Sitemap`, () => {
-  it("Has link text that corresponds to page titles", () => {
-    cy.then(Cypress.session.clearCurrentSessionData);
+  it.skip('Has link text that corresponds to page titles', () => {
     cy.visit(path);
     cy.get("main").within(() => {
       cy.get("a").each((link) => {
@@ -51,7 +50,7 @@ describe(`Sitemap`, () => {
 
     it("Does NOT display the 'You' group when logged out", () => {
       cy.visit(path);
-      cy.getByTestId("sitemap-group").should("not.have.text", "You");
+      cy.getByTestId('sitemap-group').should('not.have.text', 'Your GC Notify');
 
       cy.login(Cypress.env("NOTIFY_USER"), Cypress.env("NOTIFY_PASSWORD"));
     });
@@ -60,7 +59,7 @@ describe(`Sitemap`, () => {
       cy.login(Cypress.env("NOTIFY_USER"), Cypress.env("NOTIFY_PASSWORD"));
       cy.visit(path);
 
-      cy.getByTestId("sitemap-group").contains("You");
+      cy.getByTestId('sitemap-group').contains('Your GC Notify');
     });
   });
 

--- a/tests_cypress/cypress/e2e/admin/sitemap/sitemap.cy.js
+++ b/tests_cypress/cypress/e2e/admin/sitemap/sitemap.cy.js
@@ -6,7 +6,7 @@ const path = "/sitemap";
 const sitemap_footer_id = "nav-footer-sitemap";
 
 describe(`Sitemap`, () => {
-  it.skip('Has link text that corresponds to page titles', () => {
+  it('Has link text that corresponds to page titles', () => {
     cy.visit(path);
     cy.get("main").within(() => {
       cy.get("a").each((link) => {


### PR DESCRIPTION
# Summary | Résumé

This PR fixes the sitemap tests to look for the new content for the logged in group.

# Test instructions | Instructions pour tester la modification
- Cypress tests should all pass
