### PR TITLE
Use staging VPN for admin deployments

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -69,7 +69,7 @@ jobs:
         op read op://4eyyuwddp6w4vxlabrr2i2duxm/"Staging Github Actions VPN"/notesPlain > /var/tmp/staging.ovpn
 
     - name: Connect to VPN
-      uses: "kota65535/github-openvpn-connect-action@v2"
+      uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5"
       with:
         config_file: /var/tmp/staging.ovpn
         client_key: ${{ secrets.STAGING_OVPN_CLIENT_KEY }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,7 +9,7 @@ env:
   DOCKER_ORG: public.ecr.aws/v6b8u5o6
   DOCKER_SLUG: public.ecr.aws/v6b8u5o6/notify-admin
   WORKFLOW_PAT: ${{ secrets.WORKFLOW_GITHUB_PAT }}
-
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT
@@ -54,9 +54,36 @@ jobs:
       run: |
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:${GITHUB_SHA::7}
 
-    - name: Rollout in Kubernetes
+    - name: Install OpenVPN
       run: |
-        ./scripts/callManifestsRollout.sh ${GITHUB_SHA::7}
+        sudo apt update
+        sudo apt install -y openvpn openvpn-systemd-resolved
+
+    - name: Install 1Pass CLI
+      run: |
+        curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
+        sudo dpkg -i 1pass.deb
+
+    - name: One Password Fetch
+      run: |
+        op read op://4eyyuwddp6w4vxlabrr2i2duxm/"Staging Github Actions VPN"/notesPlain > /var/tmp/staging.ovpn
+
+    - name: Connect to VPN
+      uses: "kota65535/github-openvpn-connect-action@v2"
+      with:
+        config_file: /var/tmp/staging.ovpn
+        client_key: ${{ secrets.STAGING_OVPN_CLIENT_KEY }}
+        echo_config: false       
+        
+    - name: Configure kubeconfig
+      run: |
+        aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster     
+        kubectl config rename-context arn:aws:eks:ca-central-1:$STAGING_AWS_ACCOUNT:cluster/notification-canada-ca-staging-eks-cluster staging           
+
+    - name: Update images in staging
+      run: |
+        DOCKER_TAG=${GITHUB_SHA::7}
+        kubectl set image deployment.apps/admin admin=$DOCKER_SLUG:$DOCKER_TAG -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
 
     - name: my-app-install token
       id: notify-pr-bot


### PR DESCRIPTION
# Summary | Résumé

Moving away from Github ARC and instead using a VPN to connect to K8s to deploy Admin.

# Test instructions | Instructions pour tester la modification

Docker build/push/deploy works and the new image is deployed to staging.
