### PR TITLE
Update service template cache keys when a template category is updated

### DIFF
--- a/app/notify_client/cache.py
+++ b/app/notify_client/cache.py
@@ -32,6 +32,46 @@ def _make_key(key_format, client_method, args, kwargs):
     )
 
 
+def set_service_template(key_format):
+    def _set(client_method):
+        @wraps(client_method)
+        def new_client_method(client_instance, *args, **kwargs):
+            """
+            This decorator is functionaly the same as the `set` decorator. The only difference is that it checks if the
+            category of the service template is dirty and updates it if it is. When a category is updated via the admin
+            UI, the category is updated in the cache. However, the service template is not updated in the cache. This
+            decorator checks the category on the template against the cached category and updates the template if it is
+            dirty
+            """
+            redis_key = _make_key(key_format, client_method, args, kwargs)
+            cached_template = redis_client.get(redis_key)
+
+            if cached_template:
+                template_category = json.loads(cached_template.decode("utf-8")).get("template_category")
+                cached_category = redis_client.get(f"template_category-{template_category['id']}") if template_category else None
+
+                if cached_category:
+                    category = json.loads(cached_category.decode("utf-8"))
+
+                    if not category == template_category:
+                        redis_client.set(redis_key, json.dumps(cached_category), ex=TTL)
+
+                return json.loads(cached_template.decode("utf-8"))
+
+            api_response = client_method(client_instance, *args, **kwargs)
+
+            redis_client.set(
+                redis_key,
+                json.dumps(api_response),
+                ex=TTL,
+            )
+            return api_response
+
+        return new_client_method
+
+    return _set
+
+
 def set(key_format):
     def _set(client_method):
         @wraps(client_method)

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -268,7 +268,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             _attach_current_user({"postage": postage}),
         )
 
-    @cache.set("template-{template_id}-version-{version}")
+    @cache.set_service_template("template-{template_id}-version-{version}")
     def get_service_template(self, service_id, template_id, version=None):
         """
         Retrieve a service template.

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -189,10 +189,10 @@ def test_client_returns_count_of_service_templates(
             service_api_client.get_service,
             [SERVICE_ONE_ID],
             [call("service-{}".format(SERVICE_ONE_ID))],
-            b'{"data_from": "cache"}',
+            b'{"data": "cache"}',
             [],
             [],
-            {"data_from": "cache"},
+            {"data": "cache"},
         ),
         (
             service_api_client.get_service,
@@ -203,20 +203,20 @@ def test_client_returns_count_of_service_templates(
             [
                 call(
                     "service-{}".format(SERVICE_ONE_ID),
-                    '{"data_from": "api"}',
+                    '{"data": "api"}',
                     ex=604800,
                 )
             ],
-            {"data_from": "api"},
+            {"data": "api"},
         ),
         (
             service_api_client.get_service_template,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [call("template-{}-version-None".format(FAKE_TEMPLATE_ID))],
-            b'{"data_from": "cache"}',
+            b'{"data": "cache"}',
             [],
             [],
-            {"data_from": "cache"},
+            {"data": "cache"},
         ),
         (
             service_api_client.get_service_template,
@@ -227,20 +227,20 @@ def test_client_returns_count_of_service_templates(
             [
                 call(
                     "template-{}-version-None".format(FAKE_TEMPLATE_ID),
-                    '{"data_from": "api"}',
+                    '{"data": "api"}',
                     ex=604800,
                 )
             ],
-            {"data_from": "api"},
+            {"data": "api"},
         ),
         (
             service_api_client.get_service_template,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 1],
             [call("template-{}-version-1".format(FAKE_TEMPLATE_ID))],
-            b'{"data_from": "cache"}',
+            b'{"data": "cache"}',
             [],
             [],
-            {"data_from": "cache"},
+            {"data": "cache"},
         ),
         (
             service_api_client.get_service_template,
@@ -251,20 +251,20 @@ def test_client_returns_count_of_service_templates(
             [
                 call(
                     "template-{}-version-1".format(FAKE_TEMPLATE_ID),
-                    '{"data_from": "api"}',
+                    '{"data": "api"}',
                     ex=604800,
                 )
             ],
-            {"data_from": "api"},
+            {"data": "api"},
         ),
         (
             service_api_client.get_service_templates,
             [SERVICE_ONE_ID],
             [call("service-{}-templates".format(SERVICE_ONE_ID))],
-            b'{"data_from": "cache"}',
+            b'{"data": "cache"}',
             [],
             [],
-            {"data_from": "cache"},
+            {"data": "cache"},
         ),
         (
             service_api_client.get_service_templates,
@@ -275,20 +275,20 @@ def test_client_returns_count_of_service_templates(
             [
                 call(
                     "service-{}-templates".format(SERVICE_ONE_ID),
-                    '{"data_from": "api"}',
+                    '{"data": "api"}',
                     ex=604800,
                 )
             ],
-            {"data_from": "api"},
+            {"data": "api"},
         ),
         (
             service_api_client.get_service_template_versions,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [call("template-{}-versions".format(FAKE_TEMPLATE_ID))],
-            b'{"data_from": "cache"}',
+            b'{"data": "cache"}',
             [],
             [],
-            {"data_from": "cache"},
+            {"data": "cache"},
         ),
         (
             service_api_client.get_service_template_versions,
@@ -299,11 +299,11 @@ def test_client_returns_count_of_service_templates(
             [
                 call(
                     "template-{}-versions".format(FAKE_TEMPLATE_ID),
-                    '{"data_from": "api"}',
+                    '{"data": "api"}',
                     ex=604800,
                 )
             ],
-            {"data_from": "api"},
+            {"data": "api"},
         ),
     ],
 )
@@ -323,7 +323,7 @@ def test_returns_value_from_cache(
     )
     mock_api_get = mocker.patch(
         "app.notify_client.NotifyAdminAPIClient.get",
-        return_value={"data_from": "api"},
+        return_value={"data": "api"},
     )
     mock_redis_set = mocker.patch(
         "app.extensions.RedisClient.set",

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -189,10 +189,10 @@ def test_client_returns_count_of_service_templates(
             service_api_client.get_service,
             [SERVICE_ONE_ID],
             [call("service-{}".format(SERVICE_ONE_ID))],
-            b'{"data": "cache"}',
+            b'{"data_from": "cache"}',
             [],
             [],
-            {"data": "cache"},
+            {"data_from": "cache"},
         ),
         (
             service_api_client.get_service,
@@ -203,20 +203,20 @@ def test_client_returns_count_of_service_templates(
             [
                 call(
                     "service-{}".format(SERVICE_ONE_ID),
-                    '{"data": "api"}',
+                    '{"data_from": "api"}',
                     ex=604800,
                 )
             ],
-            {"data": "api"},
+            {"data_from": "api"},
         ),
         (
             service_api_client.get_service_template,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [call("template-{}-version-None".format(FAKE_TEMPLATE_ID))],
-            b'{"data": "cache"}',
+            b'{"data_from": "cache"}',
             [],
             [],
-            {"data": "cache"},
+            {"data_from": "cache"},
         ),
         (
             service_api_client.get_service_template,
@@ -227,20 +227,20 @@ def test_client_returns_count_of_service_templates(
             [
                 call(
                     "template-{}-version-None".format(FAKE_TEMPLATE_ID),
-                    '{"data": "api"}',
+                    '{"data_from": "api"}',
                     ex=604800,
                 )
             ],
-            {"data": "api"},
+            {"data_from": "api"},
         ),
         (
             service_api_client.get_service_template,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID, 1],
             [call("template-{}-version-1".format(FAKE_TEMPLATE_ID))],
-            b'{"data": "cache"}',
+            b'{"data_from": "cache"}',
             [],
             [],
-            {"data": "cache"},
+            {"data_from": "cache"},
         ),
         (
             service_api_client.get_service_template,
@@ -251,20 +251,20 @@ def test_client_returns_count_of_service_templates(
             [
                 call(
                     "template-{}-version-1".format(FAKE_TEMPLATE_ID),
-                    '{"data": "api"}',
+                    '{"data_from": "api"}',
                     ex=604800,
                 )
             ],
-            {"data": "api"},
+            {"data_from": "api"},
         ),
         (
             service_api_client.get_service_templates,
             [SERVICE_ONE_ID],
             [call("service-{}-templates".format(SERVICE_ONE_ID))],
-            b'{"data": "cache"}',
+            b'{"data_from": "cache"}',
             [],
             [],
-            {"data": "cache"},
+            {"data_from": "cache"},
         ),
         (
             service_api_client.get_service_templates,
@@ -275,20 +275,20 @@ def test_client_returns_count_of_service_templates(
             [
                 call(
                     "service-{}-templates".format(SERVICE_ONE_ID),
-                    '{"data": "api"}',
+                    '{"data_from": "api"}',
                     ex=604800,
                 )
             ],
-            {"data": "api"},
+            {"data_from": "api"},
         ),
         (
             service_api_client.get_service_template_versions,
             [SERVICE_ONE_ID, FAKE_TEMPLATE_ID],
             [call("template-{}-versions".format(FAKE_TEMPLATE_ID))],
-            b'{"data": "cache"}',
+            b'{"data_from": "cache"}',
             [],
             [],
-            {"data": "cache"},
+            {"data_from": "cache"},
         ),
         (
             service_api_client.get_service_template_versions,
@@ -299,11 +299,11 @@ def test_client_returns_count_of_service_templates(
             [
                 call(
                     "template-{}-versions".format(FAKE_TEMPLATE_ID),
-                    '{"data": "api"}',
+                    '{"data_from": "api"}',
                     ex=604800,
                 )
             ],
-            {"data": "api"},
+            {"data_from": "api"},
         ),
     ],
 )
@@ -323,7 +323,7 @@ def test_returns_value_from_cache(
     )
     mock_api_get = mocker.patch(
         "app.notify_client.NotifyAdminAPIClient.get",
-        return_value={"data": "api"},
+        return_value={"data_from": "api"},
     )
     mock_redis_set = mocker.patch(
         "app.extensions.RedisClient.set",


### PR DESCRIPTION
# Summary | Résumé
When a platform admin updates Template Category data, the service template cache keys become out of sync, displaying out of date Category info when editing or creating a template. 

This PR adds the `set_service_template` cache decorator that checks if the current service template cache key dirty and synchronizes them if so.

# Test instructions | Instructions pour tester la modification
## Change category data, then edit a template
1. Login as admin
2. Find a template associated with a category, make note of the category
3. In a new tab go to platform admin page and change the `name` the category noted in step 2 
4. Edit the template, note that the name of the category is what you set it to in step 3

## Create a new template
1. Create a new template up to the step where you can choose a template category
2. Leave one of the required fields empty
3. On the platform admin page, edit the `name` of one of the template categories
4. Submit the form to create a template 
5. Note not only the error message, but the edited category name should be present in the list

## Create a new template - part 2
1. Create a new template up to the step where you can choose a template category but do not submit
2. On the platform admin page, edit the `name` of the category you chose for the template in step 1
3. Submit the form and create the new template
4. Edit the template
5. Note that the category name is the same as what you edited it to in step 2