### PR TITLE
Make test less flaky by asserting the language has changed

### DIFF
--- a/tests_cypress/cypress/e2e/admin/components/remaining_messages_summary.cy.js
+++ b/tests_cypress/cypress/e2e/admin/components/remaining_messages_summary.cy.js
@@ -64,6 +64,7 @@ describe("Remaining Messages Summary Component", () => {
 
     it("shows thousands separator in FR for today’s remaining", () => {
       cy.get("#header-lang").click();
+      cy.get("html").should("have.attr", "lang", "fr");
       cy.visit(PageURL);
       RMS.Below()
         .find('*[data-testid="rms"]')
@@ -82,6 +83,7 @@ describe("Remaining Messages Summary Component", () => {
 
     it("shows thousands separator in FR for the year’s remaining", () => {
       cy.get("#header-lang").click();
+      cy.get("html").should("have.attr", "lang", "fr");
       cy.visit(PageURL);
       RMS.Below()
         .find('*[data-testid="rms"]')


### PR DESCRIPTION
# Summary | Résumé

Updates the remaining-messages-summary component tests to make sure the language has finished changing before asserting the format is correct.

# Test instructions | Instructions pour tester la modification
- [x] Cypress tests pass on this branch
