### PR TITLE
Feat/add code resend to mobile update

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -255,6 +255,13 @@ def user_profile_mobile_number_confirm():
     )
 
 
+@main.route("/user-profile/mobile-number/resend", methods=["GET", "POST"])
+def sms_not_received():
+    current_user.send_verify_code(to=session[NEW_MOBILE])
+    flash(_("Verification code re-sent"), "default_with_tick")
+    return redirect(url_for(".user_profile_mobile_number_confirm"))
+
+
 @main.route("/user-profile/password", methods=["GET", "POST"])
 @user_is_logged_in
 def user_profile_password():

--- a/app/templates/views/user-profile/confirm.html
+++ b/app/templates/views/user-profile/confirm.html
@@ -28,7 +28,12 @@
           width='form-control-5em',
           autofocus=True
         ) }}
-        {{ page_footer(_('Confirm'), cancel_button_link=url_for('.user_profile')) }}
+        {{ page_footer(_('Confirm'), cancel_button_link=url_for('.user_profile')) }} 
+        <p class="mt-16">
+          {{ _("Didn’t get a text message?") }}
+          <br />
+          <a href="{{ url_for('main.sms_not_received') }}">{{ _('Re-send security code') }}</a>
+        </p>
       {% endcall %}
     </div>
   </div>

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2195,3 +2195,4 @@
 "{} deleted","{} supprimé"
 "Visit delivery reports","Consulter les rapports de livraison"
 "If you add a number to your profile, you can text yourself test messages. We’ll text you a code to verify this number.","Si vous ajoutez un numéro de téléphone à votre profil, vous pourrez réaliser des tests en envoyant des messages texte à votre propre numéro. Nous vous enverrons un code par message texte pour vérifier ce numéro."
+"Verification code re-sent","Code de vérification renvoyé"


### PR DESCRIPTION
# Summary | Résumé

This PR adds the ability for users to re-send their verification code in the event the first one is not received.

# Test instructions | Instructions pour tester la modification

- Navigate to the user-profile page
- Click **Modify** beside your phone number
- Click **Change number**
- Change your number (or just press save to use the same one)
- Enter your password
- [x] Ensure you receive a verification code
- Click the **Re-send security code** linke
- [x] Ensure you receive a NEW verification code
- Enter the code
- [x] Ensure you see the flash message "Mobile number XXX saved to your profile"