### PR TITLE
remove old pages from gcarticles

### DIFF
--- a/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
@@ -11,7 +11,6 @@ const fullPageList = [
   { en: "/service-level-agreement", fr: "/accord-niveaux-de-service" },
   { en: "/guidance", fr: "/guides-reference" },
   { en: "/home", fr: "/accueil" },
-  { en: "/message-delivery-status", fr: "/etat-livraison-messages" },
   { en: "/other-services", fr: "/autres-services" },
   { en: "/privacy", fr: "/confidentialite" },
   { en: "/security", fr: "/securite" },


### PR DESCRIPTION
# Summary | Résumé

Removing:
https://articles.alpha.canada.ca/notification-gc-notify/wp-admin/post.php?post=29&action=edit&lang=en
https://articles.alpha.canada.ca/notification-gc-notify/wp-admin/post.php?post=27&action=edit&lang=fr


https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1525