### PR TITLE
Fix/update terms headings

### DIFF
--- a/app/templates/components/terms.html
+++ b/app/templates/components/terms.html
@@ -25,7 +25,7 @@
 {% endmacro %}
 
 {% macro terms_of_use() %}
-    <h3 class="heading-medium">{{ _('Your responsibilities') }}</h3>
+    <h2 class="heading-medium">{{ _('Your responsibilities') }}</h2>
     <p>
     <em>For CDS responsibilities, read GC Notify’s </em
     ><a href="https://notification.canada.ca/service-level-agreement"
@@ -33,14 +33,14 @@
     ><em>.</em>
     </p>
 
-    <h3 class="heading-medium">{{ _(headings[0].title.format(headings[0].link))  }}</h3>
+    <h2 class="heading-medium">{{ _(headings[0].title.format(headings[0].link))  }}</h2>
     <p>
     We may suspend your account or service if you break these terms or misuse GC
     Notify. Misuse includes creating duplicate services or services incompatible
     with your original purpose.
     </p>
 
-    <h3 class="heading-medium">{{ _(headings[1].title) }}</h3>
+    <h2 class="heading-medium">{{ _(headings[1].title) }}</h2>
     <p>
     We apply limits to maintain our
     <a href="https://notification.canada.ca/service-level-objectives"
@@ -75,7 +75,7 @@
     </div>
     </div>
 
-    <h3 class="heading-medium">{{ _(headings[2].title) }}</h3>
+    <h2 class="heading-medium">{{ _(headings[2].title) }}</h2>
     <p>Texts are:</p>
     <ul class="list list-bullet ml-10">
     <li>
@@ -94,7 +94,7 @@
     </li>
     </ul>
 
-    <h3 class="heading-medium">{{ _(headings[3].title) }}</h3>
+    <h2 class="heading-medium">{{ _(headings[3].title) }}</h2>
     <p>
     GC Notify holds information temporarily but your organization is responsible
     for that information.&nbsp;
@@ -126,7 +126,7 @@
     </li>
     </ul>
 
-    <h3 class="heading-medium">{{ _(headings[4].title) }}</h3>
+    <h2 class="heading-medium">{{ _(headings[4].title) }}</h2>
     <ul class="list list-bullet ml-10">
     <li>
         Follow your organization’s policies and check messages are:<br />(a) Within
@@ -146,7 +146,7 @@
     </li>
     </ul>
 
-    <h3 class="heading-medium">{{ _(headings[5].title) }}</h3>
+    <h2 class="heading-medium">{{ _(headings[5].title) }}</h2>
     <ul class="list list-bullet ml-10">
     <li>
         Use<strong> </strong>accurate, in-use email addresses. We may suspend your
@@ -156,7 +156,7 @@
     <li>Use accurate, in-use mobile phone numbers. Do not send to landlines.</li>
     </ul>
 
-    <h3 class="heading-medium">{{ _(headings[6].title) }}</h3>
+    <h2 class="heading-medium">{{ _(headings[6].title) }}</h2>
     <ul class="list list-bullet ml-10">
     <li>
         Assess context to decide what
@@ -176,7 +176,7 @@
     </li>
     </ul>
 
-    <h3 class="heading-medium">{{ _(headings[7].title) }}</h3>
+    <h2 class="heading-medium">{{ _(headings[7].title) }}</h2>
     <ul class="list list-bullet ml-10">
     <li>
         Use a valid government email and a mobile device with a Canadian phone

--- a/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/app_pages.cy.js
@@ -76,6 +76,7 @@ const pages = [
   { name: "Contact us", route: "/contact" },
   { name: "Create an account", route: "/register" },
   { name: "Sign in", route: "/sign-in" },
+  { name: "Terms of use", route: "/terms" },
 ];
 
 describe(`A11Y - App pages [${config.CONFIG_NAME}]`, () => {

--- a/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
@@ -9,7 +9,6 @@ const fullPageList = [
   { en: "/features", fr: "/fonctionnalites" },
   { en: "/formatting-emails", fr: "/guide-mise-en-forme" },
   { en: "/service-level-agreement", fr: "/accord-niveaux-de-service" },
-  { en: "/terms", fr: "/conditions-dutilisation" },
   { en: "/guidance", fr: "/guides-reference" },
   { en: "/home", fr: "/accueil" },
   { en: "/message-delivery-status", fr: "/etat-livraison-messages" },


### PR DESCRIPTION
# Summary | Résumé

This PR fixes the heading structure on the `/terms` page.  It changes them from `h3` to `h2` so that there is no jump in headings.  It also moves the a11y test for this page from the GCA suite to the APP suite, since this page is now an app page.


# Test instructions | Instructions pour tester la modification
- Cypress tests should pass