### PR TITLE
Fix translation

### DIFF
--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1909,7 +1909,7 @@
 "Practice continuous security","Pratiquer la sécurité continue"
 "Getting started","Découvrez comment fonctionne Notification GC"
 "Read and agree to the terms of use","Lisez et acceptez les conditions d’utilisation"
-"Read and agree to continue","Lire et accepter pour continuer"
+"Read and agree to continue","Lisez et acceptez les conditions d’utilisation"
 "Agree follows terms of use","Accepter suite aux conditions d'utilisation"
 "Priority","Envoi prioritaire",
 "Bulk","Envoi de masse"


### PR DESCRIPTION
# Summary | Résumé

Update error message in Account Creation in FR to read “Lisez et acceptez les conditions d’utilisation” not “Lire et accepter pour continuer”



# Test instructions | Instructions pour tester la modification

see the change on the admin preview app