### PR TITLE
Docker fix

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -7,7 +7,7 @@ ENV POETRY_VIRTUALENVS_CREATE false
 RUN apk add --no-cache bash build-base libxml2-dev libxslt-dev git nodejs npm g++ make libffi-dev rust cargo && rm -rf /var/cache/apk/*
 
 # update pip
-RUN python -m pip install wheel poetry==${POETRY_VERSION}
+RUN python -m pip install wheel poetry==${POETRY_VERSION} virtualenv==20.30.0
 
 # -- Install Application into container:
 RUN set -ex && mkdir /app

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -45,9 +45,9 @@ RUN mkdir -p ${APP_DIR}
 WORKDIR ${APP_DIR}
 
 # Install Poetry and isolate it from the project
-RUN python -m venv ${POETRY_HOME}
+RUN python -m venv ${POETRY_HOME} 
 RUN ${POETRY_HOME}/bin/pip3 install --upgrade pip
-RUN ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION}
+RUN ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION} virtualenv==20.30.0
 
 COPY pyproject.toml poetry.lock ${APP_DIR}/
 


### PR DESCRIPTION
# Summary | Résumé

We had an issue where docker was no longer building images due to wheel not being included in virtualenv. 

Huge kudos to @whabanks who found the issue

```
The latest version of [virtualenv no longer bundles ](https://virtualenv.pypa.io/en/latest/changelog.html)wheel[ wheels](https://virtualenv.pypa.io/en/latest/changelog.html) which is probably why it no longer considers --wheel=bundle as a valid param. I pinned virtualenv to the previous version on lines 19 and 20 in the dockerfile and was able to build the image again:
```
# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.