### PR TITLE
Fix footer TOU link localization

### DIFF
--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -225,6 +225,7 @@
 "Support","Soutien"
 "Terms of Use","Conditions d’utilisation"
 "Terms of use:","Conditions d’utilisation :"
+"Terms of use","Conditions d’utilisation"
 "terms of Use","conditions d’utilisation"
 "Message delivery status","État de livraison des messages"
 "Privacy","Confidentialité"


### PR DESCRIPTION
# Summary | Résumé
This PR fixes a localization issue where the TOU link in the footer was not properly translated when switching to the French language.

# Test instructions | Instructions pour tester la modification
1. Open the review app
2. Switch to French
3. Check the footer to ensure that the TOU link is `Conditions d’utilisation`