### PR TITLE
When the FF is off, the call to the API isn't made. Removed the FF

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -16,7 +16,6 @@ from flask_babel import _
 from flask_babel import lazy_gettext as _l
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
-from notifications_utils.decorators import requires_feature
 
 from app import (
     billing_api_client,
@@ -1131,7 +1130,6 @@ def set_sms_message_limit(service_id):
 
 @main.route("/service/<service_id>/service_settings/set-sms-annual-limit", methods=["GET", "POST"])
 @user_is_platform_admin
-@requires_feature("FF_ANNUAL_LIMIT")  # TODO: FF_ANNUAL_LIMIT removal
 def set_sms_annual_limit(service_id):
     form = SMSAnnualMessageLimit(message_limit=current_service.sms_annual_limit)
 
@@ -1150,7 +1148,6 @@ def set_sms_annual_limit(service_id):
 
 @main.route("/service/<service_id>/service_settings/set-email-annual.html", methods=["GET", "POST"])
 @user_is_platform_admin
-@requires_feature("FF_ANNUAL_LIMIT")  # TODO: FF_ANNUAL_LIMIT removal
 def set_email_annual_limit(service_id):
     form = EmailAnnualMessageLimit(message_limit=current_service.email_annual_limit)
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -348,7 +348,13 @@ def test_monthly_shows_letters_in_breakdown(
 )
 @freeze_time("2015-01-01 15:15:15.000000")
 def test_stats_pages_show_last_3_years(
-    client_request, endpoint, service_one, mocker, mock_get_monthly_notification_stats, mock_get_monthly_template_usage, mock_get_service_statistics
+    client_request,
+    endpoint,
+    service_one,
+    mocker,
+    mock_get_monthly_notification_stats,
+    mock_get_monthly_template_usage,
+    mock_get_service_statistics,
 ):
     mocker.patch("app.main.views.dashboard.annual_limit_client.get_all_notification_counts", return_value={"data": service_one})
     page = client_request.get(


### PR DESCRIPTION
# Summary | Résumé
Removed the FF requirement to update the annual SMS and email limits. 