### PR TITLE
Remove extra whitespace from the homepage

### DIFF
--- a/app/templates/views/page-content.html
+++ b/app/templates/views/page-content.html
@@ -16,7 +16,7 @@
   {% if slug != "home" %}
     <h1 class="heading-large">{{ title }}</h1>
   {% endif %}
-  <div class="{{ 'space-y-doubleGutter mb-doubleGutter' if slug == 'home' }} page-content {{ slug }}">
+  <div class="page-content {{ slug }}">
     {{ html_content | safe }}
   </div>
   {% if slug == "home" %}


### PR DESCRIPTION
# Summary | Résumé

Remove extra whitespace that is appearing between sections on the homepage.

Before:
<img width="1218" alt="Screenshot 2025-06-17 at 4 41 29 PM" src="https://github.com/user-attachments/assets/12cd2b1f-77c4-4755-bb36-cff4a405c006" />


After:

<img width="1175" alt="Screenshot 2025-06-17 at 4 42 05 PM" src="https://github.com/user-attachments/assets/9a0352da-aaf4-4a1e-a3ce-7929b744423c" />

# Test instructions | Instructions pour tester la modification

Check the review app to verify that the extra whitespace has been removed from the homepage