### PR TITLE
Fix a bug in the create service flow where `email_from` is missing

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -222,7 +222,7 @@ def add_service():
     data.update(form.data)  # add newly submitted data from POST
     # iterate through all forms and validate
     for step in WIZARD_ORDER:
-        temp_form_cls = get_form_class(current_step, government_type)
+        temp_form_cls = get_form_class(step, government_type)
         temp_form = temp_form_cls(data=data)
         if not temp_form.validate():  # something isn't right, jump to the form with bad / missing data
             return redirect(url_for(".add_service", current_step=step, government_type=government_type))

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -220,10 +220,13 @@ def test_wizard_flow_with_step_2_post_should_go_to_step_3_with_ff(
 def test_wizard_flow_with_step_3_should_create_service(
     app_: Flask,
     client_request,
+    mocker,
     mock_create_service,
     mock_create_or_update_free_sms_fragment_limit,
     child_organisation_name: str,
 ):
+    mocker.patch("app.service_api_client.is_service_name_unique", return_value=True)
+    mocker.patch("app.service_api_client.is_service_email_from_unique", return_value=True)
     app_.config["FF_SALESFORCE_CONTACT"] = True
     app_.config["CRM_ORG_LIST"] = {"en": ["CDS", "TBS"]}
     with client_request.session_transaction() as session:
@@ -233,6 +236,9 @@ def test_wizard_flow_with_step_3_should_create_service(
     client_request.post(
         "main.add_service",
         _data={
+            "email_from": "testing.the.post",
+            "name": "testing the post",
+            "default_branding": FieldWithLanguageOptions.ENGLISH_OPTION_VALUE,
             "parent_organisation_name": "Department of socks",
             "child_organisation_name": child_organisation_name,
         },
@@ -275,9 +281,12 @@ def test_wizard_flow_with_step_3_should_not_create_service_no_parent_org(
 def test_wizard_flow_with_step_3b_should_create_service(
     app_: Flask,
     client_request,
+    mocker,
     mock_create_service,
     mock_create_or_update_free_sms_fragment_limit,
 ):
+    mocker.patch("app.service_api_client.is_service_name_unique", return_value=True)
+    mocker.patch("app.service_api_client.is_service_email_from_unique", return_value=True)
     app_.config["FF_SALESFORCE_CONTACT"] = True
     app_.config["CRM_ORG_LIST"] = {"en": ["CDS", "TBS"]}
     with client_request.session_transaction() as session:


### PR DESCRIPTION
# Summary | Résumé

Fix a bug where the user was not being redirected back to step 2 in the create service flow when their step 2 data was missing.

# Test instructions | Instructions pour tester la modification

This is the bug:
1. open the review app
2. go to create a new service
3. complete step 1
4. don't fill out anything in step 2
5. change the url to replace `/add-service?current_step=choose_service_name` with `/add-service?current_step=choose_organisation`  and hit enter
6. choose your organisation and click "create service"
7. you will see a 500 error 

If you follow these steps and don't see a 500 error, the bug is fixed.