### PR TITLE
Remove `.only()` debug statement from tests

### DIFF
--- a/tests_cypress/cypress/e2e/admin/template-filters.cy.js
+++ b/tests_cypress/cypress/e2e/admin/template-filters.cy.js
@@ -130,7 +130,7 @@ describe("Template filters", () => {
           });
       });
 
-      it.only("Should list category filters alphabetically", () => {
+      it("Should list category filters alphabetically", () => {
         cy.visit(url);
 
         Page.ToggleFilters();


### PR DESCRIPTION
# Summary | Résumé

This PR removes the debugging `only()` call which makes it so only a single test runs.

# Test instructions | Instructions pour tester la modification

- Ensure all template filter tests run in the test suite.