### PR TITLE
Add hints to setup utils locally. 

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       # Update this to wherever you want VS Code to mount the folder of your project
       - ..:/workspace:cached
 
+      # Uncomment the next volume to load a local version of notification-utils in this workspace. Also check pyproject.toml
+      # - ../../notification-utils:/workspace/notifier-utils:cached
+
       # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
       # - /var/run/docker.sock:/var/run/docker.sock 
 

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,7 @@ node_modules/
 tests_cypress/cypress/videos/
 tests_cypress/cypress/screenshots/
 .ruff_cache/
+
+# Local notification-utils package
+notifier-utils/
+notification-utils/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,10 @@ unidecode = "^1.3.8"
 
 # PaaS
 awscli-cwlogs = "^1.4.6"
+# Choose whether utils comes from git or local. Also check docker-compose.yml
+# notifications-utils = { path = "/workspace/notifier-utils" }
 notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "53.0.1"}
+
 
 
 # Pinned dependencies


### PR DESCRIPTION
# Summary | Résumé

I needed a way to change utils and run some tests in admin locally. I wish I had some hints to link things up with our container. 

This PR adds comments in docker-compose.yml and pyproject.toml to hint at what needs to be done to 
1. import utils as a volume
2. use utils from a path instead of a git

I also add the folders `notifier-utils` and `notification-utils` to gitignore so that they don't get committed by accident. (I kept `notifier-utils` as it seems like an alias to `notification-utils` in git and I didn't want it to seem weird in pyproject)

# Test instructions | Instructions pour tester la modification


