### PR TITLE
Remove FF for updating annual limits

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta, timezone
 
 from flask import current_app
 from flask_login import current_user
-from notifications_utils.decorators import requires_feature
 
 from app.extensions import redis_client
 from app.notify_client import NotifyAdminAPIClient, _attach_current_user, cache
@@ -168,7 +167,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             sms_daily_limit=sms_daily_limit,
         )
 
-    @requires_feature("FF_ANNUAL_LIMIT")  # TODO: FF_ANNUAL_LIMIT removal
     @cache.delete("service-{service_id}")
     def update_sms_annual_limit(self, service_id, sms_annual_limit):
         return self.update_service(
@@ -176,7 +174,6 @@ class ServiceAPIClient(NotifyAdminAPIClient):
             sms_annual_limit=sms_annual_limit,
         )
 
-    @requires_feature("FF_ANNUAL_LIMIT")  # TODO: FF_ANNUAL_LIMIT removal
     @cache.delete("service-{service_id}")
     def update_email_annual_limit(self, service_id, email_annual_limit):
         return self.update_service(


### PR DESCRIPTION
# Summary | Résumé

There is a FF on the function that calls the API to update the annual limits. I removed that.