### PR TITLE
Fix/cypress in devcontainer

### DIFF
--- a/tests_cypress/cypress.config.js
+++ b/tests_cypress/cypress.config.js
@@ -1,7 +1,11 @@
+const fs = require('fs'); 
 const { defineConfig } = require("cypress");
 const EmailAccount = require("./cypress/plugins/email-account");
 const CreateAccount = require("./cypress/plugins/create-account");
 const htmlvalidate = require("cypress-html-validate/plugin");
+
+// determine whether Cypress is running in a Docker container
+const isDocker = fs.existsSync('/.dockerenv');
 
 module.exports = defineConfig({
   e2e: {
@@ -28,9 +32,10 @@ module.exports = defineConfig({
         },
         LOCAL: {
           Hostnames: {
-            API: 'http://localhost:6011',
-            Admin: 'http://localhost:6012',
-            DDAPI: 'http://localhost:7000',
+            // use host.docker.internal to access localhost from a Docker container
+            API: isDocker ? 'http://host.docker.internal:6011' : 'http://localhost:6011',
+            Admin: isDocker ? 'http://host.docker.internal:6012' : 'http://localhost:6012',
+            DDAPI: isDocker ? 'http://host.docker.internal:7000' : 'http://localhost:7000',
           },
         }
       }
@@ -46,7 +51,7 @@ module.exports = defineConfig({
       // Set the baseUrl to the correct environment if no override is specified (this is how CI overrides the baseUrl for each PR review env)
       if (!config.baseUrl)
         config.baseUrl = config.env.Environment[envName].Hostnames.Admin;
-
+      
       htmlvalidate.install(on, {
         rules: {
           "form-dup-name": "off",

--- a/tests_cypress/cypress/plugins/create-account.js
+++ b/tests_cypress/cypress/plugins/create-account.js
@@ -67,8 +67,7 @@ const createAccount = async (baseUrl, username, secret) => {
     
     try {
         // First do cleanup
-        // TODO: figure out why this removes system templates (i.e SMOKE_TEST_EMAIL & SMOKE_TEST_SMS)
-        // await Utilities.makeRequest(cleanupUrl, { ...options, method: 'GET' });
+        await Utilities.makeRequest(cleanupUrl, { ...options, method: 'GET' });
         
         // Then create new account
         const generatedUsername = Utilities.GenerateID(10);


### PR DESCRIPTION
# Summary | Résumé
This PR updates the cypress config to be able to use the correct hostname locally when running in a devcontainer or outside of one.

# Test instructions | Instructions pour tester la modification
- Ensure you can run the cypress tests (`cd tests_cypress; npm run a11y`)
- [ ] inside the devcontainer (headless mode only)
- [ ] outside of the devcontainer 