### PR TITLE
Fixed the send to get data for notification_count_for_the_year

### DIFF
--- a/app/notify_client/notification_counts_client.py
+++ b/app/notify_client/notification_counts_client.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from notifications_utils.clients.redis import (
     email_daily_count_cache_key,
     sms_daily_count_cache_key,
@@ -7,6 +5,7 @@ from notifications_utils.clients.redis import (
 
 from app import redis_client, service_api_client, template_statistics_client
 from app.models.service import Service
+from app.utils import get_current_financial_year
 
 
 class NotificationCounts:
@@ -83,8 +82,10 @@ class NotificationCounts:
                 }
         """
 
+        current_financial_year = get_current_financial_year()
         sent_today = self.get_all_notification_counts_for_today(service.id)
-        sent_thisyear = self.get_all_notification_counts_for_year(service.id, datetime.now().year)
+        # We are interested in getting data for the financial year, not the calendar year
+        sent_thisyear = self.get_all_notification_counts_for_year(service.id, current_financial_year)
 
         limit_stats = {
             "email": {

--- a/tests/app/notify_client/test_notification_counts_client.py
+++ b/tests/app/notify_client/test_notification_counts_client.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/app/notify_client/test_notification_counts_client.py
+++ b/tests/app/notify_client/test_notification_counts_client.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from app.notify_client.notification_counts_client import NotificationCounts
+from app.utils import get_current_financial_year
 
 
 @pytest.fixture
@@ -199,4 +200,7 @@ class TestNotificationCounts:
 
         # Assert dependencies called
         mock_today.assert_called_once_with(mock_service.id)
-        mock_year.assert_called_once_with(mock_service.id, datetime.now().year)
+        mock_year.assert_called_once_with(
+            mock_service.id,
+            get_current_financial_year(),
+        )


### PR DESCRIPTION
# Summary | Résumé

When we get the monthly notification count, we need the count for this current fiscal year. 
The code was previously sending "2025" as the year to get the monthly data information, instead 
in the time period april 2024 - march 2025, we need to call the monthly_stats function with "2024".

# Testing:
I tested this locally, and I am sending the correct data.

# Release plan
Release this to production, and then manually test the change to see if templates can be fetched.