### PR TITLE
fix: only allow authenticated users to call sms_not_received endpoint

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -256,6 +256,7 @@ def user_profile_mobile_number_confirm():
 
 
 @main.route("/user-profile/mobile-number/resend", methods=["GET", "POST"])
+@user_is_logged_in
 def sms_not_received():
     current_user.send_verify_code(to=session[NEW_MOBILE])
     flash(_("Verification code re-sent"), "default_with_tick")


### PR DESCRIPTION
# Summary | Résumé

This PR adds a decorator to the `sms_not_received` endpoint since only authenticated users can perform this function, and it will fail if a user is not authenticated.


# Test instructions | Instructions pour tester la modification

- Make an unauthenticated request to  `/user-profile/mobile-number/resend`
- [ ] Ensure you dont get a 500 error 
- [ ] Ensure you get redirected to sign-in
- [ ] 