### PR TITLE
Clean up reports page

### DIFF
--- a/app/main/views/reports.py
+++ b/app/main/views/reports.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from flask import (
     flash,
     jsonify,
@@ -34,6 +36,9 @@ def generate_report(service_id):
 
 
 def get_reports_partials(reports):
+    for report in reports:
+        if report["status"] == "ready" and datetime.fromisoformat(report["expires_at"]) < datetime.now(timezone.utc):
+            report["status"] = "expired"
     return {
         "reports": render_template(
             "views/reports/reports-table.html",

--- a/app/templates/views/reports/reports-table.html
+++ b/app/templates/views/reports/reports-table.html
@@ -15,7 +15,7 @@
   ) %}
     {% call row_heading() %}
       <div class="flex flex-col">
-        <div class="mb-4">
+        <div>
           {% if item.status == "ready" %}
           <a class="file-list-filename" href="{{ item.url }}">
             <span><time class="local-datetime-full">{{item.requested_at}}</time></span>
@@ -38,19 +38,27 @@
     
     {% call field(align='right') %}
       <div class="flex flex-col justify-end">
-        {% if item.status == "requested" %}
-            <div class="mb-4">
-              <div class="loading-spinner"></div>
-            </div>
+        <div class="mb-4">
+          {% if item.status == "requested" %}
+            <div class="loading-spinner"></div>
+          {% else %}
+            <div class="size-12"></div>
+          {% endif %}
+        </div>
+        {% if item.status == "requested" or item.status == "generating" %}
             <div class="file-list-hint">{{ _("Preparing report") }}</div>
         {% elif item.status == "ready" %}
-            <div class="mb-4">
-              <div class="size-20"></div>
-            </div>
             <div class="file-list-hint">
                 {{ _("Download before") }}
                 <span><time class="local-datetime-short">{{item.expires_at}}</time></span>
             </div>
+        {% elif item.status == "error" %}
+          <div class="file-list-hint text-red">{{ _("Failed. Try again") }}</div>
+        {% elif item.status == "expired" %}
+          <div class="file-list-hint text-red">
+            {{ _("Deleted at") }} 
+            <span><time class="local-datetime-short">{{item.expires_at}}</time></span>
+          </div>
         {% else %}
           {{ _(item.status) }}
         {% endif %}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2169,6 +2169,8 @@
 "Go to dashboard","FR Go to dashboard"
 "Requested by","FR Requested by"
 "Download before","FR Download before"
+"Failed. Try again","FR Failed. Try again"
+"Deleted at","FR Deleted at"
 "report","FR report"
 "You’ll get an email when a report you requested is ready to download. Then you have 72 hours to download it.","FR You’ll get an email when a report you requested is ready to download. Then you have 72 hours to download it."
 "Available","FR Available"

--- a/tests/app/main/views/test_reports.py
+++ b/tests/app/main/views/test_reports.py
@@ -1,0 +1,134 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import ANY
+
+import pytest
+from bs4 import BeautifulSoup
+
+
+@pytest.fixture
+def mock_reports_data():
+    return [
+        {
+            "id": "report-1",
+            "status": "ready",
+            "expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+        },
+        {
+            "id": "report-2",
+            "status": "ready",
+            "expires_at": (datetime.now(timezone.utc) - timedelta(days=1)).isoformat(),
+        },
+        {
+            "id": "report-3",
+            "status": "pending",
+            "expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+        },
+    ]
+
+
+def test_reports_page_requires_platform_admin(
+    client_request,
+    platform_admin_user,
+    mock_get_service,
+):
+    client_request.login(platform_admin_user)
+    client_request.get(
+        "main.reports",
+        service_id=ANY,
+    )
+
+
+def test_reports_page_forbidden_for_non_platform_admin(
+    client_request,
+    mock_get_service,
+):
+    client_request.get("main.reports", service_id=ANY, _expected_status=403)
+
+
+def test_get_reports_shows_list_of_reports(
+    client_request,
+    platform_admin_user,
+    mock_reports_data,
+    mocker,
+):
+    mocker.patch("app.reports_api_client.get_reports_for_service", return_value=mock_reports_data)
+    client_request.login(platform_admin_user)
+
+    response = client_request.get(
+        "main.reports",
+        service_id=ANY,
+    )
+
+    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+    reports_table = page.find("table")
+    rows = reports_table.find_all("tr")[1:]  # Skip header row
+
+    assert len(rows) == 3
+    assert "report-1" in rows[0].text
+    assert "ready" in rows[0].text
+    assert "report-2" in rows[1].text
+    assert "expired" in rows[1].text  # Status changed due to expiration
+    assert "report-3" in rows[2].text
+    assert "pending" in rows[2].text
+
+
+def test_generate_report_creates_new_report(
+    client_request,
+    platform_admin_user,
+    mock_reports_data,
+    mocker,
+):
+    mock_request_report = mocker.patch("app.reports_api_client.request_report")
+    mocker.patch("app.reports_api_client.get_reports_for_service", return_value=mock_reports_data)
+    client_request.login(platform_admin_user)
+
+    client_request.post("main.generate_report", service_id=ANY, _expected_status=200)
+
+    mock_request_report.assert_called_once_with(user_id=platform_admin_user["id"], service_id=ANY, report_type="email")
+
+
+def test_get_reports_partials_marks_expired_reports(mock_reports_data):
+    # result = get_reports_partials(mock_reports_data)
+
+    assert mock_reports_data[0]["status"] == "ready"  # Not expired
+    assert mock_reports_data[1]["status"] == "expired"  # Expired
+    assert mock_reports_data[2]["status"] == "pending"  # Not ready, so not expired
+
+
+def test_view_reports_updates_returns_json(
+    client_request,
+    platform_admin_user,
+    mock_reports_data,
+    mocker,
+):
+    mocker.patch("app.reports_api_client.get_reports_for_service", return_value=mock_reports_data)
+    client_request.login(platform_admin_user)
+
+    response = client_request.get_response(
+        "main.view_reports_updates",
+        service_id=ANY,
+    )
+
+    json_response = response.json
+    assert "reports" in json_response
+    assert isinstance(json_response["reports"], str)
+
+    # Parse the HTML in the JSON response
+    reports_html = BeautifulSoup(json_response["reports"], "html.parser")
+    rows = reports_html.find_all("tr")[1:]  # Skip header row
+    assert len(rows) == 3
+
+
+@pytest.mark.parametrize(
+    "report_status,expires_at,expected_status",
+    [
+        ("ready", datetime.now(timezone.utc) + timedelta(days=1), "ready"),
+        ("ready", datetime.now(timezone.utc) - timedelta(days=1), "expired"),
+        ("pending", datetime.now(timezone.utc) - timedelta(days=1), "pending"),
+    ],
+)
+def test_get_reports_partials_status_transitions(report_status, expires_at, expected_status):
+    reports = [{"id": "test-report", "status": report_status, "expires_at": expires_at.isoformat()}]
+
+    # result = get_reports_partials(reports)
+    assert reports[0]["status"] == expected_status


### PR DESCRIPTION
# Summary | Résumé

This PR:
- cleans up the styling on the reports page, it should now match [Figma](https://www.figma.com/design/rzjRLTIzVjM4sHpzI6e0Xl/Reports---Rapports?node-id=133-1465&t=GnIm2JAvf6TN1iwg-4)
- adds missing styles for the "generating" and "error" states
- adds an "expired" state when the report has expired
- adds tests

# Test instructions | Instructions pour tester la modification

TBD