### PR TITLE
Allowing manual runs on cypress tests

### DIFF
--- a/.github/workflows/cypress-staging.yaml
+++ b/.github/workflows/cypress-staging.yaml
@@ -3,6 +3,7 @@ name: Cypress staging a11y tests
 on:
   schedule:
     - cron: 0 */3 * * *
+  workflow_dispatch:
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
# Summary | Résumé

Allowing manual runs for cypress a11y tests

# Test instructions | Instructions pour tester la modification

RUN THE TEST