### PR TITLE
Fix the report page back link

### DIFF
--- a/app/main/views/reports.py
+++ b/app/main/views/reports.py
@@ -18,13 +18,13 @@ from notifications_utils.timezones import convert_utc_to_local_timezone
 from app import reports_api_client
 from app.articles import get_current_locale
 from app.main import main
-from app.utils import user_has_permissions
+from app.utils import user_is_platform_admin
 
 CHUNK_SIZE = 1024 * 1024  # 1 MB
 
 
 @main.route("/services/<service_id>/reports", methods=["GET"])
-@user_has_permissions("view_activity")
+@user_is_platform_admin
 def reports(service_id):
     reports = reports_api_client.get_reports_for_service(service_id)
     partials = get_reports_partials(reports)
@@ -49,7 +49,7 @@ def reports(service_id):
 
 
 @main.route("/services/<service_id>/reports", methods=["post"])
-@user_has_permissions("view_activity")
+@user_is_platform_admin
 def generate_report(service_id):
     current_lang = get_current_locale(current_app)
     reports_api_client.request_report(user_id=current_user.id, service_id=service_id, language=current_lang, report_type="email")
@@ -88,14 +88,14 @@ def get_reports_partials(reports):
 
 
 @main.route("/services/<service_id>/reports/reports.json")
-@user_has_permissions("view_activity")
+@user_is_platform_admin
 def view_reports_updates(service_id):
     reports = reports_api_client.get_reports_for_service(service_id)
     return jsonify(**get_reports_partials(reports))
 
 
 @main.route("/services/<service_id>/reports/download/<report_id>", methods=["GET"])
-@user_has_permissions("view_activity")
+@user_is_platform_admin
 def download_report_csv(service_id, report_id):
     """
     Proxies the report CSV file, allowing the filename to be set via Content-Disposition.

--- a/app/templates/views/reports/reports.html
+++ b/app/templates/views/reports/reports.html
@@ -10,7 +10,7 @@
 {% block maincolumn_content %}
   {{ page_header(
        _('Delivery reports'),
-       back_link=url_for('main.service_dashboard', service_id=current_service.id)
+       back_link=back_link
      ) }}
 
   <div class="mb-12">

--- a/tests/app/main/views/test_reports.py
+++ b/tests/app/main/views/test_reports.py
@@ -198,35 +198,10 @@ def test_get_report_totals_marks_expired_reports_correctly():
     assert reports[0]["status"] == "expired"
 
 
-def test_reports_stores_back_link_in_session(client_request, active_user_with_permissions, mock_get_reports, mocker, service_one):
-    # Set up a referer URL to simulate coming from another page
-    referer_url = "http://localhost/services/{}/dashboard".format(service_one["id"])
-
-    with client_request.session_transaction() as session:
-        # Make sure no back link exists in the session initially
-        session.pop(f'back_link_{service_one["id"]}_reports', None)
-
-    # Make the request with a referer header
-    client_request.get(
-        "main.reports",
-        service_id=service_one["id"],
-        _expected_status=200,
-        _test_page_title=False,
-        _optional_args="",
-        _return_response=False,
-        headers={"Referer": referer_url},
-    )
-
-    # Check the back link was stored in the session
-    with client_request.session_transaction() as session:
-        assert session[f'back_link_{service_one["id"]}_reports'] == referer_url
-
-
-def test_reports_uses_session_back_link_after_refresh(
-    client_request, active_user_with_permissions, mock_get_reports, mocker, service_one
-):
+def test_reports_uses_session_back_link_after_refresh(client_request, platform_admin_user, mock_get_reports, mocker, service_one):
     # Set up an initial back link in the session
     expected_back_link = "http://localhost/services/{}/dashboard".format(service_one["id"])
+    client_request.login(platform_admin_user)
 
     with client_request.session_transaction() as session:
         session[f'back_link_{service_one["id"]}_reports'] = expected_back_link

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3623,6 +3623,7 @@ class ClientRequest:
         _test_page_title: bool = True,
         _optional_args: str = "",
         _return_response: bool = False,
+        _headers: dict | None = None,
         **endpoint_kwargs,
     ):
         return ClientRequest.get_url(
@@ -3633,6 +3634,7 @@ class ClientRequest:
             _expected_redirect=_expected_redirect,
             _test_page_title=_test_page_title,
             _return_response=_return_response,
+            _headers=_headers,
         )
 
     def get_url(
@@ -3643,11 +3645,13 @@ class ClientRequest:
         _expected_redirect: str | None = None,
         _test_page_title: bool = True,
         _return_response: bool = False,
+        _headers: dict | None = None,
         **endpoint_kwargs,
     ):
         resp = self.logged_in_client.get(
             url,
             follow_redirects=_follow_redirects,
+            headers=_headers,
         )
         assert resp.status_code == _expected_status, resp.location
         if _expected_redirect:


### PR DESCRIPTION
# Summary | Résumé


This PR:
- changes the back link on the report page to use the referring page, and stores it in the user's session so it isn't lost if they refresh the page. The referrer is used because it could be the "sms in the last week", "email in the last week", "job with id=x", and any number of notification status filters.
- adds a test for this 

# Test instructions | Instructions pour tester la modification

1. check the branch out and set `FF_ASYNC_REPORTS=true` in your .env
2. run and go to your "email in the last 7 days page"
3. click the "view reports" link
4. click back from the reports page and make sure you go back to the correct page

Repeat the above steps, but refresh the reports page before you click back.