### PR TITLE
Add  terms of use prompt ui tests to CI

### DIFF
--- a/app/templates/components/tou-prompt.html
+++ b/app/templates/components/tou-prompt.html
@@ -27,8 +27,8 @@
     {{ _('If this is not correct, ') }}<a href="{{ url_for('main.contact') }}" target="_blank">{{ _('contact us') }}</a>.
     </p>
   </div>
-  <div id="tou-prompt" data-testid="tou-prompt" class="mt-16">
-    <h2 class="heading-medium mt-0 mb-6" data-testid="tou-heading">{{ _('Know your responsibilities') }}</h2>
+  <div class="mt-16">
+    <h2 class="heading-medium mt-0 mb-6">{{ _('Know your responsibilities') }}</h2>
     <div data-testid="tou-terms">
       <p>
         {{ _('By using GC Notify, you accept our ') }}

--- a/tests_cypress/cypress/e2e/admin/ci.cy.js
+++ b/tests_cypress/cypress/e2e/admin/ci.cy.js
@@ -4,6 +4,7 @@ import "./menu/disclosure_menu.cy";
 import "./sitemap/sitemap.cy";
 import "./branding/all.cy";
 import "./tou_dialog.cy";
+import "./tou_prompt.cy";
 import "./template-filters.cy";
 import "./template-categories.cy";
 import "./template/create-template.cy";


### PR DESCRIPTION
# Summary | Résumé
This PR add the TOU prompt tests to CI and fixes them to remove a duplicate ID.

# Test instructions | Instructions pour tester la modification
- TOU Prompt tests should run as part of the cypress test workflow
