### PR TITLE
Fix ugly focus outline that is visible when you log in

### DIFF
--- a/app/templates/components/tou-prompt.html
+++ b/app/templates/components/tou-prompt.html
@@ -4,7 +4,7 @@
 
 {% macro tou_prompt() %}
 
-  <h1 class="heading-large mt-0 mb-4" tabindex="0" autofocus>{{ _('Before you continue') }}</h1>
+  <h1 class="heading-large py-1 mt-0 mb-3" tabindex="0" autofocus>{{ _('Before you continue') }}</h1>
 
   {% if config["FF_CARETAKER"] %}
     {% call notice(type="warning", title=_("Communicating during caretaker period"), headingLevel=2) %}


### PR DESCRIPTION
# Summary | Résumé


This has been bothering me for a while.

Before:
<img width="974" alt="Screenshot 2025-03-21 at 3 54 26 PM" src="https://github.com/user-attachments/assets/ce1c2c68-756a-491e-85bd-c394e796ea98" />


After:
<img width="973" alt="Screenshot 2025-03-21 at 3 52 46 PM" src="https://github.com/user-attachments/assets/3174584d-15e1-4c5d-9efc-b523c03fb567" />


# Test instructions | Instructions pour tester la modification

1. log into the review app and verify that the focus outline is less ugly