### PR TITLE
Tell git that the whole workspace is a safe dir

### DIFF
--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -9,6 +9,7 @@ set -ex
 
 # Tell git the workspace repository is safe, else upcoming commands will fail.
 git config --global --add safe.directory /workspaces/notification-admin
+git config --global --add safe.directory /workspace
 
 # Install and setup dev environment
 installations.sh


### PR DESCRIPTION
# Summary | Résumé

When building the dev container, it always crashed for me when it gets to the `poetry run pre-commit install` line in `installations.sh` with the following error:

```
+ poetry run pre-commit install
An error has occurred: FatalError: git failed. Is it installed, and are you in a Git repository directory?
Check the log at /home/vscode/.cache/pre-commit/pre-commit.log
[150325 ms] postCreateCommand failed with exit code 1. Skipping any further user-provided commands.
```

And then manually running the following command would fix git:
```
git config --global --add safe.directory /workspace
```

I added this to the dev container setup script and that fixed the error during the dev container build for me.

# Test instructions | Instructions pour tester la modification

Check out this branch and try building the dev container locally. Make sure it works for you.