### PR TITLE
Improve report footer a11y

### DIFF
--- a/app/templates/components/report-footer.html
+++ b/app/templates/components/report-footer.html
@@ -3,7 +3,8 @@
     <div class="flex container mx-0 report-footer-container" {% if testid %}data-testid="{{ testid }}"{% endif %}>
         <div class="flex-grow text-small">
             {% if total_reports > 0 %}
-                <div class="text-gray-grey1" aria-live="polite" aria-label="{{ _('Delivery reports:') }}">
+                <div class="text-gray-grey1" aria-live="polite">
+                    <span class="visually-hidden">{{ _('Delivery reports:') }}</span>
                     {% set parts = [] %}
                     {% if n_generating > 0 %}
                         {% set parts = parts + [_('{} preparing').format(n_generating)] %}

--- a/app/templates/components/report-footer.html
+++ b/app/templates/components/report-footer.html
@@ -3,7 +3,7 @@
     <div class="flex container mx-0 report-footer-container" {% if testid %}data-testid="{{ testid }}"{% endif %}>
         <div class="flex-grow text-small">
             {% if total_reports > 0 %}
-                <div class="text-gray-grey1">
+                <div class="text-gray-grey1" aria-live="polite" aria-label="{{ _('Delivery reports:') }}">
                     {% set parts = [] %}
                     {% if n_generating > 0 %}
                         {% set parts = parts + [_('{} preparing').format(n_generating)] %}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2164,6 +2164,7 @@
 "Give third-party users a unique API key.","Donnez aux utilisateurs tiers et utilisatrices tierces une clé API unique."
 "Rotate keys whenever anyone with key access leaves your team.","Veillez à la rotation des clés dès qu’une personne ayant accès aux clés quitte votre équipe."
 "Delivery reports","Rapports de livraison"
+"Delivery reports:","Rapports de livraison :"
 "Report","Rapport"
 "Preparing report","En préparation"
 "Visit dashboard","Accéder au tableau de bord"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2164,7 +2164,7 @@
 "Give third-party users a unique API key.","Donnez aux utilisateurs tiers et utilisatrices tierces une clé API unique."
 "Rotate keys whenever anyone with key access leaves your team.","Veillez à la rotation des clés dès qu’une personne ayant accès aux clés quitte votre équipe."
 "Delivery reports","Rapports de livraison"
-"Delivery reports:","Rapports de livraison :"
+"Delivery reports:","Rapports de livraison&nbsp;:"
 "Report","Rapport"
 "Preparing report","En préparation"
 "Visit dashboard","Accéder au tableau de bord"


### PR DESCRIPTION
# Summary | Résumé


Add the hidden text "delivery reports" to the footer so it will be read by screenreaders, giving context to the "x ready and y deleted" text:

https://github.com/user-attachments/assets/bd1ada54-5ec9-43a8-b26d-f3acfd52a242

