### PR TITLE
Exclude autopep8 extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,23 +10,35 @@
 	"containerEnv": {
 		"SHELL": "/bin/zsh"
 	},
-	"settings": {
-		"python.pythonPath": "/usr/local/bin/python",
+	"customizations":{
+		"vscode": {
+			"extensions": [
+				"njpwerner.autodocstring",
+				"github.copilot",
+				"GitHub.copilot-labs",
+				"donjayamanne.python-extension-pack",
+				"-ms-python.autopep8",
+				"ms-python.vscode-pylance",
+				"eamodio.gitlens",
+				"wholroyd.jinja",
+				"visualstudioexptteam.vscodeintellicode",
+				"yzhang.markdown-all-in-one",
+				"ms-ossdata.vscode-postgresql",
+				"tamasfe.even-better-toml",
+				"charliermarsh.ruff",
+			],
+			"settings": {
+				"ruff.lint.run": "onSave",
+				"ruff.configurationPreference": "filesystemFirst",
+				"editor.defaultFormatter": "charliermarsh.ruff",
+				"editor.formatOnSave": true,
+				"editor.codeActionsOnSave": {
+					"source.fixAll": "explicit"
+				}
+			}
+		}
 	},
-	"extensions": [
-		"njpwerner.autodocstring",
-		"github.copilot",
-		"GitHub.copilot-labs",
-		"donjayamanne.python-extension-pack",
-		"ms-python.vscode-pylance",
-		"eamodio.gitlens",
-		"wholroyd.jinja",
-		"visualstudioexptteam.vscodeintellicode",
-		"yzhang.markdown-all-in-one",
-		"ms-ossdata.vscode-postgresql",
-		"tamasfe.even-better-toml",
-		"charliermarsh.ruff",
-	],
+
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "16.20.0"


### PR DESCRIPTION
# Summary | Résumé
This PR excludes the [autopep8](https://marketplace.visualstudio.com/items?itemName=ms-python.autopep8) from being installed in the dev container. It was directly conflicting with line ending lengths defined in Ruff, resulting in messes [like this one](https://github.com/cds-snc/notification-admin/pull/1976/commits/49c25b87ff16655a47152e6d56ad3e838bb3f03a) if the `formatOnSave` setting is enabled in vscode.

Additionally it proposes adding explicit formatter configurations for vscode with the aim to ensures that formatting remains consistent regardless of a developers preferred formatter workflow, be it `pre-commit hooks`, `make format`, or `onSave` formatting.
- Make vscode use the Ruff extension as the formatting provider. 
- Automatically configure the Ruff extension based on our formatter configs found in `pyproject.toml`
- Run the Ruff linter on save, fixing simple issues: e.g. import ordering, line breaks at end of file / between methods etc.
- Formatting on save disabled by default, but if enabled preferentially then all the plumbing is in place to keep formatting unified

# Test instructions | Instructions pour tester la modification
1. Before pulling this PR, enable the following vscode setting: `editor.formatOnSave: true`
2. Open `test_service_settings.py` and make a small change, then save the file
3. Note that it unnecessarily breaks many lines into multi-line statements
4. Undo the changes
5. Pull down this PR
6. Rebuild your dev container
7. Make changes to `test_service_settings.py` again and save
8. Note that the file doesn't get butchered.