### PR TITLE
Squash a few routing / UI bugs

### DIFF
--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -28,13 +28,11 @@ dummy_bearer_token = "bearer_token_set"
 @main.route("/services/<service_id>/api")
 @user_has_permissions("manage_api_keys")
 def api_integration(service_id):
-    callbacks_link = ".api_callbacks" if current_service.has_permission(
-        "inbound_sms") else ".delivery_status_callback"
+    callbacks_link = ".api_callbacks" if current_service.has_permission("inbound_sms") else ".delivery_status_callback"
     return render_template(
         "views/api/index.html",
         callbacks_link=callbacks_link,
-        api_notifications=notification_api_client.get_api_notifications_for_service(
-            service_id),
+        api_notifications=notification_api_client.get_api_notifications_for_service(service_id),
     )
 
 
@@ -89,8 +87,7 @@ def create_api_key(service_id):
     disabled_options, option_hints = [], {}
     if current_service.trial_mode:
         disabled_options = [KEY_TYPE_NORMAL]
-        option_hints[KEY_TYPE_NORMAL] = Markup(
-            _l("Not available because your service is in trial mode."))
+        option_hints[KEY_TYPE_NORMAL] = Markup(_l("Not available because your service is in trial mode."))
     if current_service.has_permission("letter"):
         option_hints[KEY_TYPE_TEAM] = ""
     if form.validate_on_submit():
@@ -122,8 +119,7 @@ def revoke_api_key(service_id, key_id):
     if request.method == "GET":
         flash(
             [
-                "{} ‘{}’?".format(
-                    _l("Are you sure you want to revoke"), key_name),
+                "{} ‘{}’?".format(_l("Are you sure you want to revoke"), key_name),
                 _l("You will not be able to use this API key to connect to GC Notify"),
             ],
             "revoke this API key",
@@ -141,11 +137,9 @@ def get_apis():
     callback_api = None
     inbound_api = None
     if current_service.service_callback_api:
-        callback_api = service_api_client.get_service_callback_api(
-            current_service.id, current_service.service_callback_api[0])
+        callback_api = service_api_client.get_service_callback_api(current_service.id, current_service.service_callback_api[0])
     if current_service.inbound_api:
-        inbound_api = service_api_client.get_service_inbound_api(
-            current_service.id, current_service.inbound_api[0])
+        inbound_api = service_api_client.get_service_inbound_api(current_service.id, current_service.inbound_api[0])
 
     return (callback_api, inbound_api)
 
@@ -167,8 +161,7 @@ def api_callbacks(service_id):
 
     return render_template(
         "views/api/callbacks.html",
-        received_text_messages_callback=received_text_messages_callback[
-            "url"] if received_text_messages_callback else None,
+        received_text_messages_callback=received_text_messages_callback["url"] if received_text_messages_callback else None,
         delivery_status_callback=delivery_status_callback["url"] if delivery_status_callback else None,
     )
 
@@ -182,8 +175,7 @@ def get_delivery_status_callback_details():
 @user_has_permissions("manage_api_keys")
 def delete_delivery_status_callback(service_id):
     delivery_status_callback = get_delivery_status_callback_details()
-    back_link = ".api_callbacks" if current_service.has_permission(
-        "inbound_sms") else ".api_integration"
+    back_link = ".api_callbacks" if current_service.has_permission("inbound_sms") else ".api_integration"
     url_hint_txt = "Must start with https://"
 
     if request.method == "POST":
@@ -193,23 +185,19 @@ def delete_delivery_status_callback(service_id):
                 delivery_status_callback["id"],
             )
 
-            flash(_l("Your Callback configuration has been deleted."),
-                  "default_with_tick")
+            flash(_l("Your Callback configuration has been deleted."), "default_with_tick")
             return redirect(url_for(back_link, service_id=service_id))
 
-        flash(["{}".format(
-            _l("Are you sure you want to delete this callback configuration?"))], "delete")
+    flash(["{}".format(_l("Are you sure you want to delete this callback configuration?"))], "delete")
 
     form = ServiceDeliveryStatusCallbackForm(
-        url=delivery_status_callback.get(
-            "url") if delivery_status_callback else "",
+        url=delivery_status_callback.get("url") if delivery_status_callback else "",
         bearer_token=dummy_bearer_token if delivery_status_callback else "",
     )
 
     return render_template(
         "views/api/callbacks/delivery-status-callback.html",
-        back_link=".api_callbacks" if current_service.has_permission(
-            "inbound_sms") else ".delivery_status_callback",
+        back_link=".api_callbacks" if current_service.has_permission("inbound_sms") else ".delivery_status_callback",
         hint_text=url_hint_txt,
         is_deleting=True,
         form=form,
@@ -223,13 +211,11 @@ def delete_delivery_status_callback(service_id):
 @user_has_permissions("manage_api_keys")
 def delivery_status_callback(service_id):
     delivery_status_callback = get_delivery_status_callback_details()
-    back_link = ".api_callbacks" if current_service.has_permission(
-        "inbound_sms") else ".api_integration"
+    back_link = ".api_callbacks" if current_service.has_permission("inbound_sms") else ".api_integration"
     url_hint_txt = _l("Must start with https://")
 
     form = ServiceDeliveryStatusCallbackForm(
-        url=delivery_status_callback.get(
-            "url") if delivery_status_callback else "",
+        url=delivery_status_callback.get("url") if delivery_status_callback else "",
         bearer_token=dummy_bearer_token if delivery_status_callback else "",
     )
 
@@ -244,32 +230,31 @@ def delivery_status_callback(service_id):
                 service_api_client.update_service_callback_api(
                     service_id,
                     url=form.url.data,
-                    bearer_token=check_token_against_dummy_bearer(
-                        form.bearer_token.data),
+                    bearer_token=check_token_against_dummy_bearer(form.bearer_token.data),
                     user_id=current_user.id,
                     callback_api_id=delivery_status_callback.get("id"),
                 )
 
-                # If the user is just testing their URL, don't send them back to the API Integration page
-                if request.form.get("button_pressed") == "test_response_time":
-                    flash(
-                        _l("The service {} responded in {} seconds.").format(
-                            url_hostname,
-                            response_time,
-                        ),
-                        "default_with_tick",
-                    )
-                    return redirect(url_for("main.delivery_status_callback", service_id=service_id))
-
+            # If the user is just testing their URL, don't send them back to the API Integration page
+            if request.form.get("button_pressed") == "test_response_time":
                 flash(
-                    _l("We’ve saved your callback configuration. {} responded in {} seconds.").format(
+                    _l("The service {} responded in {} seconds.").format(
                         url_hostname,
                         response_time,
                     ),
                     "default_with_tick",
                 )
+                return redirect(url_for("main.delivery_status_callback", service_id=service_id))
 
-                return redirect(url_for(back_link, service_id=service_id))
+            flash(
+                _l("We’ve saved your callback configuration. {} responded in {} seconds.").format(
+                    url_hostname,
+                    response_time,
+                ),
+                "default_with_tick",
+            )
+
+            return redirect(url_for(back_link, service_id=service_id))
         # Create a new callback
         elif form.url.data:
             service_api_client.create_service_callback_api(
@@ -312,6 +297,16 @@ def delivery_status_callback(service_id):
             )
             return redirect(url_for("main.delivery_status_callback", service_id=service_id))
 
+        flash(
+            _l("We’ve saved your callback configuration. {} responded in {} seconds.").format(
+                url_hostname,
+                response_time,
+            ),
+            "default_with_tick",
+        )
+
+        return redirect(url_for(back_link, service_id=service_id))
+
     return render_template(
         "views/api/callbacks/delivery-status-callback.html",
         has_callback_config=delivery_status_callback is not None,
@@ -334,13 +329,11 @@ def get_received_text_messages_callback():
 def received_text_messages_callback(service_id):
     if not current_service.has_permission("inbound_sms"):
         return redirect(url_for(".api_integration", service_id=service_id))
-    back_link = ".api_callbacks" if current_service.has_permission(
-        "inbound_sms") else ".api_integration"
+    back_link = ".api_callbacks" if current_service.has_permission("inbound_sms") else ".api_integration"
 
     received_text_messages_callback = get_received_text_messages_callback()
     form = ServiceReceiveMessagesCallbackForm(
-        url=received_text_messages_callback.get(
-            "url") if received_text_messages_callback else "",
+        url=received_text_messages_callback.get("url") if received_text_messages_callback else "",
         bearer_token=dummy_bearer_token if received_text_messages_callback else "",
     )
     url_hint_txt = _l("Must start with https://")
@@ -355,8 +348,7 @@ def received_text_messages_callback(service_id):
                 service_api_client.update_service_inbound_api(
                     service_id,
                     url=form.url.data,
-                    bearer_token=check_token_against_dummy_bearer(
-                        form.bearer_token.data),
+                    bearer_token=check_token_against_dummy_bearer(form.bearer_token.data),
                     user_id=current_user.id,
                     inbound_api_id=received_text_messages_callback.get("id"),
                 )
@@ -371,6 +363,15 @@ def received_text_messages_callback(service_id):
                         "default_with_tick",
                     )
                     return redirect(url_for("main.received_text_messages_callback", service_id=service_id))
+                else:
+                    flash(
+                        _l("The service {} responded in {} seconds.").format(
+                            url_hostname,
+                            response_time,
+                        ),
+                        "default_with_tick",
+                    )
+                    return redirect(url_for("main.delivery_status_callback", service_id=service_id))
 
                 flash(
                     _l("We’ve saved your callback configuration. {} responded in {} seconds.").format(
@@ -379,6 +380,7 @@ def received_text_messages_callback(service_id):
                     ),
                     "default_with_tick",
                 )
+                return redirect(url_for(back_link, service_id=service_id))
 
         elif received_text_messages_callback and not form.url.data:
             service_api_client.delete_service_inbound_api(
@@ -418,7 +420,17 @@ def received_text_messages_callback(service_id):
                 ),
                 "default_with_tick",
             )
-            return redirect(url_for("main.received_text_messages_callback", service_id=service_id))
+            return redirect(url_for("main.delivery_status_callback", service_id=service_id))
+
+        flash(
+            _l("We’ve saved your callback configuration. {} responded in {} seconds.").format(
+                url_hostname,
+                response_time,
+            ),
+            "default_with_tick",
+        )
+
+        return redirect(url_for(back_link, service_id=service_id))
 
     return render_template(
         "views/api/callbacks/received-text-messages-callback.html",
@@ -432,8 +444,7 @@ def received_text_messages_callback(service_id):
 @user_has_permissions("manage_api_keys")
 def delete_received_text_messages_callback(service_id):
     received_text_messages_callback = get_received_text_messages_callback()
-    back_link = ".api_callbacks" if current_service.has_permission(
-        "inbound_sms") else ".api_integration"
+    back_link = ".api_callbacks" if current_service.has_permission("inbound_sms") else ".api_integration"
     url_hint_txt = "Must start with https://"
 
     if request.method == "POST":
@@ -443,23 +454,19 @@ def delete_received_text_messages_callback(service_id):
                 received_text_messages_callback["id"],
             )
 
-            flash(_l("Your Callback configuration has been deleted."),
-                  "default_with_tick")
+            flash(_l("Your Callback configuration has been deleted."), "default_with_tick")
             return redirect(url_for(back_link, service_id=service_id))
 
-    flash(["{}".format(
-        _l("Are you sure you want to delete this callback configuration?"))], "delete")
+    flash(["{}".format(_l("Are you sure you want to delete this callback configuration?"))], "delete")
 
     form = ServiceReceiveMessagesCallbackForm(
-        url=received_text_messages_callback.get(
-            "url") if delivery_status_callback else "",
+        url=received_text_messages_callback.get("url") if delivery_status_callback else "",
         bearer_token=dummy_bearer_token if received_text_messages_callback else "",
     )
 
     return render_template(
         "views/api/callbacks/delivery-status-callback.html",
-        back_link=".api_callbacks" if current_service.has_permission(
-            "inbound_sms") else ".delivery_status_callback",
+        back_link=".api_callbacks" if current_service.has_permission("inbound_sms") else ".delivery_status_callback",
         hint_text=url_hint_txt,
         is_deleting=True,
         form=form,

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -28,11 +28,13 @@ dummy_bearer_token = "bearer_token_set"
 @main.route("/services/<service_id>/api")
 @user_has_permissions("manage_api_keys")
 def api_integration(service_id):
-    callbacks_link = ".api_callbacks" if current_service.has_permission("inbound_sms") else ".delivery_status_callback"
+    callbacks_link = ".api_callbacks" if current_service.has_permission(
+        "inbound_sms") else ".delivery_status_callback"
     return render_template(
         "views/api/index.html",
         callbacks_link=callbacks_link,
-        api_notifications=notification_api_client.get_api_notifications_for_service(service_id),
+        api_notifications=notification_api_client.get_api_notifications_for_service(
+            service_id),
     )
 
 
@@ -87,7 +89,8 @@ def create_api_key(service_id):
     disabled_options, option_hints = [], {}
     if current_service.trial_mode:
         disabled_options = [KEY_TYPE_NORMAL]
-        option_hints[KEY_TYPE_NORMAL] = Markup(_l("Not available because your service is in trial mode."))
+        option_hints[KEY_TYPE_NORMAL] = Markup(
+            _l("Not available because your service is in trial mode."))
     if current_service.has_permission("letter"):
         option_hints[KEY_TYPE_TEAM] = ""
     if form.validate_on_submit():
@@ -119,7 +122,8 @@ def revoke_api_key(service_id, key_id):
     if request.method == "GET":
         flash(
             [
-                "{} ‘{}’?".format(_l("Are you sure you want to revoke"), key_name),
+                "{} ‘{}’?".format(
+                    _l("Are you sure you want to revoke"), key_name),
                 _l("You will not be able to use this API key to connect to GC Notify"),
             ],
             "revoke this API key",
@@ -137,9 +141,11 @@ def get_apis():
     callback_api = None
     inbound_api = None
     if current_service.service_callback_api:
-        callback_api = service_api_client.get_service_callback_api(current_service.id, current_service.service_callback_api[0])
+        callback_api = service_api_client.get_service_callback_api(
+            current_service.id, current_service.service_callback_api[0])
     if current_service.inbound_api:
-        inbound_api = service_api_client.get_service_inbound_api(current_service.id, current_service.inbound_api[0])
+        inbound_api = service_api_client.get_service_inbound_api(
+            current_service.id, current_service.inbound_api[0])
 
     return (callback_api, inbound_api)
 
@@ -161,7 +167,8 @@ def api_callbacks(service_id):
 
     return render_template(
         "views/api/callbacks.html",
-        received_text_messages_callback=received_text_messages_callback["url"] if received_text_messages_callback else None,
+        received_text_messages_callback=received_text_messages_callback[
+            "url"] if received_text_messages_callback else None,
         delivery_status_callback=delivery_status_callback["url"] if delivery_status_callback else None,
     )
 
@@ -175,7 +182,8 @@ def get_delivery_status_callback_details():
 @user_has_permissions("manage_api_keys")
 def delete_delivery_status_callback(service_id):
     delivery_status_callback = get_delivery_status_callback_details()
-    back_link = ".api_callbacks" if current_service.has_permission("inbound_sms") else ".api_integration"
+    back_link = ".api_callbacks" if current_service.has_permission(
+        "inbound_sms") else ".api_integration"
     url_hint_txt = "Must start with https://"
 
     if request.method == "POST":
@@ -185,19 +193,23 @@ def delete_delivery_status_callback(service_id):
                 delivery_status_callback["id"],
             )
 
-            flash(_l("Your Callback configuration has been deleted."), "default_with_tick")
+            flash(_l("Your Callback configuration has been deleted."),
+                  "default_with_tick")
             return redirect(url_for(back_link, service_id=service_id))
 
-    flash(["{}".format(_l("Are you sure you want to delete this callback configuration?"))], "delete")
+    flash(["{}".format(
+        _l("Are you sure you want to delete this callback configuration?"))], "delete")
 
     form = ServiceDeliveryStatusCallbackForm(
-        url=delivery_status_callback.get("url") if delivery_status_callback else "",
+        url=delivery_status_callback.get(
+            "url") if delivery_status_callback else "",
         bearer_token=dummy_bearer_token if delivery_status_callback else "",
     )
 
     return render_template(
         "views/api/callbacks/delivery-status-callback.html",
-        back_link=".api_callbacks" if current_service.has_permission("inbound_sms") else ".delivery_status_callback",
+        back_link=".api_callbacks" if current_service.has_permission(
+            "inbound_sms") else ".delivery_status_callback",
         hint_text=url_hint_txt,
         is_deleting=True,
         form=form,
@@ -211,11 +223,13 @@ def delete_delivery_status_callback(service_id):
 @user_has_permissions("manage_api_keys")
 def delivery_status_callback(service_id):
     delivery_status_callback = get_delivery_status_callback_details()
-    back_link = ".api_callbacks" if current_service.has_permission("inbound_sms") else ".api_integration"
+    back_link = ".api_callbacks" if current_service.has_permission(
+        "inbound_sms") else ".api_integration"
     url_hint_txt = _l("Must start with https://")
 
     form = ServiceDeliveryStatusCallbackForm(
-        url=delivery_status_callback.get("url") if delivery_status_callback else "",
+        url=delivery_status_callback.get(
+            "url") if delivery_status_callback else "",
         bearer_token=dummy_bearer_token if delivery_status_callback else "",
     )
 
@@ -230,13 +244,22 @@ def delivery_status_callback(service_id):
                 service_api_client.update_service_callback_api(
                     service_id,
                     url=form.url.data,
-                    bearer_token=check_token_against_dummy_bearer(form.bearer_token.data),
+                    bearer_token=check_token_against_dummy_bearer(
+                        form.bearer_token.data),
                     user_id=current_user.id,
                     callback_api_id=delivery_status_callback.get("id"),
                 )
 
             # If the user is just testing their URL, don't send them back to the API Integration page
-            if request.form.get("button_pressed") == "test_response_time":
+            if request.form.get("button_pressed") == "test_response_time" and g.callback_response_time >= 1:
+                flash(
+                    _l("The service {} took longer than 1 second to respond.").format(
+                        url_hostname,
+                    ),
+                    "error",
+                )
+                return redirect(url_for("main.delivery_status_callback", service_id=service_id))
+            else:
                 flash(
                     _l("The service {} responded in {} seconds.").format(
                         url_hostname,
@@ -329,11 +352,13 @@ def get_received_text_messages_callback():
 def received_text_messages_callback(service_id):
     if not current_service.has_permission("inbound_sms"):
         return redirect(url_for(".api_integration", service_id=service_id))
-    back_link = ".api_callbacks" if current_service.has_permission("inbound_sms") else ".api_integration"
+    back_link = ".api_callbacks" if current_service.has_permission(
+        "inbound_sms") else ".api_integration"
 
     received_text_messages_callback = get_received_text_messages_callback()
     form = ServiceReceiveMessagesCallbackForm(
-        url=received_text_messages_callback.get("url") if received_text_messages_callback else "",
+        url=received_text_messages_callback.get(
+            "url") if received_text_messages_callback else "",
         bearer_token=dummy_bearer_token if received_text_messages_callback else "",
     )
     url_hint_txt = _l("Must start with https://")
@@ -348,19 +373,19 @@ def received_text_messages_callback(service_id):
                 service_api_client.update_service_inbound_api(
                     service_id,
                     url=form.url.data,
-                    bearer_token=check_token_against_dummy_bearer(form.bearer_token.data),
+                    bearer_token=check_token_against_dummy_bearer(
+                        form.bearer_token.data),
                     user_id=current_user.id,
                     inbound_api_id=received_text_messages_callback.get("id"),
                 )
 
                 # If the user is just testing their URL, don't send them back to the API Integration page
-                if request.form.get("button_pressed") == "test_response_time":
+                if request.form.get("button_pressed") == "test_response_time" and g.callback_response_time >= 1:
                     flash(
-                        _l("The service {} responded in {} seconds.").format(
+                        _l("The service {} took longer than 1 second to respond.").format(
                             url_hostname,
-                            response_time,
                         ),
-                        "default_with_tick",
+                        "error",
                     )
                     return redirect(url_for("main.received_text_messages_callback", service_id=service_id))
                 else:
@@ -371,7 +396,7 @@ def received_text_messages_callback(service_id):
                         ),
                         "default_with_tick",
                     )
-                    return redirect(url_for("main.delivery_status_callback", service_id=service_id))
+                    return redirect(url_for("main.received_text_messages_callback", service_id=service_id))
 
                 flash(
                     _l("We’ve saved your callback configuration. {} responded in {} seconds.").format(
@@ -420,7 +445,7 @@ def received_text_messages_callback(service_id):
                 ),
                 "default_with_tick",
             )
-            return redirect(url_for("main.delivery_status_callback", service_id=service_id))
+            return redirect(url_for("main.received_text_messages_callback", service_id=service_id))
 
         flash(
             _l("We’ve saved your callback configuration. {} responded in {} seconds.").format(
@@ -444,7 +469,8 @@ def received_text_messages_callback(service_id):
 @user_has_permissions("manage_api_keys")
 def delete_received_text_messages_callback(service_id):
     received_text_messages_callback = get_received_text_messages_callback()
-    back_link = ".api_callbacks" if current_service.has_permission("inbound_sms") else ".api_integration"
+    back_link = ".api_callbacks" if current_service.has_permission(
+        "inbound_sms") else ".api_integration"
     url_hint_txt = "Must start with https://"
 
     if request.method == "POST":
@@ -454,19 +480,23 @@ def delete_received_text_messages_callback(service_id):
                 received_text_messages_callback["id"],
             )
 
-            flash(_l("Your Callback configuration has been deleted."), "default_with_tick")
+            flash(_l("Your Callback configuration has been deleted."),
+                  "default_with_tick")
             return redirect(url_for(back_link, service_id=service_id))
 
-    flash(["{}".format(_l("Are you sure you want to delete this callback configuration?"))], "delete")
+    flash(["{}".format(
+        _l("Are you sure you want to delete this callback configuration?"))], "delete")
 
     form = ServiceReceiveMessagesCallbackForm(
-        url=received_text_messages_callback.get("url") if delivery_status_callback else "",
+        url=received_text_messages_callback.get(
+            "url") if delivery_status_callback else "",
         bearer_token=dummy_bearer_token if received_text_messages_callback else "",
     )
 
     return render_template(
         "views/api/callbacks/delivery-status-callback.html",
-        back_link=".api_callbacks" if current_service.has_permission("inbound_sms") else ".delivery_status_callback",
+        back_link=".api_callbacks" if current_service.has_permission(
+            "inbound_sms") else ".delivery_status_callback",
         hint_text=url_hint_txt,
         is_deleting=True,
         form=form,

--- a/app/templates/components/page-footer.html
+++ b/app/templates/components/page-footer.html
@@ -73,7 +73,7 @@
   button1_value="b1",
   button2_text=None,
   button2_value=None,
-  delete_link=False,
+  delete_link=None,
   delete_link_text=_("Delete")) %}
   <div class="js-stick-at-bottom-when-scrolling">
     <div class="page-footer">

--- a/app/templates/views/api/callbacks/delivery-status-callback.html
+++ b/app/templates/views/api/callbacks/delivery-status-callback.html
@@ -43,14 +43,14 @@
         {% set test_response_txt = _('Test response time')  if has_callback_config else None %}
         {% set test_response_value = _('test_response_time') if has_callback_config else None %}
         {% set display_footer = is_deleting if is_deleting else False %}
+        {% set delete_link = url_for('.delete_delivery_status_callback', service_id=current_service.id) if has_callback_config else None%}
         {% if not display_footer %}
           {{ sticky_page_footer_two_submit_buttons_and_delete_link(
             button1_text=_('Save'),
             button1_value=_('save'),
             button2_text=test_response_txt,
             button2_value=test_response_value,
-            delete_link=url_for('.delete_delivery_status_callback', service_id=current_service.id),
-            delete_link_text=_('Delete')
+            delete_link=delete_link,
           ) }}
         {% endif %}
       {% endcall %}

--- a/app/templates/views/api/callbacks/received-text-messages-callback.html
+++ b/app/templates/views/api/callbacks/received-text-messages-callback.html
@@ -38,14 +38,15 @@
         {% set test_response_txt = _('Test response time')  if has_callback_config else None %}
         {% set test_response_value = _('test_response_time') if has_callback_config else None %}
         {% set display_footer = is_deleting if is_deleting else False %}
+        {% set delete_link = url_for('.delete_received_text_messages_callback', service_id=current_service.id) if has_callback_config else None%}
+        {% set delete_link_text = _('Delete') if has_callback_config else None %}
         {% if not display_footer %}
           {{ sticky_page_footer_two_submit_buttons_and_delete_link(
             button1_text=_('Save'),
             button1_value=_('save'),
             button2_text=test_response_txt,
             button2_value=test_response_value,
-            delete_link=url_for('.delete_received_text_messages_callback', service_id=current_service.id),
-            delete_link_text=_('Delete')
+            delete_link=delete_link,
           ) }}
         {% endif %}
       {% endcall %}


### PR DESCRIPTION
# Summary | Résumé

This PR fixes a few bugs found during testing on staging for the callbacks changes:

- The delete button is not longer displayed when there isn't a callback configured
- Fixed an issue where the delete confirmation banner wasn't displaying in some circumstances
- Fixed a routing issue where deleting a received-text-messages callback was deleting the delivery status callback
- Fixed an issue where the Test callback button was not remaining on the same page after clicking

# Test instructions | Instructions pour tester la modification

