### PR TITLE
fix: ensure FF is on before trying to get `template_category_id` value

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -789,7 +789,7 @@ def add_service_template(service_id, template_type, template_folder_id=None):
                 subject,
                 None if form.process_type.data == TC_PRIORITY_VALUE else form.process_type.data,
                 template_folder_id,
-                form.template_category_id.data,
+                form.template_category_id.data if current_app.config["FF_TEMPLATE_CATEGORY"] else None,
             )
         except HTTPError as e:
             if (
@@ -954,7 +954,7 @@ def edit_service_template(service_id, template_id):  # noqa: C901 TODO: remove t
                         service_id,
                         subject,
                         None if form.process_type.data == TC_PRIORITY_VALUE else form.process_type.data,
-                        form.template_category_id.data,
+                        form.template_category_id.data if current_app.config["FF_TEMPLATE_CATEGORY"] else None,
                     )
                     flash(_("'{}' template saved").format(form.name.data), "default_with_tick")
                     return redirect(


### PR DESCRIPTION
# Summary | Résumé

This PR adds a check when editing/creating templates so that if `FF_TEMPLATE_CATEGORY` is off, it doesnt try to read a value that won't be there.

# Test instructions | Instructions pour tester la modification
- [ ] Should be able to create a new template with `FF_TEMPLATE_CATEGORY` off
   - [ ] Should be able to send a message w/ the template
- [ ] Should be able to edit/save an existing template with `FF_TEMPLATE_CATEGORY` off 
   - [ ] Should be able to send a message w/ the template
