### PR TITLE
Make poetry venv path static

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,6 +39,8 @@
 				"[python]": {
 					"editor.defaultFormatter": "charliermarsh.ruff"
 				},
+				"python.defaultInterpreterPath": "/home/vscode/.venvs/notification-admin/bin/python",
+				"python.venvPath": "/home/vscode/.venvs",
 				"useAdminDebug": true,
 				"debug.default.configuration": "Python: Remote Attach",
 				"debug.toolBarLocation": "docked",
@@ -127,7 +129,7 @@
 						}
 					]
 				}
-			}			
+			}
 		}
 	},
 	"features": {

--- a/.devcontainer/scripts/installations.sh
+++ b/.devcontainer/scripts/installations.sh
@@ -2,6 +2,7 @@
 set -ex
 
 export POETRY_VERSION="1.7.1"
+export POETRY_VENV_PATH="/home/vscode/.venv/notification-admin"
 
 # Define aliases
 echo -e "\n\n# User's Aliases" >> ~/.zshrc
@@ -31,14 +32,14 @@ poetry --version
 # Disable poetry auto-venv creation
 poetry config virtualenvs.create false
 
-# Manually create and activate a virtual environment with a static path
-python -m venv /home/vscode/.venvs/notification-admin
-source /home/vscode/.venvs/notification-admin/bin/activate
-
 # Initialize poetry autocompletions
 mkdir -p ~/.zfunc
 touch ~/.zfunc/_poetry
 poetry completions zsh > ~/.zfunc/_poetry
+
+# Manually create and activate a virtual environment with a static path
+python -m venv /home/vscode/.venvs/notification-admin
+source ${POETRY_VENV_PATH}/bin/activate
 
 # Set up git blame to ignore certain revisions e.g. sweeping code formatting changes.
 cd /workspace
@@ -48,7 +49,7 @@ git config blame.ignoreRevsFile .git-blame-ignore-revs
 poetry install
 
 # Ensure newly created shells activate the poetry venv
-echo "source /home/vscode/.venvs/notification-admin/bin/activate" >> ~/.zshrc
+echo "source ${POETRY_VENV_PATH}/bin/activate" >> ~/.zshrc
 
 # Poe the Poet plugin tab completions
 touch ~/.zfunc/_poe

--- a/.devcontainer/scripts/installations.sh
+++ b/.devcontainer/scripts/installations.sh
@@ -21,13 +21,19 @@ echo -e "source /usr/share/doc/fzf/examples/completion.zsh" >> ~/.zshrc
 echo -e "fpath+=/.zfunc" >> ~/.zshrc
 echo -e "autoload -Uz compinit && compinit"
 
-# Install Poetry
+# Install and configure Poetry
 pip install poetry==${POETRY_VERSION} poetry-plugin-sort
 echo "PATH=$PATH"
 #echo "/home/vscode/.local/bin/.."
 export PATH=$PATH:/home/vscode/.local/bin/
 which poetry
 poetry --version
+# Disable poetry auto-venv creation
+poetry config virtualenvs.create false
+
+# Manually create and activate a virtual environment with a static path
+python -m venv /home/vscode/.venvs/notification-admin
+source /home/vscode/.venvs/notification-admin/bin/activate
 
 # Initialize poetry autocompletions
 mkdir -p ~/.zfunc
@@ -40,6 +46,9 @@ git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 # Install dependencies
 poetry install
+
+# Ensure newly created shells activate the poetry venv
+echo "source /home/vscode/.venvs/notification-admin/bin/activate" >> ~/.zshrc
 
 # Poe the Poet plugin tab completions
 touch ~/.zfunc/_poe


### PR DESCRIPTION
# Summary | Résumé
This PR adds quality of life changes to the devcontainer around poetry virtual environments, ensuring that:
1. The Python interpreter in Vscode is detected and set automatically between container builds
2. New shells created in Vscode post-build always activate the poetry virtual environment, ensuring that use of the `poetry run ...` prefix is never necessary

**Changes to dev container configs:**
- Disabled Poetry's auto venv creation
- Manually create the venv to allow setting a static venv path `~/.venv/workspace`
- Set vscode default interpreter path to the static venv
- Ensure all shells started post container creation auto-activate the venv

**Some background**
By default Poetry automatically creates virtual environments and names them based on a hash value. Although Vscode is smart enough to find these venvs, it's not smart enough to automatically choose them.
![image](https://github.com/user-attachments/assets/bb068e06-5688-4299-8054-ed976f345506)

Vscode internally caches the interpreter path once you choose it, however this cached setting seems to persist across all running instances of vscode. i.e If you set your interpreter path while working in API, then switch over to Admin, rebuild the container and go to select the interpreter the cached path for API is still present:
![image](https://github.com/user-attachments/assets/01889a36-0472-4c14-ab78-a5199829f5c9)

This means each time select an interpreter you're effectively screwing up the setting for the next container you build. By setting each project's venv path to `~/.venv/workspace`, we can get around this as vscode will cache it and automatically pick up the venv regardless of the project you're working in.

# Test instructions | Instructions pour tester la modification
1. In vscode - `ctrl + shift + p` and select `Python: clear workspace interpreter setting`
2. Rebuild the dev container 
