### PR TITLE
chore: remove extension that causes crashing on the new macbooks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,6 @@
 				"fill-labs.dependi",
 				"github.copilot",
 				"GitHub.copilot-labs",
-				"mechatroner.rainbow-csv",
 				"ms-azuretools.vscode-docker",
 				"ms-ossdata.vscode-postgresql",
 				"ms-python.black-formatter",


### PR DESCRIPTION
# Summary | Résumé

This PR removes the extension `mechatroner.rainbow-csv` from the dev container.  This seems to have been causing extension host crashes.
