### PR TITLE
fix(dashboard): update check to see if redis has today's data

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -282,7 +282,7 @@ def monthly(service_id):
         todays_data = annual_limit_client.get_all_notification_counts(current_service.id)
 
         # if redis is empty, query the db
-        if todays_data is None:
+        if all(value == 0 for value in todays_data.values()):
             todays_data = service_api_client.get_service_statistics(service_id, limit_days=1, today_only=False)
             annual_data_aggregate = combine_daily_to_annual(todays_data, annual_data, "db")
 

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1582,7 +1582,7 @@ class TestAnnualLimits:
             # mock annual_limit_client.get_all_notification_counts
             mocker.patch(
                 "app.main.views.dashboard.annual_limit_client.get_all_notification_counts",
-                return_value=None,
+                return_value={"sms_delivered": 0, "email_delivered": 0, "sms_failed": 0, "email_failed": 0},
             )
 
             mocker.patch(


### PR DESCRIPTION
# Summary | Résumé

Fix for checking if the annual_limits redis client has data for today.

