### PR TITLE
Add error message when notification size > 256KB

### DIFF
--- a/app/templates/partials/check/message-too-large.html
+++ b/app/templates/partials/check/message-too-large.html
@@ -1,0 +1,15 @@
+{% from "components/banner.html" import banner_wrapper %}
+
+<div class="mb-12 clear-both contain-floats">
+  {% call banner_wrapper(type='dangerous') %}
+    <h1 class='banner-title'>
+      {{ _('Your message exceeds the size limit of 256KB') }}
+    </h1>
+    <p>
+        {{ _("{} holds the most content. You may be able to send your message if you reduce or remove that content.")
+            .format(
+            largest_element
+        ) }}
+    </p>
+  {% endcall %}
+</div>

--- a/app/templates/views/notifications/check.html
+++ b/app/templates/views/notifications/check.html
@@ -81,6 +81,11 @@
         {% include "partials/check/message-too-long.html" %}
       {% endcall %}
     </div>
+  {% elif error == 'message-too-large' %}
+    {{ govuk_back_link(back_link) }}
+    <div class="mb-12 clear-both contain-floats">
+      {% include "partials/check/message-too-large.html" %}
+    </div>
   {% else %}
     {{ page_header(
       _('Review before sending'),

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2032,3 +2032,5 @@
 "Sending paused until 7pm ET. You can schedule more messages to send later.","FR: Sending paused until 7pm ET. You can schedule more messages to send later."
 "Sending paused until annual limit resets","FR: Sending paused until annual limit resets"
 "These messages exceed the annual limit","FR: These messages exceed the annual limit"
+"Your message exceeds the size limit of 256KB","FR: Your messages exceeds the size limit of 256KB"
+"{} holds the most content. You may be able to send your message if you reduce or remove that content.","FR: {} holds the most content. You may be able to send your message if you reduce or remove that content."


### PR DESCRIPTION
# Summary | Résumé
This PR adds a front end error message, with guidance, when attempting to send a one off notification that exceeds the SQS size limit of 256KB. 

![image](https://github.com/user-attachments/assets/294645f5-6f6e-44fb-bc2b-edb17c1922c1)


# Related work
* https://github.com/cds-snc/notification-api/pull/2085

# Test instructions | Instructions pour tester la modification
Pull and run the above API PR when testing locally. From the UI there are only a couple scenarios where a notification can reach the 256KB limit by using variables in one-offs. This is because:
-  The email content and subject fields have character limit validation. 
- Files can only be attached when using the API. 
- Our `RecipientCSV` class has built in validation on column values and overall content length that prevent users from reaching the 256KB limit when performing bulk sends.

### Test 1
1. Create an email template using [template_content.txt](https://github.com/user-attachments/files/18292997/template_content.txt)
2. Send using that template with this content for the variable [var1_content.txt](https://github.com/user-attachments/files/18293005/var1_content.txt)
3. Note the error message that guides you to the largest variable in your message

### Test 2
1. Edit your template, adding two more variables
2. Chunk the above `var1_content.txt` into 3 and insert them into the newly added variables, keeping track of which variable holds the largest chunk
3. Attempt the send again and note that the largest variable is specified in the error message

