### PR TITLE
Xray Python Service Name Change

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,7 +1,7 @@
 import os
 
 from apig_wsgi import make_lambda_handler
-from aws_xray_sdk.core import patch_all, xray_recorder
+from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from dotenv import load_dotenv
 from flask import Flask
@@ -9,8 +9,6 @@ from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from app import create_app
-
-patch_all()
 
 load_dotenv()
 

--- a/application.py
+++ b/application.py
@@ -1,7 +1,7 @@
 import os
 
 from apig_wsgi import make_lambda_handler
-from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.core import patch_all, xray_recorder
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from dotenv import load_dotenv
 from flask import Flask
@@ -10,11 +10,13 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from app import create_app
 
+patch_all()
+
 load_dotenv()
 
 application = Flask("app")
 application.wsgi_app = ProxyFix(application.wsgi_app)  # type: ignore
-xray_recorder.configure(service='admin')
+xray_recorder.configure(service='Notify')
 XRayMiddleware(application, xray_recorder)
 create_app(application)
 


### PR DESCRIPTION
# Summary | Résumé

Simply renaming the xray SDK service name (across the API, Admin and Celery Code) to Notify to see if traffic will be traced through the stack.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

## Testing Steps
- After API and Admin are both deployed to staging, check the Xray maps and see if they are linked as the same service
