### PR TITLE
fix: update cypress-io/github-action to v5.8.4

### DIFF
--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -176,8 +176,18 @@ jobs:
           CYPRESS_BASE_URL: ${{needs.deploy-test-admin.outputs.LAMBDA_URL}}
         with:
           record: false
-          config: "video=false,screenshotOnRunFailure=false"
+          config: "video=true,screenshotOnRunFailure=true"
           build: npx cypress info
           working-directory: tests_cypress
           spec: |
             cypress/e2e/admin/ci.cy.js
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: cypress-artifacts
+          path: |
+            tests_cypress/cypress/videos
+            tests_cypress/cypress/screenshots
+          retention-days: 30

--- a/.github/workflows/test-admin-deploy.yaml
+++ b/.github/workflows/test-admin-deploy.yaml
@@ -171,7 +171,7 @@ jobs:
           echo '${{ secrets.CYPRESS_ENV_JSON }}' > tests_cypress/cypress.env.json 
 
       - name: Run the cypress tests
-        uses: cypress-io/github-action@d79d2d530a66e641eb4a5f227e13bc985c60b964 # v4.2.2
+        uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5.8.4
         env:
           CYPRESS_BASE_URL: ${{needs.deploy-test-admin.outputs.LAMBDA_URL}}
         with:


### PR DESCRIPTION
# Summary | Résumé

This PR performs some updates around cypress:
- upgrades `cypress-io/github-action` to  `v5.8.4` which is the latest version before breaking changes are introduced
- turns on video recording and screenshots for cypress runs to help us troubleshoot.  They can be downloaded from the action run itself, under "upload test artifacts":
- 
![image](https://github.com/user-attachments/assets/14940b93-e8b7-4aba-88cb-6a090d590924)

