### PR TITLE
Template list: only show the template category if the FF is on

### DIFF
--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -59,9 +59,11 @@
         <span id="sr-{{ item.id }}1" class="message-meta message-type">
           {{ _(item.hint) }}
         </span>
-        <span id="sr-{{ item.id }}2" class="message-meta message-category">
-          {{ item.template_category[template_category_name_col] }}
-        </span>
+        {% if config["FF_TEMPLATE_CATEGORY"] %}
+          <span id="sr-{{ item.id }}2" class="message-meta message-category">
+            {{ item.template_category[template_category_name_col] }}
+          </span>
+        {% endif %}
       </div>
     {% endfor %}
     {% if display_checkboxes %}


### PR DESCRIPTION
# Summary | Résumé

This PR fixes an issue where the template category would be shown in the templates list even if the feature flag was off.

## Before
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/755310bf-30e8-4f7e-a37f-881fd8434c39">

## After
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/c99904d1-3b6d-4b82-ba90-bd3ac237635d">

# Test instructions | Instructions pour tester la modification
- [ ] Ensure template category **is not shown** on the template list page when the **FF is OFF** 
- [ ] Ensure template category **is shown** on the template list page when the **FF is ON**