### PR TITLE
Fix/tou dialog UI tests

### DIFF
--- a/app/templates/components/tou-dialog.html
+++ b/app/templates/components/tou-dialog.html
@@ -6,7 +6,7 @@
 {% macro tou_dialog() %}
 <dialog id="tou-dialog"
   class="focus:outline-yellow overflow-y-scroll max-w-screen-lg p-0 flex flex-col w-full border-4 border-gray-300"
-  data-testid="tou-dialog" data-error-prefix="{{ _('Terms of use:') }}" data-error-msg="{{ error_msg }}">
+  data-testid="tou-dialog" data-error-prefix="{{ _('Terms of use:') }}" data-error-msg="{{ error_msg }}" tabindex="0">
   <div class="dialog-header bg-gray-200 flex items-baseline gap-gutter p-gutter py-2">
     <button id="tou-close"
       class="focus:bg-yellow focus:outline-yellow focus:text-black flex gap-2 items-center min-h-target min-w-target text-blue"
@@ -15,11 +15,10 @@
       {{ _('Close') }}
     </button>
   </div>
-  <div id="tou-terms" class="dialog-content p-gutter mb-4 focus:outline-none" tabindex="0" data-testid="tou-terms"
-    aria-describedby="tou-heading">
+  <div id="tou-terms" class="dialog-content p-gutter mb-4 focus:outline-none" tabindex="0" data-testid="tou-terms">
     {{ terms_of_use() }}
   </div>
-  <div class="dialog-sticky-footer p-gutterHalf items-baseline">
+  <div class="dialog-sticky-footer p-gutterHalf items-baseline" data-testid="tou-instruction">
     <i aria-hidden="true" class="fa-solid fa-lg fa-circle-info"></i>
     <span class="font-bold">Read the terms and accept below</span>
   </div>

--- a/tests_cypress/cypress/Notify/Admin/Pages/RegisterPage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/RegisterPage.js
@@ -10,7 +10,8 @@ let Components = {
     TOUStatusComplete: () => cy.getByTestId('tou-complete'),
     TOUStatusNotComplete: () => cy.getByTestId('tou-not-complete'),
     TOUErrorMessage: () => cy.getByTestId('tou-error-message'),
-    TOUValidationSummaryErrorMessage: () => cy.getByTestId('tou-val-summ-err')
+    TOUValidationSummaryErrorMessage: () => cy.getByTestId('tou-val-summ-err'),
+    TOUInstruction: () => cy.getByTestId('tou-instruction')
 };
 
 // Actions users can take on the page

--- a/tests_cypress/cypress/e2e/admin/tou_dialog.cy.js
+++ b/tests_cypress/cypress/e2e/admin/tou_dialog.cy.js
@@ -28,15 +28,6 @@ describe("TOU Dialog", () => {
         });
     });
 
-    it("Has terms that are described by the heading", () => {
-      RegisterPage.Components.TOUTrigger().click();
-      RegisterPage.Components.TOUTerms()
-        .should("have.attr", "aria-describedby")
-        .then((labelledById) => {
-          cy.get("#" + labelledById).should("be.visible");
-        });
-    });
-
     it("Closes when user presses ESC", () => {
       RegisterPage.Components.TOUTrigger().click();
       cy.get("body").type("{esc}");
@@ -47,9 +38,20 @@ describe("TOU Dialog", () => {
     it("Has scrollable terms that are also focusable", () => {
       RegisterPage.Components.TOUTrigger().click();
       RegisterPage.Components.TOUTerms().should("have.focus");
-      RegisterPage.Components.TOUTerms().then(($el) => {
+      RegisterPage.Components.TOUDialog().then(($el) => {
         expect($el[0].scrollHeight).to.be.gt($el[0].clientHeight);
       });
+    });
+
+    it("Has instruction that is visible before you scroll", () => {
+      RegisterPage.Components.TOUTrigger().click();
+      RegisterPage.Components.TOUInstruction().should("be.visible");
+    });
+
+    it("Has instruction that is visible after you scroll", () => {
+      RegisterPage.Components.TOUTrigger().click();
+      RegisterPage.ScrollTerms();
+      RegisterPage.Components.TOUInstruction().should("be.visible");
     });
   });
 
@@ -113,15 +115,15 @@ describe("TOU Dialog", () => {
       RegisterPage.Components.TOUDialog().should("be.visible");
     });
 
-    it("Has agree button disabled when dialog opens", () => {
+    it("Has agree button out of viewport when dialog opens", () => {
       RegisterPage.Components.TOUTrigger().click();
-      RegisterPage.Components.TOUAgree().should("be.disabled");
+      RegisterPage.Components.TOUAgree().should("not.be.visible");
     });
 
-    it("Enables agree button when user scrolls to bottom of terms", () => {
+    it("Has agree button visible when user scrolls to bottom of terms", () => {
       RegisterPage.Components.TOUTrigger().click();
       RegisterPage.ScrollTerms();
-      RegisterPage.Components.TOUAgree().should("not.be.disabled");
+      RegisterPage.Components.TOUAgree().should("not.visible");
     });
 
     it("Closes when user clicks close/cancel", () => {


### PR DESCRIPTION
# Summary | Résumé

This PR updates the tou dialog tests to account for the changes made in https://github.com/cds-snc/notification-admin/pull/1876.

## Changelog
- Remove the test that checks that the terms are described by their heading (heading was removed)
- remove the aria-describedby that points to an id that no longer exists (heading was removed)
- Update test `Has scrollable terms that are also focusable` to look at the dialog instead of the terms div (scrollable div changed)
- Rename test `Has agree button disabled when dialog opens` to `Has agree button out of viewport when dialog opens` and ensure instruction visible before scrolling (buttons no longer disabled, hidden instead)
- Rename test `Enables agree button when user scrolls to bottom of terms` to `Has agree button visible when user scrolls to bottom of terms` and ensure instruction still visible after scrolling (buttons no longer disabled, hidden instead)

# Test instructions | Instructions pour tester la modification
- Cypress tests pass