### PR TITLE
upgrade a few selected packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "accessible-autocomplete": "^2.0.4",
         "braces": "^3.0.3",
-        "dayjs": "^1.10.7",
+        "dayjs": "^1.11.13",
         "diff-dom": "4.2.8",
         "govuk_frontend_toolkit": "9.0.1",
         "hogan": "1.0.2",
@@ -5661,10 +5661,9 @@
       "dev": true
     },
     "node_modules/dayjs": {
-      "version": "1.11.12",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
-      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg==",
-      "license": "MIT"
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "accessible-autocomplete": "^2.0.4",
     "braces": "^3.0.3",
-    "dayjs": "^1.10.7",
+    "dayjs": "^1.11.13",
     "diff-dom": "4.2.8",
     "govuk_frontend_toolkit": "9.0.1",
     "hogan": "1.0.2",

--- a/poetry.lock
+++ b/poetry.lock
@@ -2233,13 +2233,13 @@ files = [
 
 [[package]]
 name = "types-python-dateutil"
-version = "2.9.0.20240316"
+version = "2.9.0.20240821"
 description = "Typing stubs for python-dateutil"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-python-dateutil-2.9.0.20240316.tar.gz", hash = "sha256:5d2f2e240b86905e40944dd787db6da9263f0deabef1076ddaed797351ec0202"},
-    {file = "types_python_dateutil-2.9.0.20240316-py3-none-any.whl", hash = "sha256:6b8cb66d960771ce5ff974e9dd45e38facb81718cc1e208b10b1baccbfdbee3b"},
+    {file = "types-python-dateutil-2.9.0.20240821.tar.gz", hash = "sha256:9649d1dcb6fef1046fb18bebe9ea2aa0028b160918518c34589a46045f6ebd98"},
+    {file = "types_python_dateutil-2.9.0.20240821-py3-none-any.whl", hash = "sha256:f5889fcb4e63ed4aaa379b44f93c32593d50b9a94c9a60a0c854d8cc3511cd57"},
 ]
 
 [[package]]
@@ -2291,13 +2291,13 @@ files = [
 
 [[package]]
 name = "unidecode"
-version = "1.3.6"
+version = "1.3.8"
 description = "ASCII transliterations of Unicode text"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "Unidecode-1.3.6-py3-none-any.whl", hash = "sha256:547d7c479e4f377b430dd91ac1275d593308dce0fc464fb2ab7d41f82ec653be"},
-    {file = "Unidecode-1.3.6.tar.gz", hash = "sha256:fed09cf0be8cf415b391642c2a5addfc72194407caee4f98719e40ec2a72b830"},
+    {file = "Unidecode-1.3.8-py3-none-any.whl", hash = "sha256:d130a61ce6696f8148a3bd8fe779c99adeb4b870584eeb9526584e9aa091fd39"},
+    {file = "Unidecode-1.3.8.tar.gz", hash = "sha256:cfdb349d46ed3873ece4586b96aa75258726e2fa8ec21d6f00a591d98806c2f4"},
 ]
 
 [[package]]
@@ -2576,4 +2576,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.9"
-content-hash = "1757fcf62e61abf167c976adabb0dc20a5230cb7bd90cf1d6a8b33b4870bd429"
+content-hash = "ea440a330db1bfd6a3f97c7cc12af0588e6352e593527bc9a8fd226f2bd6bc72"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ email-validator = "1.3.1"
 Werkzeug = "3.0.3"
 greenlet = "2.0.2"
 mixpanel = "4.10.1"
-unidecode = "^1.3.6"
+unidecode = "^1.3.8"
 
 # PaaS
 awscli-cwlogs = "^1.4.6"
@@ -77,7 +77,7 @@ mypy = "1.10.0"
 ruff = "^0.2.1"
 
 # stubs libraries to keep mypy happy
-types-python-dateutil = "2.9.0.20240316"
+types-python-dateutil = "2.9.0.20240821"
 types-pytz = "2021.3.8"
 types-requests = "2.32.0.20240712"
 types-beautifulsoup4 = "^4.12.0.6"


### PR DESCRIPTION
# Summary | Résumé

Upgrade a few packages from #1930 that have high confidence: dayjs, unidecode, and types-python-dateutil.

# Test instructions | Instructions pour tester la modification

Poke at the review app
