### PR TITLE
Fix/update links to terms

### DIFF
--- a/app/articles/routing.py
+++ b/app/articles/routing.py
@@ -23,7 +23,6 @@ GC_ARTICLES_ROUTES = {
     "service-level-objectives": {"en": "/service-level-objectives", "fr": "/objectifs-niveau-de-service"},
     "spreadsheets": {"en": "/using-a-spreadsheet", "fr": "/utiliser-une-feuille-de-calcul"},
     "terms-202104": {"en": "/terms-202104", "fr": "/conditions-dutilisation-202104"},
-    "terms": {"en": "/terms", "fr": "/conditions-dutilisation"},
     "whynotify": {"en": "/why-gc-notify", "fr": "/pourquoi-notification-gc"},
     "incidents": {"en": "/system-status", "fr": "/etat-du-systeme"},
     "new_features": {"en": "/new-features", "fr": "/nouvelles-fonctionnalites"},

--- a/app/main/sitemap.py
+++ b/app/main/sitemap.py
@@ -48,7 +48,7 @@ def get_sitemap():
                 "title": _("Policy"),
                 "pages": [
                     {"href": gca_url_for("accessibility"), "link_text": _("Accessibility")},
-                    {"href": gca_url_for("terms"), "link_text": _("GC Notify terms of use")},
+                    {"href": url_for("main.terms"), "link_text": _("GC Notify terms of use")},
                     {"href": gca_url_for("privacy"), "link_text": _("Privacy notice for staff using GC Notify")},
                     {"href": gca_url_for("security"), "link_text": _("Security")},
                     {"href": gca_url_for("service-level-agreement"), "link_text": _("GC Notify service level agreement")},

--- a/app/templates/components/tou-prompt.html
+++ b/app/templates/components/tou-prompt.html
@@ -42,7 +42,7 @@
     <div data-testid="tou-terms">
       <p>
         {{ _('By using GC Notify, you accept our ') }}
-        {{ content_link(_("terms of use"), gca_url_for('terms'), is_external_link=true) }}.
+        {{ content_link(_("terms of use"), url_for('main.terms'), is_external_link=true) }}.
         {{ _('This includes your agreement to:') }}
       </p>
       <ul class="list list-bullet ml-5">

--- a/app/templates/partials/nav/footer.html
+++ b/app/templates/partials/nav/footer.html
@@ -81,7 +81,7 @@
             {{ nav_link_light(id_key='nav-footer-secondary-a11y', class="whitespace-nowrap",label=_('Accessibility'), href=gca_url_for('accessibility')) }}
             {{ separator() }}</li>
           <li>
-            {{ nav_link_light(id_key='nav-footer-secondary-terms', class="whitespace-nowrap",label=_('Terms of use'), href=gca_url_for('terms')) }}
+            {{ nav_link_light(id_key='nav-footer-secondary-terms', class="whitespace-nowrap",label=_('Terms of use'), href=url_for('main.terms')) }}
             {{ separator() }}</li>
           <li>
             {{ nav_link_light(id_key='nav-footer-secondary-sla', class="whitespace-nowrap",label=_('Service level agreement'), href=gca_url_for('service-level-agreement')) }}

--- a/app/templates/views/service-settings/terms-of-use.html
+++ b/app/templates/views/service-settings/terms-of-use.html
@@ -16,7 +16,7 @@
     ) }}
 
     <p>
-      {{ _("Before going live, review the GC Notify <a href='{}'>terms of use</a>.").format(gca_url_for('terms')) }}
+      {{ _("Before going live, review the GC Notify <a href='{}'>terms of use</a>.").format(url_for('main.terms')) }}
     </p>
 
     <p class="font-bold">


### PR DESCRIPTION
# Summary | Résumé
This PR updates the links to the terms of use pages throughout the app to use the app page route instead of the GCA page route.  We moved this page off of GCA some time ago.

Affected pages:
- Login, TOU banner
![image](https://github.com/user-attachments/assets/363ba29a-e1e2-453f-bfc0-03fe4231c99f)
- Footer
![image](https://github.com/user-attachments/assets/9701ed8e-c66e-4d6f-9f72-b53c351d3cc2)
- Sitemap
![image](https://github.com/user-attachments/assets/2bda86bd-0848-4f0b-a786-1788d3fbf698)
- Reviewing terms as part of go-live:
![image](https://github.com/user-attachments/assets/6c6141ca-3a48-493b-a36e-bb3425a93c75)


# Related cards
- https://github.com/cds-snc/notification-planning/issues/1787

# Test instructions | Instructions pour tester la modification

- Ensure each link to the terms page works in french, and navigates to `/terms` and NOT `/conditions-dulitisation`
