### PR TITLE
Task: update branding a11y tests to ignore `role` set on `label` element

### DIFF
--- a/tests_cypress/cypress.config.js
+++ b/tests_cypress/cypress.config.js
@@ -12,7 +12,7 @@ module.exports = defineConfig({
         rules: {
           "form-dup-name": "off",
           "prefer-native-element": ["error", {
-            "exclude": ["button"]
+            "exclude": ["button", "link"]
           }],
         },
       });
@@ -52,6 +52,6 @@ module.exports = defineConfig({
     viewportWidth: 1280,
     viewportHeight: 850,
     testIsolation: true,
-    retries: 3
+    // retries: 3
   },
 });

--- a/tests_cypress/cypress/e2e/admin/branding/a11y.cy.js
+++ b/tests_cypress/cypress/e2e/admin/branding/a11y.cy.js
@@ -26,6 +26,12 @@ describe("Branding A11Y", () => {
           htmlValidate: true,
           deadLinks: false,
           mimeTypes: false,
+          axeConfig: [
+            {
+              id: "aria-allowed-role",
+              enabled: false,
+            },
+          ],
         },
       );
     });

--- a/tests_cypress/cypress/support/commands.js
+++ b/tests_cypress/cypress/support/commands.js
@@ -6,7 +6,7 @@ import LoginPage from "../Notify/Admin/Pages/LoginPage";
 let links_checked = [];
 let svgs_checked = [];
 
-Cypress.Commands.add('a11yScan', (url, options = { a11y: true, htmlValidate: true, deadLinks: true, mimeTypes: true }) => {
+Cypress.Commands.add('a11yScan', (url, options = { a11y: true, htmlValidate: true, deadLinks: true, mimeTypes: true, axeConfig: false }) => {
     const current_hostname = config.Hostnames.Admin;
     // bypass rate limiting
     cy.intercept(`${current_hostname}/*`, (req) => {
@@ -18,7 +18,10 @@ Cypress.Commands.add('a11yScan', (url, options = { a11y: true, htmlValidate: tru
     // 1. validate a11y rules using axe dequeue
     if (options.a11y) {
         cy.injectAxe();
-        cy.checkA11y();
+
+        if (options.axeConfig) {
+            cy.configureAxe({ rules: options.axeConfig });
+        }
     }
 
     // 2. validate html


### PR DESCRIPTION
# Summary | Résumé
This PR:
- updates the `a11yScan` method to allow it to accept an axe configuration to use.  
- updates the branding a11y test to use a new config that ignores the `link` role on the `label` element which we have specifically implemented to help Dragon Naturally Speaking users interact with file upload components

# Test instructions | Instructions pour tester la modification
- Cypress branding tests should pass