### PR TITLE
Remove background color from login terms

### DIFF
--- a/app/templates/components/tou-prompt.html
+++ b/app/templates/components/tou-prompt.html
@@ -29,7 +29,7 @@
   </div>
   <div id="tou-prompt" data-testid="tou-prompt" class="mt-16">
     <h2 class="heading-medium mt-0 mb-6" data-testid="tou-heading">{{ _('Know your responsibilities') }}</h2>
-    <div id="tou-terms" data-testid="tou-terms">
+    <div data-testid="tou-terms">
       <p>
         {{ _('By using GC Notify, you accept our ') }}
         {{ content_link(_("terms of use"), gca_url_for('terms'), is_external_link=true) }}.


### PR DESCRIPTION
# Summary | Résumé
This PR removes the background color from the login terms.  The same id was used for the tou dialog which caused a styling conflict.

# Before:
![image](https://github.com/cds-snc/notification-admin/assets/823749/af8800d5-c385-4c03-8567-73ebdfd06d49)

# After
![image](https://github.com/cds-snc/notification-admin/assets/823749/ca251fc2-82a9-42e7-adb1-2f9f7ba8706d)


# Test instructions | Instructions pour tester la modification

Login to notify, ensure the terms dont have a background color