### PR TITLE
Set the report filename

### DIFF
--- a/app/main/views/reports.py
+++ b/app/main/views/reports.py
@@ -1,10 +1,13 @@
 from datetime import datetime, timezone
 
+import requests
 from flask import (
+    Response,
     current_app,
     flash,
     jsonify,
     render_template,
+    stream_with_context,
     url_for,
 )
 from flask_login import current_user
@@ -32,6 +35,8 @@ def generate_report(service_id):
     reports_api_client.request_report(user_id=current_user.id, service_id=service_id, language=current_lang, report_type="email")
     flash("Test report has been requested", "default")
     reports = reports_api_client.get_reports_for_service(service_id)
+    for report in reports:
+        report["filename_display"] = get_report_filename(report=report, with_extension=False)
     partials = get_reports_partials(reports)
     return render_template(
         "views/reports/reports.html", partials=partials, updates_url=url_for(".view_reports_updates", service_id=service_id)
@@ -42,6 +47,7 @@ def get_reports_partials(reports):
     for report in reports:
         if report["status"] == "ready" and datetime.fromisoformat(report["expires_at"]) < datetime.now(timezone.utc):
             report["status"] = "expired"
+        report["filename_display"] = get_report_filename(report=report, with_extension=False)
     return {
         "reports": render_template(
             "views/reports/reports-table.html",
@@ -54,5 +60,46 @@ def get_reports_partials(reports):
 @user_is_platform_admin
 def view_reports_updates(service_id):
     reports = reports_api_client.get_reports_for_service(service_id)
-
     return jsonify(**get_reports_partials(reports))
+
+
+@main.route("/services/<service_id>/reports/download/<report_id>", methods=["GET"])
+@user_is_platform_admin
+def download_report_csv(service_id, report_id):
+    """
+    Proxies the report CSV file, allowing the filename to be set via Content-Disposition.
+    The actual filename can be customized later as needed.
+    """
+    # Fetch the report details to get the URL
+    reports = reports_api_client.get_reports_for_service(service_id)
+    report = next((r for r in reports if str(r.get("id")) == str(report_id)), None)
+    if not report or not report.get("url"):
+        return ("Report not found", 404)
+
+    remote_url = report["url"]
+    # Stream the remote CSV file
+    remote_response = requests.get(remote_url, stream=True)
+    if remote_response.status_code != 200:
+        return ("Failed to fetch report file", 502)
+
+    filename = get_report_filename(report)
+    headers = {
+        "Content-Disposition": f'attachment; filename="{filename}"',
+        "Content-Type": remote_response.headers.get("Content-Type", "text/csv"),
+    }
+    return Response(
+        stream_with_context(remote_response.iter_content(chunk_size=8192)),
+        headers=headers,
+        status=200,
+    )
+
+
+def get_report_filename(report, with_extension=True):
+    # Parse the ISO datetime string to a datetime object
+    requested_at = datetime.fromisoformat(report["requested_at"])
+    date_str = requested_at.strftime("%Y-%m-%d")
+    partial_id = report["id"][:8]
+    name = f"{date_str} [{report["language"]}] {partial_id}"
+    if with_extension:
+        name += ".csv"
+    return name

--- a/app/main/views/reports.py
+++ b/app/main/views/reports.py
@@ -17,6 +17,8 @@ from app.articles import get_current_locale
 from app.main import main
 from app.utils import user_is_platform_admin
 
+CHUNK_SIZE = 1024 * 1024  # 1 MB
+
 
 @main.route("/services/<service_id>/reports", methods=["GET"])
 @user_is_platform_admin
@@ -88,7 +90,7 @@ def download_report_csv(service_id, report_id):
         "Content-Type": remote_response.headers.get("Content-Type", "text/csv"),
     }
     return Response(
-        stream_with_context(remote_response.iter_content(chunk_size=8192)),
+        stream_with_context(remote_response.iter_content(chunk_size=CHUNK_SIZE)),
         headers=headers,
         status=200,
     )

--- a/app/templates/views/reports/reports-table.html
+++ b/app/templates/views/reports/reports-table.html
@@ -21,8 +21,7 @@
         </a>
         {% else %}
         <div class="file-list-filename text-gray-grey1" tabindex="0">
-          <span><time class="local-datetime-full">{{item.requested_at}}</time></span>
-          <span> - {{ item.report_type}} - {{ current_service.name }} {{ _("report") }}</span>
+          {{ item.filename_display}}
         </div>
         {% endif %}
         <div class="file-list-hint">

--- a/app/templates/views/reports/reports-table.html
+++ b/app/templates/views/reports/reports-table.html
@@ -16,9 +16,8 @@
     {% call row_heading() %}
       <div class="flex flex-col">
         {% if item.status == "ready" %}
-        <a class="file-list-filename" href="{{ item.url }}">
-          <span><time class="local-datetime-full">{{item.requested_at}}</time></span>
-          <span> - {{ item.report_type}} - {{ current_service.name }} {{ _("report") }}</span>
+        <a class="file-list-filename" href="{{ url_for('main.download_report_csv', service_id=current_service.id, report_id=item.id) }}">
+          {{ item.filename_display}}
         </a>
         {% else %}
         <div class="file-list-filename text-gray-grey1" tabindex="0">

--- a/tests/app/main/views/test_reports.py
+++ b/tests/app/main/views/test_reports.py
@@ -1,15 +1,19 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from freezegun import freeze_time
 
 
 @pytest.fixture
+@freeze_time("2025-01-01 00:01:00.000000")
 def mock_reports_data():
     return [
         {
             "id": "report-1",
             "status": "ready",
+            "language": "en",
             "expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+            "requested_at": datetime.now(timezone.utc).isoformat(),
             "requesting_user": {
                 "id": "user-1",
                 "name": "Test User",
@@ -18,7 +22,9 @@ def mock_reports_data():
         {
             "id": "report-2",
             "status": "ready",
+            "language": "en",
             "expires_at": (datetime.now(timezone.utc) - timedelta(days=1)).isoformat(),
+            "requested_at": datetime.now(timezone.utc).isoformat(),
             "requesting_user": {
                 "id": "user-1",
                 "name": "Test User",
@@ -27,7 +33,9 @@ def mock_reports_data():
         {
             "id": "report-3",
             "status": "generating",
+            "language": "fr",
             "expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+            "requested_at": datetime.now(timezone.utc).isoformat(),
             "requesting_user": {
                 "id": "user-1",
                 "name": "Test User",
@@ -51,6 +59,7 @@ def test_reports_page_forbidden_for_non_platform_admin(client_request, mocker, s
     client_request.get("main.reports", service_id=service_one["id"], _expected_status=403)
 
 
+@freeze_time("2025-01-01 00:01:00.000000")
 def test_get_reports_shows_list_of_reports(client_request, platform_admin_user, mock_reports_data, mocker, service_one):
     mocker.patch("app.reports_api_client.get_reports_for_service", return_value=mock_reports_data)
     client_request.login(platform_admin_user)
@@ -60,11 +69,11 @@ def test_get_reports_shows_list_of_reports(client_request, platform_admin_user, 
     reports_table = response.find("table")
     rows = reports_table.find_all("tr")[1:]  # Skip header row
     assert len(rows) == 3
-    assert "service one report" in rows[0].text
+    assert "2025-01-01 [en] report-1" in rows[0].text
     assert "Download before" in rows[0].text
-    assert "service one report" in rows[1].text
+    assert "2025-01-01 [en] report-2" in rows[1].text
     assert "Deleted at" in rows[1].text  # Status changed due to expiration
-    assert "service one report" in rows[2].text
+    assert "2025-01-01 [fr] report-3" in rows[2].text
     assert "Preparing report" in rows[2].text
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3621,6 +3621,7 @@ class ClientRequest:
         _expected_redirect: str | None = None,
         _test_page_title: bool = True,
         _optional_args: str = "",
+        _return_response: bool = False,
         **endpoint_kwargs,
     ):
         return ClientRequest.get_url(
@@ -3630,6 +3631,7 @@ class ClientRequest:
             _follow_redirects=_follow_redirects,
             _expected_redirect=_expected_redirect,
             _test_page_title=_test_page_title,
+            _return_response=_return_response,
         )
 
     def get_url(
@@ -3639,6 +3641,7 @@ class ClientRequest:
         _follow_redirects: bool = False,
         _expected_redirect: str | None = None,
         _test_page_title: bool = True,
+        _return_response: bool = False,
         **endpoint_kwargs,
     ):
         resp = self.logged_in_client.get(
@@ -3648,6 +3651,8 @@ class ClientRequest:
         assert resp.status_code == _expected_status, resp.location
         if _expected_redirect:
             assert resp.location == _expected_redirect
+        if _return_response:
+            return resp
         page = BeautifulSoup(resp.data.decode("utf-8"), "html.parser")
         if _test_page_title:
             count_of_h1s = len(page.select("h1"))


### PR DESCRIPTION
# Summary | Résumé

This PR:
- updates the report filename to use part of the uuid
- creates a new endpoint so we can set the filename of the downloaded report file
- adds tests for the new endpoint

Figma: https://www.figma.com/design/rzjRLTIzVjM4sHpzI6e0Xl/Reports---Rapports?node-id=349-1286&t=sJAB06ExbITlzDfq-0

# Test instructions | Instructions pour tester la modification

1. open the review app
2. go to the reports page
3. generate a new report
4. download the report
5. verify that the report filename matches the one that is displayed, and matches figma
