### PR TITLE
Fix nbsp rendering in flashed message

### DIFF
--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -16,7 +16,7 @@
     {{ body }}
     {% if context %}
     <p class="banner-context">
-      {{ context }}
+      {{ context|safe }}
     </p>
     {% endif %}
     {% if delete_button %}


### PR DESCRIPTION
# Summary | Résumé

There was an issue with the non-breaking space not rendering properly in one of our new error messages. This change fixes that.

Before:
<img width="1051" alt="Screenshot 2025-02-14 at 3 19 16 PM" src="https://github.com/user-attachments/assets/120ed0e1-cac9-4b08-a60f-ab54cc825722" />

After:
<img width="1030" alt="Screenshot 2025-02-14 at 3 18 46 PM" src="https://github.com/user-attachments/assets/828699a9-71e4-4619-a388-1044ea71208e" />
