### PR TITLE
fix: dont prompt to enter phone number for email test sends

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -454,7 +454,7 @@ def send_test(service_id, template_id):
         )
 
     # if the user has no phone number, redirect them to the user profile page to update their phone number
-    if not current_user.mobile_number:
+    if db_template["template_type"] == "sms" and not current_user.mobile_number:
         session["from_send_page"] = True
         session["send_page_service_id"] = service_id
         session["send_page_template_id"] = template_id

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3802,3 +3802,28 @@ def test_send_test_redirects_to_user_profile_if_no_mobile_and_ff_on(
             assert session["from_send_page"] is True
             assert session["send_page_service_id"] == service_id
             assert session["send_page_template_id"] == template_id
+
+
+def test_send_test_doesnt_redirect_to_user_profile_if_no_mobile_and_email_and_ff_on(
+    client_request,
+    app_,
+    active_user_no_mobile,
+    mocker,
+    mock_get_service_email_template_without_placeholders,
+):
+    service_id = SERVICE_ONE_ID
+    template_id = TEMPLATE_ONE_ID
+
+    with set_config(app_, "FF_OPTIONAL_PHONE", True):
+        client_request.login(active_user_no_mobile)
+        mock_get_service_email_template_without_placeholders.return_value = {
+            "data": {"id": template_id, "template_type": "email", "name": "Test Template"}
+        }
+
+        response = client_request.get("main.send_test", service_id=service_id, template_id=template_id, _expected_status=302)
+
+        assert url_for("main.user_profile_mobile_number") not in normalize_spaces(response.contents)
+        with client_request.session_transaction() as session:
+            assert "from_send_page" not in session
+            assert "send_page_service_id" not in session
+            assert "send_page_template_id" not in session


### PR DESCRIPTION
# Summary | Résumé

This PR fixes a bug where the user would be prompted to enter their phone number even though they were performing an email test send.

# Test instructions | Instructions pour tester la modification

- remove phone number from your profile page
- open an email template
- click "send yourself this message"
- observe you are now on the "add or change your mobile number" page
- You should be able to send yourself an email without entering a phone number.