### PR TITLE
Fix: update actions/cache to 4.2.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
       with:
         node-version: '16.x'
-    - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+    - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
@@ -27,7 +27,7 @@ jobs:
       run: pip install poetry==${POETRY_VERSION} poetry-plugin-sort && poetry --version
     - name: Install requirements
       run: poetry install --with test
-    - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+    - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/test_endpoints.yaml
+++ b/.github/workflows/test_endpoints.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
 
-    - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+    - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/test_prod_config.yaml
+++ b/.github/workflows/test_prod_config.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
       with:
         node-version: '16.x'
-    - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+    - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
@@ -27,7 +27,7 @@ jobs:
       run: pip install poetry==${POETRY_VERSION} && poetry --version
     - name: Install requirements
       run: poetry install --with test
-    - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+    - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/app/assets/stylesheets/tailwind/components/preview-pane.css
+++ b/app/assets/stylesheets/tailwind/components/preview-pane.css
@@ -6,7 +6,8 @@
   }
 
   #logo-img {
-    background-image: linear-gradient(45deg, $grey-3 25%, transparent 25%),
+    background-image:
+      linear-gradient(45deg, $grey-3 25%, transparent 25%),
       linear-gradient(-45deg, $grey-3 25%, transparent 25%),
       linear-gradient(45deg, transparent 75%, $grey-3 75%),
       linear-gradient(-45deg, transparent 75%, $grey-3 75%);

--- a/app/assets/stylesheets/tailwind/elements/form-multiple-choice.css
+++ b/app/assets/stylesheets/tailwind/elements/form-multiple-choice.css
@@ -159,7 +159,8 @@
     background-position:
       0 0,
       5px 5px;
-    background-image: linear-gradient(
+    background-image:
+      linear-gradient(
         45deg,
         #cfd5dd 25%,
         transparent 25%,


### PR DESCRIPTION
# Summary | Résumé

This PR updates references to `actions/cache` due to the [current version being deprecated]

# Test instructions | Instructions pour tester la modification
- CI passes on this PR
