### PR TITLE
Mark API documentation link as external in navigation

### DIFF
--- a/app/templates/partials/nav/gc_header_nav.html
+++ b/app/templates/partials/nav/gc_header_nav.html
@@ -75,7 +75,7 @@
             {{ nav_menu_item(url='/', localised_txt=_('Home'), css_classes='pl-0 ', id_key='nav-head-home', is_active=header_navigation.is_selected('home')) }}
             {{ nav_menu_item(url=gca_url_for('whynotify'), localised_txt=_('By and for the GC'), id_key='nav-head-why-notify', is_active=header_navigation.is_selected('why-notify')) }}
             {{ nav_menu_item(url=gca_url_for('features'), localised_txt=_('Features'), id_key='nav-head-features', is_active=header_navigation.is_selected('features')) }}
-            {{ nav_menu_item(url=documentation_url(), localised_txt=_('API documentation'), id_key='nav-head-doc', is_active=header_navigation.is_selected('documentation')) }}
+            {{ nav_menu_item(url=documentation_url(), localised_txt=_('API documentation'), id_key='nav-head-doc', is_active=header_navigation.is_selected('documentation'), is_external_link=true) }}
             {{ nav_menu_item(url=gca_url_for('guidance'), localised_txt=_('Guidance'), id_key='nav-head-guidance', is_active=header_navigation.is_selected('guidance')) }}
             {{ nav_menu_item(url=url_for('main.contact'), localised_txt=_('Contact us'), id_key='nav-head-contact', is_active=header_navigation.is_selected('contact')) }}
           {% endif %}


### PR DESCRIPTION
# Summary | Résumé
Indicate API docs menu item as an external link to be consistent with the articles menu.

# Related cards
* https://github.com/cds-snc/notification-planning/issues/1003

# Test instructions | Instructions pour tester la modification
- Ensure the menu items are the same when you are on an articles page (like `/home`) and an admin page (like `/activity`)