### PR TITLE
Add redirects for old articles pages

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -367,6 +367,8 @@ def old_page_redirects():
 @main.route("/format", endpoint="formatting_guide")
 @main.route("/messages-status", endpoint="message_delivery_status")
 @main.route("/pourquoi-gc-notification", endpoint="whynotify")
+@main.route("/why-gc-notify", endpoint="whynotify")
+@main.route("/pourquoi-notification-gc", endpoint="whynotify")
 def gca_redirects():
     return redirect(gca_url_for(request.endpoint.replace("main.", "")), code=301)
 


### PR DESCRIPTION
# Summary | Résumé

Add redirects for old articles pages.

# Test instructions | Instructions pour tester la modification

1. open the review app
2. visit the old urls: `/why-gc-notify` and `/pourquoi-notification-gc` and make sure they are redirecting to the new page