### PR TITLE
fix: add `servicecanada.gc.ca` to the reply-to safelist

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -69,7 +69,7 @@ class Config(object):
     DEFAULT_SERVICE_LIMIT = env.int("DEFAULT_SERVICE_LIMIT", 50)
     DEFAULT_SMS_DAILY_LIMIT = env.int("DEFAULT_SMS_DAILY_LIMIT", 50)
     DOCUMENTATION_DOMAIN = os.getenv("DOCUMENTATION_DOMAIN", "documentation.notification.canada.ca")
-    REPLY_TO_DOMAINS_SAFELIST = ["canada.ca", "gc.ca", "2Vandenbos.org"]
+    REPLY_TO_DOMAINS_SAFELIST = ["canada.ca", "gc.ca", "2Vandenbos.org", "servicecanada.gc.ca"]
     EMAIL_2FA_EXPIRY_SECONDS = 1_800  # 30 Minutes
     EMAIL_EXPIRY_SECONDS = 3600  # 1 hour
 


### PR DESCRIPTION
# Summary | Résumé

Add `servicecanada.gc.ca` to the reply-to safelist.  In the longer term we need to fix the `*.gc.ca` wildcard that should have handled this.

# Test instructions | Instructions pour tester la modification

- Reply-to addresses with `@servicecanada.gc.ca` should be allowed