### PR TITLE
Add report language to the api request

### DIFF
--- a/app/main/views/reports.py
+++ b/app/main/views/reports.py
@@ -1,10 +1,11 @@
 from flask import (
+    current_app,
     flash,
     render_template,
 )
 from flask_login import current_user
 
-from app import reports_api_client
+from app import get_current_locale, reports_api_client
 from app.main import main
 from app.utils import user_is_platform_admin
 
@@ -19,7 +20,8 @@ def reports(service_id):
 @main.route("/services/<service_id>/reports", methods=["post"])
 @user_is_platform_admin
 def generate_report(service_id):
-    reports_api_client.request_report(user_id=current_user.id, service_id=service_id, report_type="email")
+    language = get_current_locale(current_app)
+    reports_api_client.request_report(user_id=current_user.id, service_id=service_id, report_type="email", language=language)
     flash("Test report has been requested", "default")
     reports = reports_api_client.get_reports_for_service(service_id)
     return render_template("views/reports/reports.html", reports=reports)

--- a/app/notify_client/reports_api_client.py
+++ b/app/notify_client/reports_api_client.py
@@ -2,11 +2,12 @@ from app.notify_client import NotifyAdminAPIClient
 
 
 class ReportsApiClient(NotifyAdminAPIClient):
-    def request_report(self, user_id, service_id, report_type, job_id=None):
+    def request_report(self, user_id, service_id, report_type, language, job_id=None):
         data = {
             "requesting_user_id": user_id,
             "service_id": service_id,
             "report_type": report_type,
+            "language": language,
             "job_id": job_id,
         }
         self.post(f"/service/{service_id}/report", data=data)


### PR DESCRIPTION
# Summary | Résumé

This PR sends the language parameter to the api endpoint that creates new reports.

# Test instructions | Instructions pour tester la modification

1. log in to the review app
3. visit the reports page for your service: `\services/<your-service-id>/reports`
4. generate a report
5. look in the staging db and make sure a new row has appeared in the `reports` table with the `language` column set to your selected language on the admin site
