### PR TITLE
Fix/handle api exception bulk send

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -892,7 +892,10 @@ def start_job(service_id, upload_id):
         job_api_client.create_job(upload_id, service_id, scheduled_for=request.form.get("scheduled_for", ""))
     except HTTPError as exception:
         return render_template(
-            "views/notifications/check.html", **(get_template_error_dict(exception) if exception else {}), template=None
+            "views/notifications/check.html",
+            time_to_reset=get_limit_reset_time_et(),
+            **(get_template_error_dict(exception) if exception else {}),
+            template=None,
         )
     session.pop("sender_id", None)
 

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -88,7 +88,9 @@
     ) }}
   {% endif %}
 
-  {{ template|string|translate_preview_template }}
+  {% if template %}
+    {{ template|string|translate_preview_template }}
+  {% endif %}
 
   <div class="js-stick-at-bottom-when-scrolling">
     <form method="post" enctype="multipart/form-data" action="{{url_for(


### PR DESCRIPTION
# Summary | Résumé

This PR updates bulk sending to ensure daily/annual limit exceptions are handled if API throws them.

# Test instructions | Instructions pour tester la modification
- [ ] Scenarios identified in bug bash are now working
