### PR TITLE
Add a hint only for admins when navigating outside of their teams.

### DIFF
--- a/app/templates/views/templates/_template.html
+++ b/app/templates/views/templates/_template.html
@@ -27,6 +27,10 @@
           <a href="{{ url_for('.send_test', service_id=current_service.id, template_id=template.id) }}" class="button button-secondary">{{ _('No, send yourself this message') }}</a>
         </div>
       {% endif %}
+    {% elif current_user.platform_admin %}
+    <p class="hint">
+      {{ _("You cannot send messages from this service. Only team members can send messages.") }}
+    </p>
     {% endif %}
   {% endif %}
 </div>

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2032,3 +2032,4 @@
 "Sending paused until 7pm ET. You can schedule more messages to send later.","FR: Sending paused until 7pm ET. You can schedule more messages to send later."
 "Sending paused until annual limit resets","FR: Sending paused until annual limit resets"
 "These messages exceed the annual limit","FR: These messages exceed the annual limit"
+"You cannot send messages from this service. Only team members can send messages.","Vous ne pouvez pas envoyer de messages à partir de ce service. Seuls les membres de l’équipe peuvent envoyer des messages."


### PR DESCRIPTION
# Summary | Résumé


admins can't send messages from client services. 

Sometimes we can wonder why the send buttons are not displaying when investigating issues. This PR adds a bit of a hint to let us know that we can't send messages from some services. (When we are not part of their team)

# Test instructions | Instructions pour tester la modification

1. With an admin account, navigate to a template in a service where you are not part of the team. You should see the hint
2. With an admin account, navigate to a template in one of your services/teams. You should NOT see the hint
3. With a regular account, navigate to a template in any of your services. You should NOT see the hint. 
