### PR TITLE
chore: update cypress action in the scheduled tests too

### DIFF
--- a/.github/workflows/cypress-staging.yaml
+++ b/.github/workflows/cypress-staging.yaml
@@ -26,7 +26,7 @@ jobs:
           echo '${{ secrets.CYPRESS_ENV_JSON }}' > tests_cypress/cypress.env.json 
 
       - name: Run the cypress tests
-        uses: cypress-io/github-action@d79d2d530a66e641eb4a5f227e13bc985c60b964 # v4.2.2
+        uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5.8.4
         with:
           record: false
           config: video=false,screenshotOnRunFailure=false
@@ -35,6 +35,16 @@ jobs:
           spec: |
             cypress/e2e/admin/a11y/app_pages.cy.js
             cypress/e2e/admin/a11y/gca_pages.cy.js
+            - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: cypress-artifacts
+          path: |
+            tests_cypress/cypress/videos
+            tests_cypress/cypress/screenshots
+          retention-days: 30
+
       - name: Notify Slack channel if this job failed
         if: ${{ failure() }}
         run: |


### PR DESCRIPTION
# Summary | Résumé

This PR performs some updates around cypress for the scheduled tests:

- upgrades cypress-io/github-action to v5.8.4 which is the latest version before breaking changes are introduced
- turns on video recording and screenshots for cypress runs to help us troubleshoot. They can be downloaded from the action run itself, under "upload test artifacts"