### PR TITLE
Update template-filters test with setup/teardown process

### DIFF
--- a/tests_cypress/cypress/Notify/NotifyAPI.js
+++ b/tests_cypress/cypress/Notify/NotifyAPI.js
@@ -85,11 +85,11 @@ const Admin = {
             }
         })
     },
-    CreateTemplate: ({ name, type, content, service_id, subject = null, process_type, parent_folder_id = null, template_category_id = null }) => {
+    CreateTemplate: ({ name, type, content, service_id, subject = null, process_type, parent_folder_id = null, template_category_id = null, created_by = null }) => {
         var token = Utilities.CreateJWT();
         return cy.request({
             url: `${BASE_URL}/service/${service_id}/template`,
-            method: 'GET',
+            method: 'POST',
             headers: {
                 Authorization: `Bearer ${token}`,
                 "Content-Type": 'application/json'
@@ -97,10 +97,12 @@ const Admin = {
             body: {
                 "name": name,
                 "template_type": type,
+                "subject": subject,
                 "content": content,
                 "service": service_id,
                 "process_type": process_type,
                 "template_category_id": template_category_id,
+                "created_by": created_by
             }
         });
     },

--- a/tests_cypress/cypress/e2e/admin/template-filters.cy.js
+++ b/tests_cypress/cypress/e2e/admin/template-filters.cy.js
@@ -192,12 +192,10 @@ describe("Template filters", () => {
             // Empty state should NOT be visible
             Page.Components.EmptyState().should("not.be.visible");
 
-            if (lang == "fr") {
-              Admin.DeleteTemplate({
-                templateId: resp.body.data.id,
-                serviceId: config.Services.Cypress,
-              });
-            }
+            Admin.DeleteTemplate({
+              templateId: resp.body.data.id,
+              serviceId: config.Services.Cypress,
+            });
           });
         });
       });

--- a/tests_cypress/cypress/e2e/admin/template-filters.cy.js
+++ b/tests_cypress/cypress/e2e/admin/template-filters.cy.js
@@ -1,8 +1,6 @@
 /// <reference types="cypress" />
 
-import { name } from "file-loader";
 import config from "../../../config";
-import { TemplatesPage as TemplatesPage } from "../../Notify/Admin/Pages/all";
 import { TemplateFiltersPage as Page } from "../../Notify/Admin/Pages/all";
 import { Admin, API } from "../../Notify/NotifyAPI";
 

--- a/tests_cypress/cypress/support/commands.js
+++ b/tests_cypress/cypress/support/commands.js
@@ -104,9 +104,9 @@ Cypress.Commands.add('getByTestId', (selector, ...args) => {
 
 Cypress.Commands.add('login', (agreeToTerms = true) => {
     cy.task('createAccount', { baseUrl: config.Hostnames.API, username: Cypress.env('CYPRESS_AUTH_USER_NAME'), secret: Cypress.env('CYPRESS_AUTH_CLIENT_SECRET') }).then((acct) => {
+        Cypress.env('ADMIN_USER_ID', acct.admin.id)
+        Cypress.env('REGULAR_USER_ID', acct.regular.id)
         cy.session([acct.regular.email_address, agreeToTerms], () => {
-            Cypress.env('ADMIN_USER_ID', acct.admin.id)
-            Cypress.env('REGULAR_USER_ID', acct.regular.id)
             LoginPage.Login(acct.regular.email_address, Cypress.env('CYPRESS_USER_PASSWORD'), agreeToTerms);
         });
     });
@@ -115,9 +115,9 @@ Cypress.Commands.add('login', (agreeToTerms = true) => {
 
 Cypress.Commands.add('loginAsPlatformAdmin', (agreeToTerms = true) => {
     cy.task('createAccount', { baseUrl: config.Hostnames.API, username: Cypress.env('CYPRESS_AUTH_USER_NAME'), secret: Cypress.env('CYPRESS_AUTH_CLIENT_SECRET') }).then((acct) => {
+        Cypress.env('ADMIN_USER_ID', acct.admin.id)
+        Cypress.env('REGULAR_USER_ID', acct.regular.id)
         cy.session([acct.admin.email_address, agreeToTerms], () => {
-            Cypress.env('ADMIN_USER_ID', acct.admin.id)
-            Cypress.env('REGULAR_USER_ID', acct.regular.id)
             LoginPage.Login(acct.admin.email_address, Cypress.env('CYPRESS_USER_PASSWORD'), agreeToTerms);
         });
     });

--- a/tests_cypress/cypress/support/commands.js
+++ b/tests_cypress/cypress/support/commands.js
@@ -18,7 +18,7 @@ afterEach(function() {
 
 Cypress.Commands.add('a11yScan', (url, options = { a11y: true, htmlValidate: true, deadLinks: true, mimeTypes: true, axeConfig: false }) => {
     const current_hostname = config.Hostnames.Admin;
-    
+
     if (url) {
         cy.visit(url);
     }
@@ -105,6 +105,8 @@ Cypress.Commands.add('getByTestId', (selector, ...args) => {
 Cypress.Commands.add('login', (agreeToTerms = true) => {
     cy.task('createAccount', { baseUrl: config.Hostnames.API, username: Cypress.env('CYPRESS_AUTH_USER_NAME'), secret: Cypress.env('CYPRESS_AUTH_CLIENT_SECRET') }).then((acct) => {
         cy.session([acct.regular.email_address, agreeToTerms], () => {
+            Cypress.env('ADMIN_USER_ID', acct.admin.id)
+            Cypress.env('REGULAR_USER_ID', acct.regular.id)
             LoginPage.Login(acct.regular.email_address, Cypress.env('CYPRESS_USER_PASSWORD'), agreeToTerms);
         });
     });
@@ -114,6 +116,8 @@ Cypress.Commands.add('login', (agreeToTerms = true) => {
 Cypress.Commands.add('loginAsPlatformAdmin', (agreeToTerms = true) => {
     cy.task('createAccount', { baseUrl: config.Hostnames.API, username: Cypress.env('CYPRESS_AUTH_USER_NAME'), secret: Cypress.env('CYPRESS_AUTH_CLIENT_SECRET') }).then((acct) => {
         cy.session([acct.admin.email_address, agreeToTerms], () => {
+            Cypress.env('ADMIN_USER_ID', acct.admin.id)
+            Cypress.env('REGULAR_USER_ID', acct.regular.id)
             LoginPage.Login(acct.admin.email_address, Cypress.env('CYPRESS_USER_PASSWORD'), agreeToTerms);
         });
     });
@@ -122,10 +126,10 @@ Cypress.Commands.add('loginAsPlatformAdmin', (agreeToTerms = true) => {
 // this adds the waf-secret to cy.visit()'s that target the admin hostname
 Cypress.Commands.overwrite('visit', (originalFn, url, options = {}) => {
      // Get full URL by combining baseUrl with path
-    const fullUrl = url.startsWith('http') 
-        ? url 
+    const fullUrl = url.startsWith('http')
+        ? url
         : `${Cypress.config('baseUrl')}${url}`;
-       
+
     // Only add headers if URL matches admin hostname
     if (fullUrl.includes(config.Hostnames.Admin)) {
         const mergedOptions = {
@@ -137,6 +141,6 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options = {}) => {
         };
         return originalFn(url, mergedOptions);
     }
-    
+
     return originalFn(url, options);
 });


### PR DESCRIPTION
# Summary | Résumé
This PR updates the template filter test: `Filtering to 0 results shows empty message`. It now creates an email template assigned to the `Test` category before the test runs. This ensures that when testing for the empty state that the results are consistent. Once the test is complete the template is removed.

It also adds the admin and regular user_id's to `Cypress.env` after a fresh account is created for the test run. We'll need access to these once we start enforcing `created_by_id` assignments when creating new entities.

# Test instructions | Instructions pour tester la modification

CI passes