### PR TITLE
Add a check in case the `email_from` field is empty after sanitisation

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -217,6 +217,9 @@ def validate_email_from(form, field):
     if email_safe(field.data) != field.data.lower():
         # fix their data instead of only warning them
         field.data = email_safe(field.data)
+    if len(field.data) == 0:
+        # the field became empty after sanitisation
+        raise ValidationError(_l("This cannot be empty"))
     if len(field.data) > 64:
         raise ValidationError(_l("This cannot exceed 64 characters in length"))
     # this filler is used because service id is not available when validating a new service to be created

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -157,6 +157,7 @@ def _get_notifications_csv_mock(mocker, api_user_active, job_id=fake_uuid):
         ("sending-domain", "sending-domain"),
         ("sending_domain_", "sending_domain_"),
         ("sending-domain-", "sending-domain-"),
+        ("$", ""),
     ],
 )
 def test_email_safe_return_dot_separated_email_domain(service_name, safe_email):


### PR DESCRIPTION
# Summary | Résumé

Add a check to raise a validation error if the "email from" data becomes an empty string after it is sanitised. I believe this caused a 500 error on Prod today. 

# Test instructions | Instructions pour tester la modification

1. open the review app
2. start the flow to create a new service
3. On step 2, put a `$` or other special character in the "email from" form field
4. you should see the validation error in the screenshot below

<img width="1093" alt="Screenshot 2025-04-09 at 1 18 54 PM" src="https://github.com/user-attachments/assets/0ad2cdb7-806e-419f-b5ad-19b47f61db45" />
