### PR TITLE
debug: add some perf timing logs

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -358,6 +358,21 @@ def aggregate_notifications_stats(template_statistics):
 
 
 def get_dashboard_partials(service_id):
+    import logging
+    import time
+
+    logger = logging.getLogger(__name__)
+    timings = {}
+
+    def time_function(func_name, *args, **kwargs):
+        start = time.time()
+        result = args[0](*args[1:], **kwargs)
+        end = time.time()
+        duration = (end - start) * 1000  # Convert to milliseconds
+        timings[func_name] = duration
+        logger.info(f"TIMING: {func_name} took {duration:.2f}ms")
+        return result
+
     def aggregate_by_type(data, daily_data):
         counts = {"sms": 0, "email": 0, "letter": 0}
         # flatten out this structure to match the above
@@ -373,25 +388,60 @@ def get_dashboard_partials(service_id):
         }
         return counts
 
+    # Time each backend API call
+    start_total = time.time()
+
+    start = time.time()
     all_statistics_weekly = template_statistics_client.get_template_statistics_for_service(service_id, limit_days=7)
+    timings["template_statistics_weekly"] = (time.time() - start) * 1000
+
+    start = time.time()
     template_statistics_weekly = aggregate_template_usage(all_statistics_weekly)
+    timings["aggregate_template_usage"] = (time.time() - start) * 1000
 
     scheduled_jobs, immediate_jobs = [], []
     if job_api_client.has_jobs(service_id):
+        start = time.time()
         scheduled_jobs = job_api_client.get_scheduled_jobs(service_id)
-        immediate_jobs = [add_rate_to_job(job) for job in job_api_client.get_immediate_jobs(service_id)]
+        timings["get_scheduled_jobs"] = (time.time() - start) * 1000
+
+        start = time.time()
+        immediate_jobs_raw = job_api_client.get_immediate_jobs(service_id)
+        timings["get_immediate_jobs"] = (time.time() - start) * 1000
+
+        start = time.time()
+        immediate_jobs = [add_rate_to_job(job) for job in immediate_jobs_raw]
+        timings["add_rate_to_job"] = (time.time() - start) * 1000
 
     # get the daily stats
+    start = time.time()
     dashboard_totals_daily, highest_notification_count_daily, all_statistics_daily = _get_daily_stats(service_id)
+    timings["_get_daily_stats"] = (time.time() - start) * 1000
 
     column_width, max_notifiction_count = get_column_properties(number_of_columns=2)
+
+    start = time.time()
     stats_weekly = aggregate_notifications_stats(all_statistics_weekly)
     dashboard_totals_weekly = (get_dashboard_totals(stats_weekly),)
+    timings["weekly_stats_aggregation"] = (time.time() - start) * 1000
+
+    start = time.time()
     bounce_rate_data = get_bounce_rate_data_from_redis(service_id)
+    timings["get_bounce_rate_data"] = (time.time() - start) * 1000
 
     # get annual data from fact table (all data this year except today)
+    start = time.time()
     annual_data = service_api_client.get_monthly_notification_stats(service_id, get_current_financial_year())
+    timings["get_monthly_notification_stats"] = (time.time() - start) * 1000
+
+    start = time.time()
     annual_data = aggregate_by_type(annual_data, dashboard_totals_daily[0])
+    timings["aggregate_by_type"] = (time.time() - start) * 1000
+
+    # Calculate total time
+    total_time = (time.time() - start_total) * 1000
+    logger.info(f"TIMING: Total get_dashboard_partials execution took {total_time:.2f}ms")
+    logger.info(f"TIMING SUMMARY: {timings}")
 
     return {
         "upcoming": render_template("views/dashboard/_upcoming.html", scheduled_jobs=scheduled_jobs),
@@ -425,6 +475,7 @@ def get_dashboard_partials(service_id):
         "jobs": render_template("views/dashboard/_jobs.html", jobs=immediate_jobs),
         "has_jobs": bool(immediate_jobs),
         "has_scheduled_jobs": bool(scheduled_jobs),
+        "debug_timings": timings,  # Include timings in the response for debugging
     }
 
 


### PR DESCRIPTION
# Summary | Résumé

This PR adds some logging statements to capture the duration of the various queries that happen in the dashboard in order to troubleshoot the slow response times for trial services we are seeing.