### PR TITLE
Experiment/create ephemeral UI test accts

### DIFF
--- a/tests_cypress/cypress.config.js
+++ b/tests_cypress/cypress.config.js
@@ -1,7 +1,8 @@
 var config = require('./config');
 
 const { defineConfig } = require("cypress");
-const EmailAccount = require("./cypress/plugins/email-account")
+const EmailAccount = require("./cypress/plugins/email-account");
+const CreateAccount = require("./cypress/plugins/create-account");
 const htmlvalidate = require("cypress-html-validate/plugin");
 
 module.exports = defineConfig({
@@ -28,8 +29,8 @@ module.exports = defineConfig({
           return null
         },
         // Email Account ///
-        getLastEmail() {
-          return emailAccount.getLastEmail()
+        getLastEmail(emailAddress) {
+          return emailAccount.getLastEmail(emailAddress)
         },
         deleteAllEmails() {
           return emailAccount.deleteAllEmails()
@@ -40,6 +41,18 @@ module.exports = defineConfig({
         createEmailAccount() {
           return emailAccount.createEmailAccount();
         },
+        createAccount({ baseUrl, username, secret }) {
+          if (global.acct) {
+            return global.acct;
+          } else {
+            let acct = CreateAccount(baseUrl, username, secret);
+            global.acct = acct;
+            return acct
+          }          
+        },
+        getUserName() {
+          return global.stuff;
+        }
       });
 
       on('before:browser:launch', (browser = {}, launchOptions) => {

--- a/tests_cypress/cypress/Notify/Admin/Pages/LoginPage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/LoginPage.js
@@ -19,7 +19,7 @@ let Actions = {
     },
     Login: (email, password, agreeToTerms=true) => {
         cy.clearCookie(ADMIN_COOKIE); // clear auth cookie
-        cy.task('deleteAllEmails'); // purge email inbox to make getting the 2fa code easier
+        // cy.task('deleteAllEmails'); // purge email inbox to make getting the 2fa code easier
 
         // login with username and password
         cy.visit(LoginPage.URL);
@@ -29,7 +29,7 @@ let Actions = {
 
         // get email 2fa code
         recurse(
-            () => cy.task('getLastEmail', {} ), // Cypress commands to retry
+            () => cy.task('getLastEmail', email), // Cypress commands to retry
             Cypress._.isObject, // keep retrying until the task returns an object
             {
                 log: true,

--- a/tests_cypress/cypress/Notify/Admin/Pages/TouPrompt.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/TouPrompt.js
@@ -12,7 +12,7 @@ let Actions = {
     AgreeToTerms: () => {
         TouPrompt.Components.Terms().scrollTo('bottom', { ensureScrollable: false });
         Components.DismissButton().click();
-        cy.url().should('include', '/accounts');
+        cy.url().should('include', '/services');
     },
 };
 

--- a/tests_cypress/cypress/Notify/NotifyAPI.js
+++ b/tests_cypress/cypress/Notify/NotifyAPI.js
@@ -15,7 +15,7 @@ const Utilities = {
         return jwt.jws.JWS.sign("HS256", JSON.stringify(headers), JSON.stringify(claims), Cypress.env('ADMIN_SECRET'));
     },
     GenerateID: (length = 10) => {
-        const nanoid = customAlphabet('1234567890abcdef-_', length)
+        const nanoid = customAlphabet('1234567890abcdef', length)
         return nanoid()
     }
 };
@@ -74,6 +74,22 @@ const Admin = {
                 "service_id": serviceId
             }
         })
+    },
+    CreateUITestUser: () => {
+        var token = Utilities.CreateJWT();
+        // generate random 10 char string
+        var username = Utilities.GenerateID(10);
+        return cy.request({
+            failOnStatusCode: false,
+            url: `${BASE_URL}/cypress/create_user/${username}`,
+            method: 'GET',
+            // headers: {
+            //     Authorization: `Bearer ${token}`,
+            //     "Content-Type": 'application/json'
+            // },
+        }).then((resp) => {
+            cy.wrap(resp.body.email_address).as('username');
+        });
     },
 }
 // const Admin = {

--- a/tests_cypress/cypress/plugins/create-account.js
+++ b/tests_cypress/cypress/plugins/create-account.js
@@ -1,0 +1,72 @@
+const http = require('http');
+const https = require('https');
+
+// TODO: This duplicates some code in Notify/NotifyAPI.js and should be consolidated
+const Utilities = {
+    CreateJWT: (username, secret) => {
+        const jwt = require('jsrsasign');
+        const claims = {
+            'iss': username,
+            'iat': Math.round(Date.now() / 1000)
+        }
+
+        const headers = { alg: "HS256", typ: "JWT" };
+        return jwt.jws.JWS.sign("HS256", JSON.stringify(headers), JSON.stringify(claims), secret);
+    },
+    GenerateID: (length = 10) => {
+        const characters = '0123456789abcdefghijklmnopqrstuvwxyz';
+        let result = '';
+        const charactersLength = characters.length;
+        for (let i = 0; i < length; i++) {
+            result += characters.charAt(Math.floor(Math.random() * charactersLength));
+        }
+        return result;
+    }
+};
+
+const createAccount = async (baseUrl, username, secret) => {
+    // return a generated id
+    const token = Utilities.CreateJWT(username, secret);
+    const generatedUsername = Utilities.GenerateID(10);
+    const url = `${baseUrl}/cypress/create_user/${generatedUsername}`;
+    console.log('generatedUsername', generatedUsername);
+
+    return new Promise((resolve, reject) => {
+        const options = {
+            method: 'GET', // or 'POST', depending on your API
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": 'application/json'
+            }
+        };
+
+        const getHttpModule = (url) => url.startsWith('https://') ? https : http;
+
+        const req = getHttpModule(url).request(url, options, (res) => {
+            let data = '';
+
+            res.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            res.on('end', () => {
+                try {
+                    const parsedData = JSON.parse(data);
+                    resolve(parsedData);
+                } catch (e) {
+                    reject(e);
+                }
+            });
+        });
+
+        req.on('error', (error) => {
+            reject(error); // Reject the promise on request error
+        });
+
+        req.end();
+    });
+
+};
+
+
+module.exports = createAccount;

--- a/tests_cypress/cypress/support/commands.js
+++ b/tests_cypress/cypress/support/commands.js
@@ -3,6 +3,7 @@ import "cypress-real-events";
 import config from "../../config";
 
 import LoginPage from "../Notify/Admin/Pages/LoginPage";
+import { Admin } from "../Notify/NotifyAPI";
 
 // keep track of what we test so we dont test the same thing twice
 let links_checked = [];
@@ -97,8 +98,10 @@ Cypress.Commands.add('getByTestId', (selector, ...args) => {
     return cy.get(`[data-testid=${selector}]`, ...args)
 });
 
-Cypress.Commands.add('login', (username, password, agreeToTerms = true) => {
-    cy.session([username, password, agreeToTerms], () => {
-        LoginPage.Login(username, password, agreeToTerms);
+Cypress.Commands.add('login', (un, password, agreeToTerms = true) => {
+    cy.task('createAccount', { baseUrl: config.Hostnames.API, username: Cypress.env('ADMIN_USERNAME'), secret: Cypress.env('ADMIN_SECRET') }).then((acct) => {
+        cy.session([acct.email_address, password, agreeToTerms], () => {
+            LoginPage.Login(acct.email_address, password, agreeToTerms);
+        });
     });
 });


### PR DESCRIPTION
# Summary | Résumé

This is an experiment to use ephemeral test account aliases in order to increase concurrency potential for UI tests.  It still uses a single gmail inbox, but now can create an unlimited amount of aliases on demand so that if tests are running in parallel they won't try to login to the same account in the same environment.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
