### PR TITLE
Clear cache when annual limit is updated

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -272,6 +272,7 @@ class Production(Config):
     NOTIFY_LOG_LEVEL = "INFO"
     SYSTEM_STATUS_URL = "https://status.notification.canada.ca"
     NO_BRANDING_ID = "760c802a-7762-4f71-b19e-f93c66c92f1a"
+    FF_ANNUAL_LIMIT = False
 
 
 class Staging(Production):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -163,6 +163,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         )
 
     @requires_feature("FF_ANNUAL_LIMIT")  # TODO: FF_ANNUAL_LIMIT removal
+    @cache.delete("service-{service_id}")
     def update_sms_annual_limit(self, service_id, sms_annual_limit):
         return self.update_service(
             service_id,
@@ -170,6 +171,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         )
 
     @requires_feature("FF_ANNUAL_LIMIT")  # TODO: FF_ANNUAL_LIMIT removal
+    @cache.delete("service-{service_id}")
     def update_email_annual_limit(self, service_id, email_annual_limit):
         return self.update_service(
             service_id,

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -99,7 +99,7 @@
   </td>
 {%- endmacro %}
 
-{% macro text_field(text, status='', truncate=false, date_format=None, cell_width=None) -%}
+{% macro text_field(text, status='', truncate=false, date_format=None, cell_width=None, attributes=None) -%}
   {% call field(status=status, cell_width=cell_width) %}
     {% if text is iterable and text is not string %}
       <ul>
@@ -112,15 +112,15 @@
     {% else %}
       {% if truncate %}
         {% if date_format %}
-          <time class="truncate-text {{date_format if date_format}}">{{text}}</time>
+          <time class="truncate-text {{date_format if date_format}}" {% if attributes %} {{ attributes }} {% endif %}>{{text}}</time>
         {% else %}
-          <div class="truncate-text {{date_format if date_format}}">{{text}}</div>
+          <div class="truncate-text {{date_format if date_format}}" {% if attributes %} {{ attributes }} {% endif %}>{{text}}</div>
         {% endif %}
       {% else %}
         {% if date_format %}
-          <time class="do-not-truncate-text {{date_format}}">{{text}}</time>
+          <time class="do-not-truncate-text {{date_format}}" {% if attributes %} {{ attributes }} {% endif %}>{{text}}</time>
         {% else %}
-          <div class="do-not-truncate-text">{{text}}</div>
+          <div class="do-not-truncate-text" {% if attributes %} {{ attributes }} {% endif %}>{{text}}</div>
         {% endif %}
       {% endif %}
     {% endif %}

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -194,11 +194,11 @@
           {{ text_field(txt) }}
           {# TODO: FF_ANNUAL_LIMIT removal #}
           {% if config["FF_ANNUAL_LIMIT"]  %}
-            {% set annual_limit = _('{} million emails').format((current_service.email_annual_limit//1000000) | format_number) %}
+            {% set annual_limit = _('{} emails').format((current_service.email_annual_limit) | format_number) %}
           {% else %}
             {% set annual_limit = _('{} million emails').format((limits.free_yearly_email//1000000) | format_number) %}
           {% endif%}
-          {{ text_field(annual_limit) }}
+          {{ text_field(annual_limit, attributes="data-testid=email-annual-limit") }}
           {{ text_field('')}}
         {% endcall %}
 
@@ -277,7 +277,7 @@
           {% else %}
             {% set annual_sms_limit = _('{} text messages').format((limits.free_yearly_sms) | format_number) %}
           {% endif%}
-          {{ text_field(annual_sms_limit) }}
+          {{ text_field(annual_sms_limit, attributes="data-testid=sms-annual-limit") }}
           {{ text_field('')}}
         {% endcall %}
 
@@ -392,6 +392,7 @@
             {{ edit_field(
               change_txt,
               url_for('.set_email_annual_limit', service_id=current_service.id),
+              attributes="data-testid=edit-email-annual-limit",
               for=txt
             ) }}
           {% endcall %}
@@ -403,6 +404,7 @@
             {{ edit_field(
               change_txt,
               url_for('.set_sms_annual_limit', service_id=current_service.id),
+              attributes="data-testid=edit-sms-annual-limit",
               for=txt
             ) }}
           {% endcall %}

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -71,7 +71,7 @@ def mock_get_service_settings_page_common(
                 "Email branding English Government of Canada signature Change",
                 "Send files by email Off (API-only) Change",
                 "Daily maximum 1,000 emails",
-                "Annual maximum(April 1 to March 31) 10 million emails",
+                "Annual maximum(April 1 to March 31) 10,000,000 emails",
                 "Label Value Action",
                 "Send text messages On Change",
                 "Start text messages with service name On Change",
@@ -95,7 +95,7 @@ def mock_get_service_settings_page_common(
                 "Email branding English Government of Canada signature Change",
                 "Send files by email Off (API-only) Change",
                 "Daily maximum 1,000 emails",
-                "Annual maximum(April 1 to March 31) 10 million emails",
+                "Annual maximum(April 1 to March 31) 10,000,000 emails",
                 "Label Value Action",
                 "Send text messages On Change",
                 "Start text messages with service name On Change",
@@ -233,7 +233,7 @@ def test_organisation_name_links_to_org_dashboard(
                 "Email branding Your branding (Organisation name) Change",
                 "Send files by email Off (API-only) Change",
                 "Daily maximum 1,000 emails",
-                "Annual maximum(April 1 to March 31) 10 million emails",
+                "Annual maximum(April 1 to March 31) 10,000,000 emails",
                 "Label Value Action",
                 "Send text messages On Change",
                 "Start text messages with service name On Change",
@@ -255,7 +255,7 @@ def test_organisation_name_links_to_org_dashboard(
                 "Email branding Your branding (Organisation name) Change",
                 "Send files by email Off (API-only) Change",
                 "Daily maximum 1,000 emails",
-                "Annual maximum(April 1 to March 31) 10 million emails",
+                "Annual maximum(April 1 to March 31) 10,000,000 emails",
                 "Label Value Action",
                 "Send text messages On Change",
                 "Start text messages with service name On Change",
@@ -281,20 +281,22 @@ def test_should_show_overview_for_service_with_more_things_set_inc_sms_daily_lim
     expected_rows,
     app_,
 ):
-    client.login(active_user_with_permissions, mocker, service_one)
-    service_one["permissions"] = permissions
-    service_one["email_branding"] = uuid4()
-    response = client.get(url_for("main.service_settings", service_id=service_one["id"]))
-    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-    rows = page.find_all("tr")
-    for index, row in enumerate(expected_rows):
-        formatted_row = row.format(sending_domain=os.environ.get("SENDING_DOMAIN", "notification.alpha.canada.ca"))
-        visible = rows[index + 1]
-        sr_only = visible.find("span", "sr-only")
-        if sr_only:
-            sr_only.extract()
-            assert " ".join(visible.text.split()).startswith(" ".join(sr_only.text.split()))
-        assert formatted_row == " ".join(visible.text.split())
+    # TODO FF_ANNUAL_LIMIT removal
+    with set_config(app_, "FF_ANNUAL_LIMIT", True):
+        client.login(active_user_with_permissions, mocker, service_one)
+        service_one["permissions"] = permissions
+        service_one["email_branding"] = uuid4()
+        response = client.get(url_for("main.service_settings", service_id=service_one["id"]))
+        page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+        rows = page.find_all("tr")
+        for index, row in enumerate(expected_rows):
+            formatted_row = row.format(sending_domain=os.environ.get("SENDING_DOMAIN", "notification.alpha.canada.ca"))
+            visible = rows[index + 1]
+            sr_only = visible.find("span", "sr-only")
+            if sr_only:
+                sr_only.extract()
+                assert " ".join(visible.text.split()).startswith(" ".join(sr_only.text.split()))
+            assert formatted_row == " ".join(visible.text.split())
 
 
 def test_if_cant_send_letters_then_cant_see_letter_contact_block(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3093,7 +3093,7 @@ def test_should_set_sms_message_limit(
 def test_should_set_email_annual_limit(platform_admin_client, limit, expected_limit, mock_update_email_annual_limit, app_):
     with set_config(app_, "FF_ANNUAL_LIMIT", True):
         response = platform_admin_client.post(
-            url_for("main.set_email_annual_limit",service_id=SERVICE_ONE_ID),
+            url_for("main.set_email_annual_limit", service_id=SERVICE_ONE_ID),
             data={"message_limit": limit},
         )
 

--- a/tests_cypress/cypress/Notify/Admin/Pages/ServiceSettingsPage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/ServiceSettingsPage.js
@@ -3,17 +3,46 @@ let Components = {
     // Service
 
     // Emails
-    EditEmailBrandingLink: () => cy.getByTestId("edit-email-branding")
+    EditEmailBrandingLink: () => cy.getByTestId("edit-email-branding"),
+    EmailAnnualLimit: () => cy.getByTestId("email-annual-limit"),
 
     // Text messages
+    SmsAnnualLimit: () => cy.getByTestId("sms-annual-limit"),
 
     // Platform admin settings
+    EditSmsAnnualLimitLink: () => cy.getByTestId("edit-sms-annual-limit"),
+    EditEmailAnnualLimitLink: () => cy.getByTestId("edit-email-annual-limit"),
+    MessageLimitTextBox: () => cy.get("#message_limit"),
+    SubmitButton: () => cy.get("button[type='submit']"),
+
+    // Common
+    MessageBanner: () => cy.get("div[role='status']"),
 };
 
 let Actions = {
+    // Emails
     ClickChangeEmailBrandingLink: () => {
         Components.EditEmailBrandingLink().click();
-    }
+    },
+    ClickChangeEmailAnnualLimitLink: () => {
+        Components.EditEmailAnnualLimitLink().click();
+    },
+
+    // Text messages
+
+    // Platform admin
+    ClickChangeEmailAnnualLimitLink: () => {
+        Components.EditEmailAnnualLimitLink().click();
+    },
+    ClickChangeSmsAnnualLimitLink: () => {
+        Components.EditSmsAnnualLimitLink().click();
+    },
+    SetMessageLimit: (limit) => {
+        Components.MessageLimitTextBox().clear().type(limit);
+    },
+    Submit: () => {
+        return Components.SubmitButton().click();
+    },
 };
 
 let ServiceSettingsPage = {

--- a/tests_cypress/cypress/Notify/Admin/Pages/ServiceSettingsPage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/ServiceSettingsPage.js
@@ -24,9 +24,6 @@ let Actions = {
     ClickChangeEmailBrandingLink: () => {
         Components.EditEmailBrandingLink().click();
     },
-    ClickChangeEmailAnnualLimitLink: () => {
-        Components.EditEmailAnnualLimitLink().click();
-    },
 
     // Text messages
 

--- a/tests_cypress/cypress/e2e/admin/service-settings.cy.js
+++ b/tests_cypress/cypress/e2e/admin/service-settings.cy.js
@@ -2,7 +2,6 @@
 
 import config from "../../../config";
 import { ServiceSettingsPage } from "../../Notify/Admin/Pages/all";
-import ADMIN_COOKIE from "../../Notify/Admin/Pages/LoginPage";
 
 describe("Service Settings", () => {
   beforeEach(() => {

--- a/tests_cypress/cypress/e2e/admin/service-settings.cy.js
+++ b/tests_cypress/cypress/e2e/admin/service-settings.cy.js
@@ -2,16 +2,15 @@
 
 import config from "../../../config";
 import { ServiceSettingsPage } from "../../Notify/Admin/Pages/all";
+import ADMIN_COOKIE from "../../Notify/Admin/Pages/LoginPage";
 
 describe("Service Settings", () => {
-  // Login to notify before the test suite starts
-  before(() => {
-    cy.login(Cypress.env("NOTIFY_USER"), Cypress.env("NOTIFY_PASSWORD"));
-  });
-
   beforeEach(() => {
     // stop the recurring dashboard fetch requests
     cy.intercept("GET", "**/dashboard.json", {});
+
+    cy.login(Cypress.env("NOTIFY_USER"), Cypress.env("NOTIFY_PASSWORD"));
+
     cy.visit(
       config.Hostnames.Admin +
         `/services/${config.Services.Cypress}/service-settings`,
@@ -25,5 +24,43 @@ describe("Service Settings", () => {
   it("Loads branding settings page", () => {
     ServiceSettingsPage.ClickChangeEmailBrandingLink();
     cy.get("h1").contains("Email logo").should("be.visible");
+  });
+});
+
+describe("Platform Admin Service Settings", () => {
+  beforeEach(() => {
+    // stop the recurring dashboard fetch requests
+    cy.intercept("GET", "**/dashboard.json", {});
+    cy.login(Cypress.env("NOTIFY_ADMIN_USER"), Cypress.env("NOTIFY_PASSWORD"));
+    cy.visit(
+      config.Hostnames.Admin +
+        `/services/${config.Services.Cypress}/service-settings`,
+    );
+  });
+
+  it("Saves and displays new email annual limit", () => {
+    ServiceSettingsPage.ClickChangeEmailAnnualLimitLink();
+    cy.get("h1").contains("Annual email message limit").should("be.visible");
+    ServiceSettingsPage.SetMessageLimit(250000);
+    ServiceSettingsPage.Submit();
+    ServiceSettingsPage.Components.EmailAnnualLimit().contains(
+      "250,000 emails",
+    );
+    ServiceSettingsPage.Components.MessageBanner().contains(
+      "An email has been sent to service users",
+    );
+  });
+
+  it("Saves and displays new sms annual limit", () => {
+    ServiceSettingsPage.ClickChangeSmsAnnualLimitLink();
+    cy.get("h1").contains("Annual text message limit").should("be.visible");
+    ServiceSettingsPage.SetMessageLimit(10000);
+    ServiceSettingsPage.Submit();
+    ServiceSettingsPage.Components.SmsAnnualLimit().contains(
+      "10,000 text messages",
+    );
+    ServiceSettingsPage.Components.MessageBanner().contains(
+      "An email has been sent to service users",
+    );
   });
 });


### PR DESCRIPTION
# Summary | Résumé

Squashes a bug where cache was not deleted when updating a service's annual limit causing the service settings page to incorrectly display their annual limit.

Added Cypress tests for annual limits on the `service-settings` page.

# Test instructions | Instructions pour tester la modification
1. Navigate to service settings
2. Note the defaults of 10mil Emails and 25k SMS are displayed
3. Update either annual limit
4. Note that the new annual limit is properly displayed.