### PR TITLE
add debates-debats.ca to allowed user email domains

### DIFF
--- a/app/email_domains.txt
+++ b/app/email_domains.txt
@@ -26,3 +26,4 @@ oipc.bc.ca
 cfp-pcaf.ca
 surete.qc.ca
 invcanada.ca
+debates-debats.ca


### PR DESCRIPTION
# Summary | Résumé

add `debates-debats.ca` domain for user email addresses, as discussed in [this thread](https://gcdigital.slack.com/archives/CV38DBNVA/p1740148354903079). 

# Test instructions | Instructions pour tester la modification

We'll ask the user to create an account after release to production.