### PR TITLE
Add the current language to the report request

### DIFF
--- a/app/main/views/reports.py
+++ b/app/main/views/reports.py
@@ -1,4 +1,5 @@
 from flask import (
+    current_app,
     flash,
     jsonify,
     render_template,
@@ -7,6 +8,7 @@ from flask import (
 from flask_login import current_user
 
 from app import reports_api_client
+from app.articles import get_current_locale
 from app.main import main
 from app.utils import user_is_platform_admin
 
@@ -24,7 +26,8 @@ def reports(service_id):
 @main.route("/services/<service_id>/reports", methods=["post"])
 @user_is_platform_admin
 def generate_report(service_id):
-    reports_api_client.request_report(user_id=current_user.id, service_id=service_id, report_type="email")
+    current_lang = get_current_locale(current_app)
+    reports_api_client.request_report(user_id=current_user.id, service_id=service_id, language=current_lang, report_type="email")
     flash("Test report has been requested", "default")
     reports = reports_api_client.get_reports_for_service(service_id)
     partials = get_reports_partials(reports)

--- a/app/notify_client/reports_api_client.py
+++ b/app/notify_client/reports_api_client.py
@@ -2,12 +2,13 @@ from app.notify_client import NotifyAdminAPIClient
 
 
 class ReportsApiClient(NotifyAdminAPIClient):
-    def request_report(self, user_id, service_id, report_type, job_id=None):
+    def request_report(self, user_id, service_id, report_type, language, job_id=None):
         data = {
             "requesting_user_id": user_id,
             "service_id": service_id,
             "report_type": report_type,
             "job_id": job_id,
+            "language": language,
         }
         self.post(f"/service/{service_id}/report", data=data)
 

--- a/tests/app/main/views/test_reports.py
+++ b/tests/app/main/views/test_reports.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture
+def mock_reports_data():
+    return [
+        {
+            "id": "report-1",
+            "status": "ready",
+            "expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+            "requesting_user": {
+                "id": "user-1",
+                "name": "Test User",
+            },
+        },
+        {
+            "id": "report-2",
+            "status": "ready",
+            "expires_at": (datetime.now(timezone.utc) - timedelta(days=1)).isoformat(),
+            "requesting_user": {
+                "id": "user-1",
+                "name": "Test User",
+            },
+        },
+        {
+            "id": "report-3",
+            "status": "generating",
+            "expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+            "requesting_user": {
+                "id": "user-1",
+                "name": "Test User",
+            },
+        },
+    ]
+
+
+def test_reports_page_requires_platform_admin(client_request, platform_admin_user, service_one, mocker):
+    client_request.login(platform_admin_user)
+    mocker.patch("app.reports_api_client.get_reports_for_service", return_value=[])
+    client_request.get(
+        "main.reports",
+        service_id=service_one["id"],
+        _expected_status=200,
+    )
+
+
+def test_reports_page_forbidden_for_non_platform_admin(client_request, mocker, service_one):
+    mocker.patch("app.reports_api_client.get_reports_for_service", return_value=[])
+    client_request.get("main.reports", service_id=service_one["id"], _expected_status=403)
+
+
+def test_get_reports_shows_list_of_reports(client_request, platform_admin_user, mock_reports_data, mocker, service_one):
+    mocker.patch("app.reports_api_client.get_reports_for_service", return_value=mock_reports_data)
+    client_request.login(platform_admin_user)
+
+    response = client_request.get("main.reports", service_id=service_one["id"], _expected_status=200)
+
+    reports_table = response.find("table")
+    rows = reports_table.find_all("tr")[1:]  # Skip header row
+    assert len(rows) == 3
+    assert "service one report" in rows[0].text
+    assert "Download before" in rows[0].text
+    assert "service one report" in rows[1].text
+    assert "Deleted at" in rows[1].text  # Status changed due to expiration
+    assert "service one report" in rows[2].text
+    assert "Preparing report" in rows[2].text
+
+
+def test_generate_report_creates_new_report(
+    client_request,
+    platform_admin_user,
+    mock_reports_data,
+    mocker,
+    service_one,
+):
+    mock_request_report = mocker.patch("app.reports_api_client.request_report")
+    mocker.patch("app.reports_api_client.get_reports_for_service", return_value=mock_reports_data)
+    client_request.login(platform_admin_user)
+
+    client_request.post("main.generate_report", service_id=service_one["id"], _expected_status=200)
+
+    mock_request_report.assert_called_once_with(
+        user_id=platform_admin_user["id"], service_id=service_one["id"], report_type="email", language="en"
+    )


### PR DESCRIPTION
# Summary | Résumé

Add the user's current language to the data that is sent when the user requests a report.

* working on https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1846

# Test instructions | Instructions pour tester la modification

- log into the review app
- generate a report
- there should be no errors and the report should be the same as before (the api code to generate the FR report is still in progress)