### PR TITLE
Fix: SMS daily limit check for CSV sending should not use fragments

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -813,10 +813,10 @@ def check_messages(service_id, template_id, upload_id, row_index=2):
         else:
             # if they arent over their limit, and its sms, check if they are over their daily limit
             if data["template"].template_type == "sms":
-                data["send_exceeds_daily_limit"] = data["recipients"].sms_fragment_count > data["sms_parts_remaining"]
+                data["send_exceeds_daily_limit"] = len(data["recipients"]) > data["sms_parts_remaining"]
 
     else:
-        data["send_exceeds_daily_limit"] = data["recipients"].sms_fragment_count > data["sms_parts_remaining"]
+        data["send_exceeds_daily_limit"] = len(data["recipients"]) > data["sms_parts_remaining"]
 
     if (
         data["recipients"].too_many_rows

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -76,7 +76,8 @@ from app.utils import (
 )
 
 
-def daily_sms_fragment_count(service_id):
+def daily_sms_count(service_id):
+    """Get the number of SMS messages (not fragments) sent today for a service."""
     return int(redis_client.get(sms_daily_count_cache_key(service_id)) or "0")
 
 
@@ -663,9 +664,9 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
         if e.status_code != 404:
             raise
 
-    sms_fragments_sent_today = daily_sms_fragment_count(service_id)
+    sms_sent_today = daily_sms_count(service_id)
     emails_sent_today = daily_email_count(service_id)
-    remaining_sms_message_fragments_today = current_service.sms_daily_limit - sms_fragments_sent_today
+    remaining_sms_messages_today = current_service.sms_daily_limit - sms_sent_today
     remaining_email_messages_today = current_service.message_limit - emails_sent_today
 
     contents = s3download(service_id, upload_id)
@@ -675,7 +676,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
     email_reply_to = None
     sms_sender = None
     recipients_remaining_messages = (
-        remaining_email_messages_today if db_template["template_type"] == "email" else remaining_sms_message_fragments_today
+        remaining_email_messages_today if db_template["template_type"] == "email" else remaining_sms_messages_today
     )
 
     if db_template["template_type"] == "email":
@@ -760,7 +761,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
         upload_id=upload_id,
         form=CsvUploadForm(),
         remaining_messages=remaining_email_messages_today,
-        remaining_sms_message_fragments=remaining_sms_message_fragments_today,
+        remaining_sms_message_fragments=remaining_sms_messages_today,
         sms_parts_to_send=sms_parts_to_send,
         is_sms_parts_estimated=is_sms_parts_estimated,
         choose_time_form=choose_time_form,
@@ -798,7 +799,7 @@ def check_messages(service_id, template_id, upload_id, row_index=2):
 
     data["original_file_name"] = SanitiseASCII.encode(data.get("original_file_name", ""))
     data["sms_parts_requested"] = data["stats_daily"]["sms"]["requested"]
-    data["sms_parts_remaining"] = current_service.sms_daily_limit - daily_sms_fragment_count(service_id)
+    data["sms_parts_remaining"] = current_service.sms_daily_limit - daily_sms_count(service_id)
 
     if current_app.config["FF_ANNUAL_LIMIT"]:
         data["send_exceeds_annual_limit"] = False
@@ -1103,7 +1104,7 @@ def _check_notification(service_id, template_id, exception=None):
         sms_parts_data["sms_parts_to_send"] = template.fragment_count
         sms_parts_data["is_sms_parts_estimated"] = False
         sms_parts_data["sms_parts_requested"] = stats_daily["sms"]["requested"]
-        sms_parts_data["sms_parts_remaining"] = current_service.sms_daily_limit - daily_sms_fragment_count(service_id)
+        sms_parts_data["sms_parts_remaining"] = current_service.sms_daily_limit - daily_sms_count(service_id)
         sms_parts_data["send_exceeds_daily_limit"] = sms_parts_data["sms_parts_to_send"] > sms_parts_data["sms_parts_remaining"]
 
     return dict(

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -761,7 +761,7 @@ def _check_messages(service_id, template_id, upload_id, preview_row, letters_as_
         upload_id=upload_id,
         form=CsvUploadForm(),
         remaining_messages=remaining_email_messages_today,
-        remaining_sms_message_fragments=remaining_sms_messages_today,
+        remaining_sms_messages_today=remaining_sms_messages_today,
         sms_parts_to_send=sms_parts_to_send,
         is_sms_parts_estimated=is_sms_parts_estimated,
         choose_time_form=choose_time_form,

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -23,7 +23,7 @@ from notifications_utils.template import LetterImageTemplate, LetterPreviewTempl
 from xlrd.biffh import XLRDError
 from xlrd.xldate import XLDateAmbiguous, XLDateError, XLDateNegative, XLDateTooLarge
 
-from app.main.views.send import daily_email_count, daily_sms_fragment_count
+from app.main.views.send import daily_email_count, daily_sms_count
 from tests import validate_route_permission, validate_route_permission_with_client
 from tests.conftest import (
     SERVICE_ONE_ID,
@@ -56,11 +56,11 @@ test_non_spreadsheet_files = glob(path.join("tests", "non_spreadsheet_files", "*
 
 
 @pytest.mark.parametrize("redis_value,expected_result", [(None, 0), ("3", 3)])
-def test_daily_sms_fragment_count(mocker, redis_value, expected_result):
+def test_daily_sms_count(mocker, redis_value, expected_result):
     mocker.patch(
         "app.extensions.redis_client.get", lambda x: redis_value if x == sms_daily_count_cache_key(SERVICE_ONE_ID) else None
     )
-    assert daily_sms_fragment_count(SERVICE_ONE_ID) == expected_result
+    assert daily_sms_count(SERVICE_ONE_ID) == expected_result
 
 
 @pytest.mark.parametrize("redis_value,expected_result", [(None, 0), ("3", 3)])
@@ -2596,8 +2596,8 @@ def mock_notification_counts_client():
 
 
 @pytest.fixture
-def mock_daily_sms_fragment_count():
-    with patch("app.main.views.send.daily_sms_fragment_count") as mock:
+def mock_daily_sms_count():
+    with patch("app.main.views.send.daily_sms_count") as mock:
         yield mock
 
 
@@ -3427,7 +3427,7 @@ class TestAnnualLimitsSend:
         mock_get_jobs,
         mock_s3_set_metadata,
         mock_notification_counts_client,
-        mock_daily_sms_fragment_count,
+        mock_daily_sms_count,
         mock_daily_email_count,
         fake_uuid,
         num_being_sent,
@@ -3464,7 +3464,7 @@ class TestAnnualLimitsSend:
 
             # mock that we've already sent `emails_sent_today` emails today
             mock_daily_email_count.return_value = num_sent_today
-            mock_daily_sms_fragment_count.return_value = 900  # not used in test but needs a value
+            mock_daily_sms_count.return_value = 900  # not used in test but needs a value
 
             with client_request.session_transaction() as session:
                 session["file_uploads"] = {
@@ -3530,7 +3530,7 @@ class TestAnnualLimitsSend:
         mock_get_jobs,
         mock_s3_set_metadata,
         mock_notification_counts_client,
-        mock_daily_sms_fragment_count,
+        mock_daily_sms_count,
         mock_daily_email_count,
         fake_uuid,
         num_being_sent,
@@ -3565,7 +3565,7 @@ class TestAnnualLimitsSend:
             }
             # mock that we've already sent `num_sent_today` emails today
             mock_daily_email_count.return_value = 900  # not used in test but needs a value
-            mock_daily_sms_fragment_count.return_value = num_sent_today
+            mock_daily_sms_count.return_value = num_sent_today
 
             with client_request.session_transaction() as session:
                 session["file_uploads"] = {


### PR DESCRIPTION
# Summary | Résumé

This PR changes the validation we do when a user uploads a CSV for an sms send. We now just look at the number of rows using the `len` function defined here: https://github.com/cds-snc/notification-utils/blob/main/notifications_utils/recipients.py#L114-L117

The `daily_sms_count` in redis is already being correctly set to the number of sms sent, not to the number of sms fragments.

Bug card: https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1913

# Test instructions | Instructions pour tester la modification

Checkout the branch and run locally.

## Test 1

1. set the daily sms limit for your service to 10
2. create a csv file with 8 sends to the aws success number: 14254147755
3. create a template for your service with the following text (2 sms fragments):
```1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890567890123456789012345678901234567890123456789012345678901234567890```
4. click to send the template to multiple recipients
5. upload the csv file you created in step 2
6. observe that you do not see any error message and that you can send successfully
7. look in Redis and verify that `sms-<service-id>-2025-05-14-count` has a value of `8`

## Test 2

1. create a csv file with 3 sends to the aws success number: 14254147755
2. use the template you created in Test 1
3. click to send the template to multiple recipients
4. upload the csv file you created in step 2
5. observe that you see the following error message and that you are prevented from sending:
> These messages exceed your daily limit
To request a daily limit above 10 text messages, contact us
