### PR TITLE
Add a check that we have a valid `message_type`

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -227,6 +227,9 @@ def view_job_updates(service_id, job_id):
 @main.route("/services/<service_id>/notifications/<message_type>", methods=["GET", "POST"])
 @user_has_permissions()
 def view_notifications(service_id, message_type=None):
+    if message_type not in ["email", "sms", None]:
+        abort(404)
+
     service_data_retention_days = current_app.config.get("ACTIVITY_STATS_LIMIT_DAYS", None)
 
     if message_type is not None:

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -584,9 +584,9 @@ def test_redacts_templates_that_should_be_redacted(
 
 @pytest.mark.parametrize(
     "message_type, tablist_visible, search_bar_visible",
-    [("email", True, True), ("sms", True, True), ("letter", False, False)],
+    [("email", True, True), ("sms", True, True)],
 )
-def test_big_numbers_and_search_dont_show_for_letters(
+def test_big_numbers_and_search_show_for_email_sms(
     client_request,
     service_one,
     mock_get_notifications,
@@ -649,54 +649,6 @@ def test_big_numbers_and_search_dont_show_for_letters(
             False,
         ),
         ("sms", "delivered", None, "Delivered 16:31:00", True),
-        ("letter", "created", None, "2017-09-27T16:30:00+00:00", True),
-        ("letter", "pending-virus-check", None, "2017-09-27T16:30:00+00:00", True),
-        ("letter", "sending", None, "2017-09-27T16:30:00+00:00", True),
-        ("letter", "delivered", None, "2017-09-27T16:30:00+00:00", True),
-        ("letter", "received", None, "2017-09-27T16:30:00+00:00", True),
-        ("letter", "accepted", None, "2017-09-27T16:30:00+00:00", True),
-        (
-            "letter",
-            "cancelled",
-            None,
-            "2017-09-27T16:30:00+00:00",
-            False,
-        ),  # The API won’t return cancelled letters
-        (
-            "letter",
-            "permanent-failure",
-            None,
-            "16:31:00",
-            False,
-        ),  # Deprecated for ‘cancelled’
-        (
-            "letter",
-            "temporary-failure",
-            None,
-            "2017-09-27T16:30:00+00:00",
-            False,
-        ),  # Not currently a real letter status
-        (
-            "letter",
-            "virus-scan-failed",
-            None,
-            "Virus detected 2017-09-27T16:30:00+00:00",
-            False,
-        ),
-        (
-            "letter",
-            "validation-failed",
-            None,
-            "Validation failed 2017-09-27T16:30:00+00:00",
-            False,
-        ),
-        (
-            "letter",
-            "technical-failure",
-            None,
-            "Technical failure 2017-09-27T16:30:00+00:00",
-            False,
-        ),
     ],
 )
 def test_sending_status_hint_displays_correctly_on_notifications_page_new_statuses(

--- a/tests/app/main/views/test_activity.py
+++ b/tests/app/main/views/test_activity.py
@@ -287,6 +287,7 @@ def test_letters_with_status_virus_scan_failed_shows_a_failure_description(
     assert "Virus detected\n" in error_description
 
 
+@pytest.mark.skip(reason="letters: unused functionality")
 @pytest.mark.parametrize("letter_status", ["pending-virus-check", "virus-scan-failed"])
 def test_should_not_show_preview_link_for_precompiled_letters_in_virus_states(
     mocker,


### PR DESCRIPTION
# Summary | Résumé

Add a check that we have a valid `message_type` for the `.view_notifications` route.
It was causing a 500 error if visited a url like `https://staging.notification.cdssandbox.xyz/services/d6aa2c68-a2d9-4437-ab19-3ae8eb202553/notifications/all`. See the zenhub card below for more details.

- https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1662

# Test instructions | Instructions pour tester la modification

- log on to the review app
- visit the "emails sent in the last week" page for one of your services
- edit the last part of the url to be: `/services/<your-service-id>/notifications/all` or `/services/<your-service-id>/notifications/blah`
- confirm that you see a "Page could not be found" message and not "Sorry, we’re experiencing technical difficulties"