### PR TITLE
Changed the TOU continue step to take the next_url

### DIFF
--- a/app/templates/components/tou-prompt.html
+++ b/app/templates/components/tou-prompt.html
@@ -2,7 +2,7 @@
 {% from "components/terms.html" import tou_heading_list %}
 {% from "components/notice.html" import notice %}
 
-{% macro tou_prompt() %}
+{% macro tou_prompt(next_url) %}
 
   <h1 class="heading-large py-1 mt-0 mb-3" tabindex="0" autofocus>{{ _('Before you continue') }}</h1>
 
@@ -52,7 +52,7 @@
     </div>
     <form action="/agree-terms" method="post" class="mt-10">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-      <input type="hidden" name="next" value="{{ request.path }}" />
+      <input type="hidden" name="next" value="{{ next_url }}" />
 
       <div class="flex">
         <button


### PR DESCRIPTION
# Summary | Résumé

When using a security key, we are redirected to the login_events page twice.
The first time it has the TOU instruction, the second time it only has the login_events.

Changed the continue step to explicitly take the `next_url` so that the browser knows what page to go to.
In the previous flow, it redirects to the request.path, which in the case of fido2 is its login page -> it says its authenticated -> so goes to the login_events page (and doesn't have the TOU this time around)

# Test instructions | Instructions pour tester la modification
Go to staging
1. Login
2. Set up your security key
3. Login using your security key
4. You will see two login_event pages (one with the TOU and one without)

Go to the review app
1. Login using your security key
2. you shouldnt see two login event pages
