### PR TITLE
Remove "under development" banners from template category admin

### DIFF
--- a/app/templates/views/templates/template_categories.html
+++ b/app/templates/views/templates/template_categories.html
@@ -9,13 +9,6 @@
 
 {% block platform_admin_content %}
   <div class="p-gutterHalf">
-    {# TODO: remove when feature goes live #}
-    <div id="sticky-banner" tabindex="-1" class="flex justify-between w-full p-4 border-b border-gray-200 bg-red text-white rounded-lg">
-      <div class="flex items-center mx-auto">
-        <svg xmlns="http://www.w3.org/2000/svg"  style="width: 40px; fill: #860909;" class="mr-5"  viewBox="0 0 576 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M208 64a48 48 0 1 1 96 0 48 48 0 1 1 -96 0zM9.8 214.8c5.1-12.2 19.1-18 31.4-12.9L60.7 210l22.9-38.1C99.9 144.6 129.3 128 161 128c51.4 0 97 32.9 113.3 81.7l34.6 103.7 79.3 33.1 34.2-45.6c6.4-8.5 16.6-13.3 27.2-12.8s20.3 6.4 25.8 15.5l96 160c5.9 9.9 6.1 22.2 .4 32.2s-16.3 16.2-27.8 16.2H288c-11.1 0-21.4-5.7-27.2-15.2s-6.4-21.2-1.4-31.1l16-32c5.4-10.8 16.5-17.7 28.6-17.7h32l22.5-30L22.8 246.2c-12.2-5.1-18-19.1-12.9-31.4zm82.8 91.8l112 48c11.8 5 19.4 16.6 19.4 29.4v96c0 17.7-14.3 32-32 32s-32-14.3-32-32V405.1l-60.6-26-37 111c-5.6 16.8-23.7 25.8-40.5 20.2S-3.9 486.6 1.6 469.9l48-144 11-33 32 13.7z"/></svg>
-        <span>This page is under development and is not yet functional.</span>
-      </div>
-    </div>
     {{ page_header(_('Template categories'), id_text='template_cats') }}
     {{ live_search(target_selector='.table-row', show=True, form=search_form) }}
 

--- a/app/templates/views/templates/template_category.html
+++ b/app/templates/views/templates/template_category.html
@@ -11,14 +11,6 @@
 
 {% block platform_admin_content %}
   <div class="p-gutterHalf">
-    {# TODO: remove when feature goes live #}
-    <div id="sticky-banner" tabindex="-1" class="z-50 flex justify-between w-full p-4 border-b border-gray-200 bg-red text-white rounded-lg">
-      <div class="flex items-center mx-auto">
-        <svg xmlns="http://www.w3.org/2000/svg"  style="width: 40px; fill: #860909;" class="mr-5"  viewBox="0 0 576 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M208 64a48 48 0 1 1 96 0 48 48 0 1 1 -96 0zM9.8 214.8c5.1-12.2 19.1-18 31.4-12.9L60.7 210l22.9-38.1C99.9 144.6 129.3 128 161 128c51.4 0 97 32.9 113.3 81.7l34.6 103.7 79.3 33.1 34.2-45.6c6.4-8.5 16.6-13.3 27.2-12.8s20.3 6.4 25.8 15.5l96 160c5.9 9.9 6.1 22.2 .4 32.2s-16.3 16.2-27.8 16.2H288c-11.1 0-21.4-5.7-27.2-15.2s-6.4-21.2-1.4-31.1l16-32c5.4-10.8 16.5-17.7 28.6-17.7h32l22.5-30L22.8 246.2c-12.2-5.1-18-19.1-12.9-31.4zm82.8 91.8l112 48c11.8 5 19.4 16.6 19.4 29.4v96c0 17.7-14.3 32-32 32s-32-14.3-32-32V405.1l-60.6-26-37 111c-5.6 16.8-23.7 25.8-40.5 20.2S-3.9 486.6 1.6 469.9l48-144 11-33 32 13.7z"/></svg>
-        <span>This page is under development and is not yet functional.</span>
-      </div>
-    </div>
-
     {{ page_header(_('Update category') if template_category else _('Create category'), id_text='template_cats') }}
     {% call form_wrapper() %}
       <div class="form-group contain-floats box-border mb-gutterHalf md:mb-gutter">


### PR DESCRIPTION
# Summary | Résumé
This PR removes the "under development" banners from the template category admin pages.

# Test instructions | Instructions pour tester la modification
Banner is removed from:
- [x] `/template-categories`
- [x] `/template-category/{category-id}` 
- [x] `/template-category/add`
