### PR TITLE
Add UTF8 info to file upload error message

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -205,7 +205,11 @@ def send_messages(service_id, template_id):
                 )
             )
         except (UnicodeDecodeError, BadZipFile, XLRDError):
-            flash(_("Could not read {}. Try using a different file format.").format(form.file.data.filename))
+            flash(
+                _("Could not read {}. Try using a different file format. Ensure your file is encoded as UTF-8.").format(
+                    form.file.data.filename
+                )
+            )
         except XLDateError:
             flash(
                 _(
@@ -303,7 +307,11 @@ def s3_send(service_id, template_id):
                 )
             )
         except (UnicodeDecodeError, BadZipFile, XLRDError):
-            flash(_("Could not read {}. Try using a different file format.").format(form.s3_files.data))
+            flash(
+                _("Could not read {}. Try using a different file format. Ensure your file is encoded as UTF-8.").format(
+                    form.s3_files.data
+                )
+            )
         except XLDateError:
             flash(
                 _(

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1222,7 +1222,7 @@
 "The security code in the email we sent you has expired. Enter your email address to re-send.","Le code de sécurité que nous vous avons envoyé par courriel a expiré. Entrez votre adresse courriel pour le renvoyer."
 "The security code in the email has already been used","Le code de sécurité envoyé par courriel a déjà été utilisé"
 "Are you sure you want to remove","Êtes-vous certain de vouloir retirer"
-"Could not read {}. Try using a different file format.","{} ne peut pas être lu. Veuillez essayer un format de fichier différent."
+"Could not read {}. Try using a different file format. Ensure your file is encoded as UTF-8.","{} ne peut pas être lu. Veuillez essayer un format de fichier différent. Assurez-vous que votre fichier est encodé en UTF-8."
 "{} contains numbers or dates that GC Notify can’t understand. Try formatting all columns as ‘text’ or export your file as CSV.","{} contient des nombres ou des dates que Notification GC ne peut pas comprendre. Veuillez essayer de modifier le format des colonnes en «&thinsp;texte&thinsp;» ou exportez votre fichier en CSV."
 "Are you sure you want to remove security key {}?","Êtes-vous certain de vouloir retirer la clé de sécurité {}?"
 "You cannot accept an invite for another person.","Vous ne pouvez pas accepter une invitation pour une autre personne."

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -302,7 +302,7 @@ def test_upload_files_in_different_formats(
     else:
         assert not mock_s3_upload.called
         assert normalize_spaces(page.select_one(".banner-dangerous").text) == (
-            "Could not read {}. Try using a different file format.".format(filename)
+            "Could not read {}. Try using a different file format. Ensure your file is encoded as UTF-8.".format(filename)
         )
 
 
@@ -311,15 +311,15 @@ def test_upload_files_in_different_formats(
     [
         (
             partial(UnicodeDecodeError, "codec", b"", 1, 2, "reason"),
-            ("Could not read example.xlsx. Try using a different file format."),
+            ("Could not read example.xlsx. Try using a different file format. Ensure your file is encoded as UTF-8."),
         ),
         (
             BadZipFile,
-            ("Could not read example.xlsx. Try using a different file format."),
+            ("Could not read example.xlsx. Try using a different file format. Ensure your file is encoded as UTF-8."),
         ),
         (
             XLRDError,
-            ("Could not read example.xlsx. Try using a different file format."),
+            ("Could not read example.xlsx. Try using a different file format. Ensure your file is encoded as UTF-8."),
         ),
         (
             XLDateError,


### PR DESCRIPTION
# Summary | Résumé
Adds hint for users to encode their CSV's as UTF-8.

## Before
<img width="1109" alt="image" src="https://github.com/user-attachments/assets/1fff23f3-3552-4c5c-9b99-c8360dfc8f77" />

## After
<img width="1052" alt="image" src="https://github.com/user-attachments/assets/64d963ae-3dd2-4e30-9a0f-31dc9c42cca1" />

# Test instructions | Instructions pour tester la modification
- Do a bulk send with a CSV saved in an invalid encoding (i.e. CP1252)
- [ ] Ensure you see note about UTF8 in the error message
