### PR TITLE
fix: update flash call to make french work properly

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -233,7 +233,7 @@ def user_profile_mobile_number_confirm():
         del session[NEW_MOBILE_PASSWORD_CONFIRMED]
         current_user.update(mobile_number=mobile_number)
 
-        flash(_("Mobile number {} saved to your profile".format(mobile_number)), "default_with_tick")
+        flash(_("Mobile number {} saved to your profile").format(mobile_number), "default_with_tick")
 
         # Check if we are coming from the send page, do cleanup
         from_send_page = session.pop("from_send_page", False)


### PR DESCRIPTION
# Summary | Résumé

This PR fixes a bug where the flash message wasn't getting properly translated, resulting in this when adding a phone number to your profile in french:

# Related cards
* https://github.com/cds-snc/notification-planning/issues/1907

# Test instructions | Instructions pour tester la modification

- Switch app to French
- Go to your profile
- Click **Modifier** by the phone number
- Click the **Modifier le numero** button
- Update your phone number
- Enter your password
- Check your email and enter the confirm code
- [ ] Flash message should say: `Numéro de téléphone mobile XYZ enregistré dans votre profil`