### PR TITLE
Fix/500-errors-caused-by-missing-ff-check

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -741,7 +741,7 @@ def get_template_data(template_id):
     methods=["GET", "POST"],
 )
 @user_has_permissions("manage_templates")
-def add_service_template(service_id, template_type, template_folder_id=None):
+def add_service_template(service_id, template_type, template_folder_id=None):  # noqa: C901
     if template_type not in ["sms", "email", "letter"]:
         abort(404)
     if not current_service.has_permission("letter") and template_type == "letter":
@@ -790,7 +790,8 @@ def add_service_template(service_id, template_type, template_folder_id=None):
                 None if form.process_type.data == TC_PRIORITY_VALUE else form.process_type.data,
                 template_folder_id,
                 form.template_category_id.data if current_app.config["FF_TEMPLATE_CATEGORY"] else None,
-            )            # Send the information in form's template_category_other field to Freshdesk
+            )
+            # Send the information in form's template_category_other field to Freshdesk
             # This code path is a little complex - We do not want to raise an error if the request to Freshdesk fails, only if template creation fails
             if current_app.config["FF_TEMPLATE_CATEGORY"]:
                 if form.template_category_other.data:

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -790,7 +790,27 @@ def add_service_template(service_id, template_type, template_folder_id=None):
                 None if form.process_type.data == TC_PRIORITY_VALUE else form.process_type.data,
                 template_folder_id,
                 form.template_category_id.data if current_app.config["FF_TEMPLATE_CATEGORY"] else None,
-            )
+            )            # Send the information in form's template_category_other field to Freshdesk
+            # This code path is a little complex - We do not want to raise an error if the request to Freshdesk fails, only if template creation fails
+            if current_app.config["FF_TEMPLATE_CATEGORY"]:
+                if form.template_category_other.data:
+                    is_english = get_current_locale(current_app) == "en"
+                    try:
+                        current_user.send_new_template_category_request(
+                            current_user.id,
+                            current_service.id,
+                            form.template_category_other.data if is_english else None,
+                            form.template_category_other.data if not is_english else None,
+                            new_template["data"]["id"],
+                        )
+                    except HTTPError as e:
+                        current_app.logger.error(
+                            f"Failed to send new template category request to Freshdesk: {e} for template {new_template['data']['id']}, data is {form.template_category_other.data}"
+                        )
+                    except AttributeError as e:
+                        current_app.logger.error(
+                            f"Failed to send new template category request to Freshdesk: {e} for template {new_template['data']['id']}, data is {form.template_category_other.data}"
+                        )
         except HTTPError as e:
             if (
                 e.status_code == 400
@@ -956,6 +976,23 @@ def edit_service_template(service_id, template_id):  # noqa: C901 TODO: remove t
                         None if form.process_type.data == TC_PRIORITY_VALUE else form.process_type.data,
                         form.template_category_id.data if current_app.config["FF_TEMPLATE_CATEGORY"] else None,
                     )
+                    # Send the information in form's template_category_other field to Freshdesk
+                    # This code path is a little complex - We do not want to raise an error if the request to Freshdesk fails, only if template creation fails
+                    if current_app.config["FF_TEMPLATE_CATEGORY"]:
+                        if form.template_category_other.data:
+                            is_english = get_current_locale(current_app) == "en"
+                            try:
+                                current_user.send_new_template_category_request(
+                                    current_user.id,
+                                    current_service.id,
+                                    form.template_category_other.data if is_english else None,
+                                    form.template_category_other.data if not is_english else None,
+                                    template_id,
+                                )
+                            except HTTPError as e:
+                                current_app.logger.error(
+                                    f"Failed to send new template category request to Freshdesk: {e} for template {template_id}, data is {form.template_category_other.data}"
+                                )
                     flash(_("'{}' template saved").format(form.name.data), "default_with_tick")
                     return redirect(
                         url_for(

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -394,6 +394,13 @@ class User(JSONModel, UserMixin):
             self.id, serviceID, service_name, org_id, org_name, filename, alt_text_en, alt_text_fr, branding_logo_name
         )
 
+    def send_new_template_category_request(
+        self, user_id, service_id, template_category_name_en, template_category_name_fr, template_id
+    ):
+        user_api_client.send_new_template_category_request(
+            user_id, service_id, template_category_name_en, template_category_name_fr, template_id
+        )
+
     def refresh_session_id(self):
         self.current_session_id = user_api_client.get_user(self.id).get("current_session_id")
         session["current_session_id"] = self.current_session_id

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -115,9 +115,9 @@ class TestSendOtherCategoryInfo:
         mock_send_other_category_to_freshdesk,
         active_user_with_permissions,
         fake_uuid,
-        app_
+        app_,
     ):
-        with set_config(app_, "FF_TEMPLATE_CATEGORY", True): 
+        with set_config(app_, "FF_TEMPLATE_CATEGORY", True):
             client_request.post(
                 ".add_service_template",
                 service_id=SERVICE_ONE_ID,
@@ -150,9 +150,9 @@ class TestSendOtherCategoryInfo:
         mock_send_other_category_to_freshdesk,
         active_user_with_permissions,
         fake_uuid,
-        app_
+        app_,
     ):
-        with set_config(app_, "FF_TEMPLATE_CATEGORY", True): 
+        with set_config(app_, "FF_TEMPLATE_CATEGORY", True):
             name = "new name"
             content = "template <em>content</em> with & entity"
             client_request.post(
@@ -1330,12 +1330,7 @@ def test_should_redirect_to_one_off_if_template_type_is_letter(
 
 
 def test_should_redirect_when_saving_a_template(
-    client_request,
-    mock_get_template_categories,
-    mock_get_service_template,
-    mock_update_service_template,
-    fake_uuid,
-    app_
+    client_request, mock_get_template_categories, mock_get_service_template, mock_update_service_template, fake_uuid, app_
 ):
     name = "new name"
     content = "template <em>content</em> with & entity"
@@ -1359,19 +1354,20 @@ def test_should_redirect_when_saving_a_template(
     assert flash_banner == f"'{name}' template saved"
 
     mock_update_service_template.assert_called_with(
-        fake_uuid, name, "sms", content, SERVICE_ONE_ID, None, DEFAULT_PROCESS_TYPE, DEFAULT_TEMPLATE_CATEGORY_LOW if app_.config["FF_TEMPLATE_CATEGORY"] else None
+        fake_uuid,
+        name,
+        "sms",
+        content,
+        SERVICE_ONE_ID,
+        None,
+        DEFAULT_PROCESS_TYPE,
+        DEFAULT_TEMPLATE_CATEGORY_LOW if app_.config["FF_TEMPLATE_CATEGORY"] else None,
     )
 
 
 @pytest.mark.parametrize("process_type", [TemplateProcessTypes.NORMAL.value, TemplateProcessTypes.PRIORITY.value])
 def test_should_edit_content_when_process_type_is_set_not_platform_admin(
-    client_request,
-    mocker,
-    mock_update_service_template,
-    mock_get_template_categories,
-    fake_uuid,
-    process_type,
-    app_
+    client_request, mocker, mock_update_service_template, mock_get_template_categories, fake_uuid, process_type, app_
 ):
     mock_get_service_template_with_process_type(mocker, process_type)
     client_request.post(
@@ -1719,7 +1715,7 @@ def test_should_redirect_when_saving_a_template_email(
     mock_get_template_categories,
     mock_get_user_by_email,
     fake_uuid,
-    app_
+    app_,
 ):
     name = "new name"
     content = "template <em>content</em> with & entity ((thing)) ((date))"
@@ -1747,7 +1743,14 @@ def test_should_redirect_when_saving_a_template_email(
         ),
     )
     mock_update_service_template.assert_called_with(
-        fake_uuid, name, "email", content, SERVICE_ONE_ID, subject, DEFAULT_PROCESS_TYPE, DEFAULT_TEMPLATE_CATEGORY_LOW if app_.config['FF_TEMPLATE_CATEGORY'] else None
+        fake_uuid,
+        name,
+        "email",
+        content,
+        SERVICE_ONE_ID,
+        subject,
+        DEFAULT_PROCESS_TYPE,
+        DEFAULT_TEMPLATE_CATEGORY_LOW if app_.config["FF_TEMPLATE_CATEGORY"] else None,
     )
 
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -48,6 +48,7 @@ from tests.conftest import (
     fake_uuid,
     mock_get_service_template_with_process_type,
     normalize_spaces,
+    set_config,
 )
 
 DEFAULT_PROCESS_TYPE = TemplateProcessTypes.BULK.value
@@ -101,6 +102,83 @@ class TestRedisPreviewUtilities:
         actual_data = get_preview_data(fake_uuid)
 
         assert actual_data == {}
+
+
+class TestSendOtherCategoryInfo:
+    def test_create_email_template_cat_other_to_freshdesk(
+        self,
+        client_request,
+        mock_create_service_template,
+        mock_get_template_folders,
+        mock_get_service_template_when_no_template_exists,
+        mock_get_template_categories,
+        mock_send_other_category_to_freshdesk,
+        active_user_with_permissions,
+        fake_uuid,
+        app_
+    ):
+        with set_config(app_, "FF_TEMPLATE_CATEGORY", True): 
+            client_request.post(
+                ".add_service_template",
+                service_id=SERVICE_ONE_ID,
+                template_type="email",
+                _data={
+                    "name": "new name",
+                    "subject": "Food incoming!",
+                    "template_content": "here's a burrito 🌯",
+                    "template_type": "email",
+                    "template_category_id": TESTING_TEMPLATE_CATEGORY,
+                    "service": SERVICE_ONE_ID,
+                    "process_type": DEFAULT_PROCESS_TYPE,
+                    "button_pressed": "save",
+                    "template_category_other": "hello",
+                },
+                _follow_redirects=True,
+            )
+            assert mock_create_service_template.called is True
+            assert mock_send_other_category_to_freshdesk.called is True
+            mock_send_other_category_to_freshdesk.assert_called_once_with(
+                active_user_with_permissions["id"], SERVICE_ONE_ID, "hello", None, fake_uuid
+            )
+
+    def test_edit_email_template_cat_other_to_freshdesk(
+        self,
+        client_request,
+        mock_get_template_categories,
+        mock_get_service_template,
+        mock_update_service_template,
+        mock_send_other_category_to_freshdesk,
+        active_user_with_permissions,
+        fake_uuid,
+        app_
+    ):
+        with set_config(app_, "FF_TEMPLATE_CATEGORY", True): 
+            name = "new name"
+            content = "template <em>content</em> with & entity"
+            client_request.post(
+                ".edit_service_template",
+                service_id=SERVICE_ONE_ID,
+                template_id=fake_uuid,
+                _data={
+                    "id": fake_uuid,
+                    "name": name,
+                    "template_content": content,
+                    "template_type": "sms",
+                    "template_category_id": DEFAULT_TEMPLATE_CATEGORY_LOW,
+                    "service": SERVICE_ONE_ID,
+                    "template_category_other": "hello",
+                    "reply_to_text": "reply@go.com",
+                },
+                _follow_redirects=True,
+            )
+
+            mock_update_service_template.assert_called_with(
+                fake_uuid, name, "sms", content, SERVICE_ONE_ID, None, DEFAULT_PROCESS_TYPE, DEFAULT_TEMPLATE_CATEGORY_LOW
+            )
+            assert mock_send_other_category_to_freshdesk.called is True
+            mock_send_other_category_to_freshdesk.assert_called_once_with(
+                active_user_with_permissions["id"], SERVICE_ONE_ID, "hello", None, fake_uuid
+            )
 
 
 def test_should_show_empty_page_when_no_templates(
@@ -1257,6 +1335,7 @@ def test_should_redirect_when_saving_a_template(
     mock_get_service_template,
     mock_update_service_template,
     fake_uuid,
+    app_
 ):
     name = "new name"
     content = "template <em>content</em> with & entity"
@@ -1280,7 +1359,7 @@ def test_should_redirect_when_saving_a_template(
     assert flash_banner == f"'{name}' template saved"
 
     mock_update_service_template.assert_called_with(
-        fake_uuid, name, "sms", content, SERVICE_ONE_ID, None, DEFAULT_PROCESS_TYPE, DEFAULT_TEMPLATE_CATEGORY_LOW
+        fake_uuid, name, "sms", content, SERVICE_ONE_ID, None, DEFAULT_PROCESS_TYPE, DEFAULT_TEMPLATE_CATEGORY_LOW if app_.config["FF_TEMPLATE_CATEGORY"] else None
     )
 
 
@@ -1292,6 +1371,7 @@ def test_should_edit_content_when_process_type_is_set_not_platform_admin(
     mock_get_template_categories,
     fake_uuid,
     process_type,
+    app_
 ):
     mock_get_service_template_with_process_type(mocker, process_type)
     client_request.post(
@@ -1323,7 +1403,7 @@ def test_should_edit_content_when_process_type_is_set_not_platform_admin(
         SERVICE_ONE_ID,
         None,
         process_type,
-        TESTING_TEMPLATE_CATEGORY,
+        TESTING_TEMPLATE_CATEGORY if app_.config["FF_TEMPLATE_CATEGORY"] else None,
     )
 
 
@@ -1639,6 +1719,7 @@ def test_should_redirect_when_saving_a_template_email(
     mock_get_template_categories,
     mock_get_user_by_email,
     fake_uuid,
+    app_
 ):
     name = "new name"
     content = "template <em>content</em> with & entity ((thing)) ((date))"
@@ -1666,7 +1747,7 @@ def test_should_redirect_when_saving_a_template_email(
         ),
     )
     mock_update_service_template.assert_called_with(
-        fake_uuid, name, "email", content, SERVICE_ONE_ID, subject, DEFAULT_PROCESS_TYPE, DEFAULT_TEMPLATE_CATEGORY_LOW
+        fake_uuid, name, "email", content, SERVICE_ONE_ID, subject, DEFAULT_PROCESS_TYPE, DEFAULT_TEMPLATE_CATEGORY_LOW if app_.config['FF_TEMPLATE_CATEGORY'] else None
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -971,6 +971,11 @@ def mock_create_service_template(mocker, fake_uuid):
 
 
 @pytest.fixture(scope="function")
+def mock_send_other_category_to_freshdesk(mocker):
+    return mocker.patch("app.user_api_client.send_new_template_category_request")
+
+
+@pytest.fixture(scope="function")
 def mock_update_service_template(mocker):
     def _update(
         id_,


### PR DESCRIPTION

# Summary | Résumé

- Adds a check before calling the freshdesk code to make sure FF is on.
- Updates the tests to handle the FF being on and off


# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
