### PR TITLE
Update json format used in slack web hook call

### DIFF
--- a/.github/workflows/cypress-staging.yaml
+++ b/.github/workflows/cypress-staging.yaml
@@ -38,5 +38,5 @@ jobs:
       - name: Notify Slack channel if this job failed
         if: ${{ failure() }}
         run: |
-          json="{'text':'<!here> Staging a11y tests failed: <https://github.com/cds-snc/notification-admin/actions/runs/${GITHUB_RUN_ID}|see failure details> !'}"
+          json='{"text":"<!here> Staging a11y tests failed: <https://github.com/cds-snc/notification-admin/actions/runs/${GITHUB_RUN_ID}|see failure details> !"}'
           curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
# Summary | Résumé
This PR updates the json payload used in the slack webhook call as it is all of the sudden failing.

# Test instructions | Instructions pour tester la modification
- [ ] Run the cypress staging job, when it fails, de channel should be notified
> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
