### PR TITLE
Decrease the api query page size

### DIFF
--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -256,7 +256,7 @@ def download_notifications_csv(service_id):
                 job_id=None,
                 status=filter_args.get("status"),
                 page=request.args.get("page", 1),
-                page_size=10000,
+                page_size=5000,
                 format_for_csv=True,
                 template_type=filter_args.get("message_type"),
                 limit_days=service_data_retention_days,


### PR DESCRIPTION
# Summary | Résumé

Decrease the api query page size used in the "download this report" queries from 10k to 5k.

When you click: Dashboard > Email > "Download this report" for services with a lot of sends, the download fails partway through. 
I used my debugger to intercept the SQL used to get the report data, and it looks like this:  
```
SELECT notifications.id, notifications."to", notifications.normalised_to, notifications.job_id, notifications.job_row_number, notifications.service_id, notifications.template_id, notifications.template_version, notifications.api_key_id, notifications.key_type, notifications.billable_units, notifications.notification_type, notifications.created_at, notifications.sent_at, notifications.sent_by, notifications.updated_at, notifications.notification_status, notifications.reference, notifications._personalisation, notifications.client_reference, notifications.international, notifications.phone_prefix, notifications.rate_multiplier, notifications.created_by_id, notifications.reply_to_text, notifications.postage, notifications.provider_response, notifications.queue_name, notifications.feedback_type, notifications.feedback_subtype, notifications.ses_feedback_id, notifications.ses_feedback_date, notifications.feedback_reason, notifications.sms_total_message_price, notifications.sms_total_carrier_fee, notifications.sms_iso_country_code, notifications.sms_carrier_name, notifications.sms_message_encoding, notifications.sms_origination_phone_number 
FROM notifications 
WHERE notifications.service_id = 'xyz'::UUID 
AND notifications.created_at > '2025-02-28 23:59:59.999999' 
AND notifications.key_type != 'test' 
AND notifications.notification_status IN ('pii-check-failed', 'permanent-failure', 'sent', 'pending', 'technical-failure', 'sending', 'provider-failure', 'failed', 'created', 'validation-failed', 'returned-letter', 'delivered', 'virus-scan-failed', 'pending-virus-check', 'temporary-failure') 
AND notifications.notification_type IN ('email')
ORDER BY notifications.created_at DESC
limit 10000
offset 40000
```
The api is queried multiple times, and the offset changes depending on what page we want.
 
This query is actually pretty fast on the affected service, so I'm not sure what the issue is. It runs in about 2 seconds for a page size of 10k, and in about 1 second for a page size of 5k. 

A page size of 5k is used elsewhere in the app, so lets try that to see if it fixes our timeout issues.

- https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1750

# Test instructions | Instructions pour tester la modification

We can't really test that this fix has worked on the affected service until it is released to Prod. When it is released to Staging we can also test on some services there to see if it speeds up the report download.