### PR TITLE
Add guidance around joining a service

### DIFF
--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -121,4 +121,17 @@
     </div>
   {% endif %}
 
+  <div class="grid-row contain-floats py-10 px-6">
+    <p data-testid="guidance-join-existing-service">{{ _("To join an existing service, check your email for an invitation from the team for that service.  GC Notify staff cannot send these invitations.") }}</p>
+    <details data-testid="details-join-existing-service">
+      <summary class="flex gap-10 py-2">{{ _("If you do not have an invitation") }}</summary>
+      <div class="details-body">
+        <p>{{ _('Ask which team members have permission to invite you. If the team is unsure, from a GC Notify account visit the main menu and select “Team members.” That page:') }}</p>
+        <ul class="list list-bullet">
+          <li>{{ _('Includes an invitation button at the top of the page, if the member is permitted to send invitations.') }}</li>
+          <li>{{ _('Lists permitted tasks under the name of each  member.') }}</li>
+        </ul>
+      </div>
+    </details>
+  </div>
 {% endblock %}

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -129,7 +129,7 @@
         <p>{{ _('Ask which team members have permission to invite you. If the team is unsure, from a GC Notify account visit the main menu and select “Team members.” That page:') }}</p>
         <ul class="list list-bullet">
           <li>{{ _('Includes an invitation button at the top of the page, if the member is permitted to send invitations.') }}</li>
-          <li>{{ _('Lists permitted tasks under the name of each  member.') }}</li>
+          <li>{{ _('Lists permitted tasks under the name of each member.') }}</li>
         </ul>
       </div>
     </details>

--- a/app/templates/views/welcome.html
+++ b/app/templates/views/welcome.html
@@ -14,7 +14,7 @@
             <li class="pt-4 leading-tight">{{ _('Send messages to yourself and team members.') }}</li>
             <li class="pt-4 leading-tight">{{ _('Send up to {} messages per day.').format(default_limit | format_number) }}</li>
         </ul>
-        <p class="pt-10">{{ _("Once you've set up your team and tried out sending, you can request to go live in Settings.") }}</p>
+        <p class="pt-10">{{ _("When you’re ready to send more than 50 messages per day, you can request to go live in settings.") }}</p>
         <a href="{{ url_for('main.add_service', first='first') }}" class="mt-4 button">{{ _('Create your first service') }}</a>
     </div>
 

--- a/app/templates/views/welcome.html
+++ b/app/templates/views/welcome.html
@@ -18,4 +18,17 @@
         <a href="{{ url_for('main.add_service', first='first') }}" class="mt-4 button">{{ _('Create your first service') }}</a>
     </div>
 
+    <div class="grid-row contain-floats py-10 px-6">
+        <p data-testid="guidance-join-existing-service">{{ _("To join an existing service, check your email for an invitation from the team for that service.  GC Notify staff cannot send these invitations.") }}</p>
+        <details data-testid="details-join-existing-service">
+          <summary class="flex gap-10 py-2">{{ _("If you do not have an invitation") }}</summary>
+          <div class="details-body">
+            <p>{{ _('Ask which team members have permission to invite you. If the team is unsure, from a GC Notify account visit the main menu and select “Team members.” That page:') }}</p>
+            <ul class="list list-bullet">
+              <li>{{ _('Includes an invitation button at the top of the page, if the member is permitted to send invitations.') }}</li>
+              <li>{{ _('Lists permitted tasks under the name of each  member.') }}</li>
+            </ul>
+          </div>
+        </details>
+      </div>
 {% endblock %}

--- a/app/templates/views/welcome.html
+++ b/app/templates/views/welcome.html
@@ -26,7 +26,7 @@
             <p>{{ _('Ask which team members have permission to invite you. If the team is unsure, from a GC Notify account visit the main menu and select “Team members.” That page:') }}</p>
             <ul class="list list-bullet">
               <li>{{ _('Includes an invitation button at the top of the page, if the member is permitted to send invitations.') }}</li>
-              <li>{{ _('Lists permitted tasks under the name of each  member.') }}</li>
+              <li>{{ _('Lists permitted tasks under the name of each member.') }}</li>
             </ul>
           </div>
         </details>

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1503,7 +1503,7 @@
 "Send messages to yourself and team members.","Envoyer des messages à vous-même et aux membres de votre équipe."
 "Send up to {} messages per day.","Envoyer jusqu'à {} messages par jour."
 "Create your first service","Créer votre premier service"
-"Once you've set up your team and tried out sending, you can request to go live in Settings.","Une fois que vous aurez mis en place votre équipe et essayé d'envoyer des messages, vous pourrez demander d'activer votre service dans la section Paramètres."
+"When you’re ready to send more than 50 messages per day, you can request to go live in settings.","Lorsqu’il sera temps pour vous d’envoyer plus de 50 messages par jour, vous pourrez vous rendre dans les paramètres pour demander l’activation de votre service."
 "failure","échec"
 "failures","échecs"
 "This feature is only available when sending through the API.<br>Learn more in the <a href='{}'>API documentation</a>.","Cette fonctionnalité n’est disponible que pour les envois programmés par le biais de l’API.<br>Pour en savoir plus, consultez la <a href='{}'>documentation API</a>."

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2103,3 +2103,8 @@
 "SVG Images only!","Images SVG uniquement"
 "English Government of Canada signature and custom logo","Signature du gouvernement du Canada en anglais et logo personnalisé"
 "Upload a PNG logo","Téléverser un logo PNG"
+"To join an existing service, check your email for an invitation from the team for that service.  GC Notify staff cannot send these invitations.","Pour vous joindre à un service existant, cherchez dans vos courriels une invitation de l’équipe pour ce service. L’équipe de Notification GC ne peut pas envoyer ces invitations."
+"If you do not have an invitation","Si vous n’avez pas reçu d’invitation"
+"Ask which team members have permission to invite you. If the team is unsure, from a GC Notify account visit the main menu and select “Team members.” That page:","Demandez quels ou quelles membres de l’équipe ont la permission de vous inviter. Si l’équipe n’en est pas certaine, utilisez un compte Notification GC pour visiter le menu principal et rendez-vous dans la section « Votre équipe ». Cette page comprend :"
+"Includes an invitation button at the top of the page, if the member is permitted to send invitations.","un bouton d’invitation au haut de la page si le ou la membre de l’équipe a la permission d’envoyer des invitations; et"
+"Lists permitted tasks under the name of each member.","sous le nom de chaque membre de l’équipe, une liste des tâches que cette personne a l’autorisation de réaliser."

--- a/tests_cypress/cypress/Notify/Admin/Pages/AccountsPage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/AccountsPage.js
@@ -5,6 +5,8 @@ let Components = {
     ServiceName: () => cy.get('#name'),
     SendingAddress: () => cy.get('#email_from'),
     DepartmentName: () => cy.get('#parent_organisation_name'),
+    GuidanceJoinService: () => cy.getByTestId('guidance-join-existing-service'),
+    DetailsJoinService: () => cy.getByTestId('details-join-existing-service'),
     SubmitButton: () => cy.get('button[type="submit"]'),
 };
 
@@ -13,7 +15,7 @@ let Actions = {
     AddService: (branding, ) => {
         Components.AddServiceButton().click();
         cy.contains('h1', 'Choose order for official languages').should('be.visible');
-        
+
         Components.DefaultBranding().check();
         Components.SubmitButton().click();
         cy.contains('h1', 'Create service name and email address').should('be.visible');
@@ -26,7 +28,10 @@ let Actions = {
         Components.DepartmentName().type('Treasury Board of Canada Secretariat');
         Components.SubmitButton().click();
         cy.contains('h1', 'Dashboard').should('be.visible');
-    }   
+    },
+    ExpandDetailsJoinService: () => {
+        Components.DetailsJoinService().click();
+    },
 
 };
 

--- a/tests_cypress/cypress/Notify/Admin/Pages/WelcomePage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/WelcomePage.js
@@ -1,0 +1,22 @@
+let Components = {
+    CreateYourFirstService: () => cy.get("a[href='/add-service?first=first']"),
+    GuidanceJoinService: () => cy.getByTestId('guidance-join-existing-service'),
+    DetailsJoinService: () => cy.getByTestId('details-join-existing-service'),
+}
+
+let Actions = {
+    ClickCreateYourFirstService: () => {
+        Components.CreateYourFirstService().click();
+    },
+    ExpandDetailsJoinService: () => {
+        Components.DetailsJoinService().click();
+    },
+}
+
+let WelcomePage = {
+    URL: '/welcome', // URL for the page, relative to the base URL
+    Components,
+    ...Actions
+};
+
+export default WelcomePage;

--- a/tests_cypress/cypress/Notify/Admin/Pages/all.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/all.js
@@ -15,7 +15,7 @@ import ServiceSettingsPage from "./ServiceSettingsPage";
 import TemplateFiltersPage from "./TemplateFiltersPage";
 import TemplateCategoriesPage from "./admin/TemplateCategoriesPage";
 import ManageTemplateCategoryPage from "./admin/ManageTemplateCategoryPage";
-
+import WelcomePage from "./WelcomePage";
 export default {
     LoginPage,
     TwoFactorPage,
@@ -24,6 +24,7 @@ export default {
     Navigation,
     TemplatesPage,
     AccountsPage,
+    WelcomePage,
     CreateAccountPage,
     BrandingSettingsPage,
     EditBrandingPage,

--- a/tests_cypress/cypress/e2e/admin/accounts.cy.js
+++ b/tests_cypress/cypress/e2e/admin/accounts.cy.js
@@ -1,0 +1,38 @@
+import config from "../../../config";
+import { AccountsPage } from "../../Notify/Admin/Pages/all";
+
+describe("Accounts Page", () => {
+  before(() => {
+    cy.login(Cypress.env("NOTIFY_USER"), Cypress.env("NOTIFY_PASSWORD"));
+    cy.visit(config.Hostnames.Admin + `/accounts`);
+  });
+
+  it("Contains guidance for joining an existing service", () => {
+    AccountsPage.Components.GuidanceJoinService().should("be.visible");
+    AccountsPage.Components.DetailsJoinService().contains(
+      "If you do not have an invitation",
+    );
+    AccountsPage.ExpandDetailsJoinService();
+    AccountsPage.Components.DetailsJoinService()
+      .find("p")
+      .should("be.visible")
+      .and(
+        "contain",
+        "Ask which team members have permission to invite you. If the team is unsure, from a GC Notify account visit the main menu and select “Team members.” That page:",
+      );
+    AccountsPage.Components.DetailsJoinService()
+      .find("li")
+      .should(
+        "contain",
+        "Includes an invitation button at the top of the page, if the member is permitted to send invitations.",
+      )
+      .should("be.visible");
+    AccountsPage.Components.DetailsJoinService()
+      .find("li")
+      .should(
+        "contain",
+        "Includes an invitation button at the top of the page, if the member is permitted to send invitations.",
+      )
+      .and("be.visible");
+  });
+});

--- a/tests_cypress/cypress/e2e/admin/welcome.cy.js
+++ b/tests_cypress/cypress/e2e/admin/welcome.cy.js
@@ -1,0 +1,38 @@
+import config from "../../../config";
+import { WelcomePage } from "../../Notify/Admin/Pages/all";
+
+describe("Welcome Page", () => {
+  before(() => {
+    cy.login(Cypress.env("NOTIFY_USER"), Cypress.env("NOTIFY_PASSWORD"));
+    cy.visit(config.Hostnames.Admin + `/welcome`);
+  });
+
+  it("Contains guidance for joining an existing service", () => {
+    WelcomePage.Components.GuidanceJoinService().should("be.visible");
+    WelcomePage.Components.DetailsJoinService().contains(
+      "If you do not have an invitation",
+    );
+    WelcomePage.ExpandDetailsJoinService();
+    WelcomePage.Components.DetailsJoinService()
+      .find("p")
+      .should("be.visible")
+      .and(
+        "contain",
+        "Ask which team members have permission to invite you. If the team is unsure, from a GC Notify account visit the main menu and select “Team members.” That page:",
+      );
+    WelcomePage.Components.DetailsJoinService()
+      .find("li")
+      .should(
+        "contain",
+        "Includes an invitation button at the top of the page, if the member is permitted to send invitations.",
+      )
+      .should("be.visible");
+    WelcomePage.Components.DetailsJoinService()
+      .find("li")
+      .should(
+        "contain",
+        "Includes an invitation button at the top of the page, if the member is permitted to send invitations.",
+      )
+      .and("be.visible");
+  });
+});


### PR DESCRIPTION
# Summary | Résumé
This PR adds guidance sections to the `/welcome` and `/accounts` pages, encouraging users to get in touch with their team members to get added to existing services.

[Figma designs for reference](https://www.figma.com/design/1ccAvKpMboyDmnUliunnBY/Onboarding-and-set-up-%7C-Embarquement-et-configuration?node-id=2740-495&focus-id=2988-334&m=dev)

# Test instructions | Instructions pour tester la modification
1. Login, note the new section below the list of services attached to your account
2. Navigate to `/welcome` and note the same section is present on this page as well.