### PR TITLE
Fix bug where the report url expires early

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -115,6 +115,7 @@ class Config(object):
     PERMANENT_SESSION_LIFETIME = 8 * 60 * 60  # 8 hours
     REDIS_ENABLED = env.bool("REDIS_ENABLED", False)
     REDIS_URL = os.environ.get("REDIS_URL")
+    REPORTS_BUCKET_NAME = os.getenv("REPORTS_BUCKET_NAME", "notification-canada-ca-production-reports")
     ROUTE_SECRET_KEY_1 = os.environ.get("ROUTE_SECRET_KEY_1", "")
     ROUTE_SECRET_KEY_2 = os.environ.get("ROUTE_SECRET_KEY_2", "")
 

--- a/app/main/views/reports.py
+++ b/app/main/views/reports.py
@@ -118,9 +118,7 @@ def download_report_csv(service_id, report_id):
 
         # Stream the data in chunks
         def generate():
-            for chunk in s3download_report_chunks(
-                current_app.config["REPORTS_BUCKET_NAME"], f"reports/{service_id}/{report_id}.csv"
-            ):
+            for chunk in s3download_report_chunks(service_id, report_id):
                 yield chunk
 
         return Response(

--- a/app/s3_client/s3_csv_client.py
+++ b/app/s3_client/s3_csv_client.py
@@ -8,6 +8,10 @@ from notifications_utils.s3 import s3upload as utils_s3upload
 from app.s3_client.s3_logo_client import get_s3_object
 
 FILE_LOCATION_STRUCTURE = "service-{}-notify/{}.csv"
+REPORTS_FILE_LOCATION_STRUCTURE = "service-{}/{}.csv"
+
+# Default chunk size for streaming (1MB)
+CHUNK_SIZE = 1024 * 1024
 
 
 def get_csv_location(service_id, upload_id):
@@ -15,6 +19,10 @@ def get_csv_location(service_id, upload_id):
         current_app.config["CSV_UPLOAD_BUCKET_NAME"],
         FILE_LOCATION_STRUCTURE.format(service_id, upload_id),
     )
+
+
+def get_report_location(service_id, report_id):
+    return REPORTS_FILE_LOCATION_STRUCTURE.format(service_id, report_id)
 
 
 def get_csv_upload(service_id, upload_id):
@@ -40,6 +48,17 @@ def s3download(service_id, upload_id):
         contents = key.get()["Body"].read().decode("utf-8")
     except botocore.exceptions.ClientError as e:
         current_app.logger.error("Unable to download s3 file {}".format(FILE_LOCATION_STRUCTURE.format(service_id, upload_id)))
+        raise e
+    return contents
+
+
+def s3download_report(service_id, report_id):
+    contents = ""
+    try:
+        key = get_report_location(service_id, report_id)
+        contents = key.get()["Body"].read().decode("utf-8")
+    except botocore.exceptions.ClientError as e:
+        current_app.logger.error("Unable to download s3 file {}".format(key))
         raise e
     return contents
 
@@ -71,3 +90,29 @@ def copy_bulk_send_file_to_uploads(service_id, filekey):
     body = obj.get()["Body"].read()
     upload_id = s3upload(service_id, {"data": body}, current_app.config["AWS_REGION"])
     return upload_id
+
+
+def s3download_report_chunks(bucket_name, file_path, chunk_size=CHUNK_SIZE):
+    """
+    Generator function to stream S3 file data in chunks.
+
+    Args:
+        bucket_name: The S3 bucket name
+        file_path: The path to the file in the bucket
+        chunk_size: Size of chunks to read (defaults to 1MB)
+
+    Yields:
+        Chunks of binary data from the S3 file
+    """
+    try:
+        key = get_s3_object(bucket_name, file_path)
+        # Get the S3 object body
+        body = key.get()["Body"]
+        # Read and yield chunks
+        chunk = body.read(chunk_size)
+        while chunk:
+            yield chunk
+            chunk = body.read(chunk_size)
+    except botocore.exceptions.ClientError as e:
+        current_app.logger.error(f"Unable to stream S3 file {bucket_name}/{file_path}")
+        raise e


### PR DESCRIPTION
# Summary | Résumé

Fix a bug where the report url expires early.

We have been using the presigned s3 url that is saved in the db. But it is not actually necessary since the user now no longer downloads the report directly from s3. They download it via the `download_report_csv` endpoint in admin so we can set the appropriate filename. Admin already has access to this bucket, so we can just get the s3 object directly. 

Bug card: https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1898

# Test instructions | Instructions pour tester la modification

We can't test in the review app since it doesn't have the right s3 access. It will only be possible to test the actual bug case in staging (where the report is more than 1 day old).

1. check out locally and run
2. generate a report
3. verify that you can still download it successfully