### PR TITLE
Make the "prepare reports" footer more responsive

### DIFF
--- a/.github/workflows/backstage-catalog-helper.yml
+++ b/.github/workflows/backstage-catalog-helper.yml
@@ -1,8 +1,6 @@
 name: Backstage Catalog Info Helper
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   update-catalog-info:

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -226,3 +226,70 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
     }
   }
 }).call(this);
+
+// Report form handler - prevents page reload and shows spinner immediately
+(function() {
+  "use strict";
+
+  document.addEventListener('DOMContentLoaded', function() {
+    // Find forms containing the "Prepare report" button
+    const reportForms = document.querySelectorAll('form button[name="generate-report"]');
+    
+    if (reportForms.length === 0) return;
+
+    reportForms.forEach(button => {
+      const form = button.closest('form');
+      if (!form) return;
+
+      form.addEventListener('submit', function(event) {
+        if (event.submitter && event.submitter.name === 'generate-report') {
+          event.preventDefault();
+          
+          // Disable the button immediately
+          button.disabled = true;
+          
+          // Show the loading spinner immediately
+          const reportFooterContainer = document.querySelector('.report-footer-container');
+          if (reportFooterContainer) {
+            const spinnerContainer = document.createElement('div');
+            spinnerContainer.className = 'loading-spinner-large';
+            reportFooterContainer.querySelector('.flex-grow-0').prepend(spinnerContainer);
+          }
+          
+          // Get the form data
+          const formData = new FormData(form);
+          
+          // Make sure we're passing the generate-report button name and value
+          formData.append('generate-report', '');
+          
+          // Make the AJAX request
+          fetch(form.action, {
+            method: 'POST',
+            body: formData,
+            headers: {
+              'X-Requested-With': 'XMLHttpRequest',
+              // Don't set Content-Type header - let the browser set it with boundary for multipart/form-data
+            },
+            credentials: 'same-origin' // Include cookies for session authentication
+          }).then(response => {
+            if (!response.ok) {
+              throw new Error('Network response was not ok');
+            }
+            // The ajax-block will automatically update with the new report totals
+            // via its polling mechanism
+          }).catch(error => {
+            console.error('Error preparing report:', error);
+            // Re-enable the button if there was an error
+            button.disabled = false;
+            
+            // Remove the spinner if there was an error
+            if (reportFooterContainer) {
+              const spinner = reportFooterContainer.querySelector('.loading-spinner-large');
+              if (spinner) spinner.remove();
+            }
+          });
+        }
+      });
+    });
+  });
+})();

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -228,24 +228,26 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
 }).call(this);
 
 // Report form handler - prevents page reload and shows spinner immediately
-(function() {
+(function () {
   "use strict";
 
-  document.addEventListener('DOMContentLoaded', function() {
+  document.addEventListener("DOMContentLoaded", function () {
     // Find forms containing the "Prepare report" button
-    const reportForms = document.querySelectorAll('form button[name="generate-report"]');
-    
+    const reportForms = document.querySelectorAll(
+      'form button[name="generate-report"]',
+    );
+
     if (reportForms.length === 0) return;
 
-    reportForms.forEach(button => {
-      const form = button.closest('form');
+    reportForms.forEach((button) => {
+      const form = button.closest("form");
       if (!form) return;
-      
+
       // Track submission state to prevent double submissions
       let isSubmitting = false;
-      
+
       // Add click handler to immediately disable the button
-      button.addEventListener('click', function(e) {
+      button.addEventListener("click", function (e) {
         if (isSubmitting) {
           e.preventDefault();
           return false;
@@ -254,61 +256,68 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
         button.disabled = true;
       });
 
-      form.addEventListener('submit', function(event) {
-        if (event.submitter && event.submitter.name === 'generate-report') {
+      form.addEventListener("submit", function (event) {
+        if (event.submitter && event.submitter.name === "generate-report") {
           event.preventDefault();
-          
+
           // Prevent double submissions
           if (isSubmitting) return false;
           isSubmitting = true;
-          
+
           // Disable the button (redundant but ensures it's disabled)
           button.disabled = true;
-          
+
           // Show the loading spinner immediately
-          const reportFooterContainer = document.querySelector('.report-footer-container');
+          const reportFooterContainer = document.querySelector(
+            ".report-footer-container",
+          );
           if (reportFooterContainer) {
-            const spinnerContainer = document.createElement('div');
-            spinnerContainer.className = 'loading-spinner-large';
-            reportFooterContainer.querySelector('.flex-grow-0').prepend(spinnerContainer);
+            const spinnerContainer = document.createElement("div");
+            spinnerContainer.className = "loading-spinner-large";
+            reportFooterContainer
+              .querySelector(".flex-grow-0")
+              .prepend(spinnerContainer);
           }
-          
+
           // Get the form data
           const formData = new FormData(form);
-          
+
           // Make sure we're passing the generate-report button name and value
-          formData.append('generate-report', '');
-          
+          formData.append("generate-report", "");
+
           // Make the AJAX request
           fetch(form.action, {
-            method: 'POST',
+            method: "POST",
             body: formData,
             headers: {
-              'X-Requested-With': 'XMLHttpRequest',
+              "X-Requested-With": "XMLHttpRequest",
               // Don't set Content-Type header - let the browser set it with boundary for multipart/form-data
             },
-            credentials: 'same-origin' // Include cookies for session authentication
-          }).then(response => {
-            if (!response.ok) {
-              throw new Error('Network response was not ok');
-            }
-            // The ajax-block will automatically update with the new report totals
-            // via its polling mechanism
-            button.disabled = false;
-            isSubmitting = false;
+            credentials: "same-origin", // Include cookies for session authentication
+          })
+            .then((response) => {
+              if (!response.ok) {
+                throw new Error("Network response was not ok");
+              }
+              // The ajax-block will automatically update with the new report totals
+              // via its polling mechanism
+              button.disabled = false;
+              isSubmitting = false;
+            })
+            .catch((error) => {
+              console.error("Error preparing report:", error);
+              // Re-enable the button if there was an error
+              button.disabled = false;
+              isSubmitting = false;
 
-          }).catch(error => {
-            console.error('Error preparing report:', error);
-            // Re-enable the button if there was an error
-            button.disabled = false;
-            isSubmitting = false;
-            
-            // Remove the spinner if there was an error
-            if (reportFooterContainer) {
-              const spinner = reportFooterContainer.querySelector('.loading-spinner-large');
-              if (spinner) spinner.remove();
-            }
-          });
+              // Remove the spinner if there was an error
+              if (reportFooterContainer) {
+                const spinner = reportFooterContainer.querySelector(
+                  ".loading-spinner-large",
+                );
+                if (spinner) spinner.remove();
+              }
+            });
         }
       });
     });

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -254,6 +254,7 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
         }
         // Visual feedback - disable immediately
         button.disabled = true;
+        button.classList.add("disabled");
       });
 
       form.addEventListener("submit", function (event) {
@@ -302,12 +303,14 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
               // The ajax-block will automatically update with the new report totals
               // via its polling mechanism
               button.disabled = false;
+              button.classList.remove("disabled");
               isSubmitting = false;
             })
             .catch((error) => {
               console.error("Error preparing report:", error);
               // Re-enable the button if there was an error
               button.disabled = false;
+              button.classList.remove("disabled");
               isSubmitting = false;
 
               // Remove the spinner if there was an error

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -252,9 +252,6 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
           e.preventDefault();
           return false;
         }
-        // Visual feedback - disable immediately
-        button.disabled = true;
-        button.classList.add("disabled");
       });
 
       form.addEventListener("submit", function (event) {
@@ -264,9 +261,6 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
           // Prevent double submissions
           if (isSubmitting) return false;
           isSubmitting = true;
-
-          // Disable the button (redundant but ensures it's disabled)
-          button.disabled = true;
 
           // Get the form data
           const formData = new FormData(form);
@@ -290,18 +284,12 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
               }
               // The ajax-block will automatically update with the new report totals
               // via its polling mechanism
-              button.disabled = false;
-              button.classList.remove("disabled");
               isSubmitting = false;
             })
             .catch((error) => {
               console.error("Error preparing report:", error);
               // Re-enable the button if there was an error
-              button.disabled = false;
-              button.classList.remove("disabled");
               isSubmitting = false;
-
-            
             });
         }
       });

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -240,12 +240,29 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
     reportForms.forEach(button => {
       const form = button.closest('form');
       if (!form) return;
+      
+      // Track submission state to prevent double submissions
+      let isSubmitting = false;
+      
+      // Add click handler to immediately disable the button
+      button.addEventListener('click', function(e) {
+        if (isSubmitting) {
+          e.preventDefault();
+          return false;
+        }
+        // Visual feedback - disable immediately
+        button.disabled = true;
+      });
 
       form.addEventListener('submit', function(event) {
         if (event.submitter && event.submitter.name === 'generate-report') {
           event.preventDefault();
           
-          // Disable the button immediately
+          // Prevent double submissions
+          if (isSubmitting) return false;
+          isSubmitting = true;
+          
+          // Disable the button (redundant but ensures it's disabled)
           button.disabled = true;
           
           // Show the loading spinner immediately
@@ -277,10 +294,14 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
             }
             // The ajax-block will automatically update with the new report totals
             // via its polling mechanism
+            button.disabled = false;
+            isSubmitting = false;
+
           }).catch(error => {
             console.error('Error preparing report:', error);
             // Re-enable the button if there was an error
             button.disabled = false;
+            isSubmitting = false;
             
             // Remove the spinner if there was an error
             if (reportFooterContainer) {

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -268,18 +268,6 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
           // Disable the button (redundant but ensures it's disabled)
           button.disabled = true;
 
-          // Show the loading spinner immediately
-          const reportFooterContainer = document.querySelector(
-            ".report-footer-container",
-          );
-          if (reportFooterContainer) {
-            const spinnerContainer = document.createElement("div");
-            spinnerContainer.className = "loading-spinner-large";
-            reportFooterContainer
-              .querySelector(".flex-grow-0")
-              .prepend(spinnerContainer);
-          }
-
           // Get the form data
           const formData = new FormData(form);
 
@@ -313,13 +301,7 @@ $(() => $(".banner-dangerous").eq(0).trigger("focus"));
               button.classList.remove("disabled");
               isSubmitting = false;
 
-              // Remove the spinner if there was an error
-              if (reportFooterContainer) {
-                const spinner = reportFooterContainer.querySelector(
-                  ".loading-spinner-large",
-                );
-                if (spinner) spinner.remove();
-              }
+            
             });
         }
       });

--- a/app/templates/components/report-footer.html
+++ b/app/templates/components/report-footer.html
@@ -38,7 +38,7 @@
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
             <button 
                 type="submit" 
-                class="button button-secondary"
+                class="button button-secondary {% if n_generating > 0 %}disabled{% endif %}"
                 name="generate-report" 
                 {% if n_generating > 0 %}disabled{% endif %}
             >

--- a/app/templates/components/report-footer.html
+++ b/app/templates/components/report-footer.html
@@ -3,7 +3,7 @@
     <div class="flex container mx-0 report-footer-container" {% if testid %}data-testid="{{ testid }}"{% endif %}>
         <div class="flex-grow text-small">
             {% if total_reports > 0 %}
-                <div class="text-gray-grey1">
+                <div class="text-gray-grey1" aria-live="polite" aria-label="{{ _('Delivery reports:') }}">
                     {% set parts = [] %}
                     {% if n_generating > 0 %}
                         {% set parts = parts + [_('{} preparing').format(n_generating)] %}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2164,6 +2164,7 @@
 "Give third-party users a unique API key.","Donnez aux utilisateurs tiers et utilisatrices tierces une clé API unique."
 "Rotate keys whenever anyone with key access leaves your team.","Veillez à la rotation des clés dès qu’une personne ayant accès aux clés quitte votre équipe."
 "Delivery reports","Rapports de livraison"
+"Delivery reports:","Rapports de livraison&nbsp;:"
 "Report","Rapport"
 "Preparing report","En préparation"
 "Visit dashboard","Accéder au tableau de bord"


### PR DESCRIPTION
# Summary | Résumé

This PR adds some javascript that adds event listeners to the "prepare report" button and the associated form. These listeners make the loading spinner appear as soon as the button is clicked, and send the form data via AJAX and prevent the page from reloading.

# Test instructions | Instructions pour tester la modification

1. Check out locally
2. set `FF_ASYNC_REPORTS=true` in your .env
3. `npm rub build` , `make run-dev` and hard refresh the "email in last week" page
4. try generating some reports and verify that the page does not reload when the button is clicked and that the loading spinner appears without a delay
 