### PR TITLE
Remove `FF_OPTIONAL_PHONE`

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -81,7 +81,6 @@ class Config(object):
     FF_RTL = env.bool("FF_RTL", True)
     FF_ANNUAL_LIMIT = env.bool("FF_ANNUAL_LIMIT", False)
     FF_CARETAKER = env.bool("FF_CARETAKER", False)
-    FF_OPTIONAL_PHONE = env.bool("FF_OPTIONAL_PHONE", False)
     FF_ASYNC_REPORTS = env.bool("FF_ASYNC_REPORTS", False)
 
     FREE_YEARLY_EMAIL_LIMIT = env.int("FREE_YEARLY_EMAIL_LIMIT", 20_000_000)
@@ -217,7 +216,6 @@ class Test(Development):
     GC_ORGANISATIONS_BUCKET_NAME = "test-gc-organisations"
     FF_RTL = True
     FF_ANNUAL_LIMIT = True
-    FF_OPTIONAL_PHONE = True
 
 
 class ProductionFF(Config):
@@ -243,7 +241,6 @@ class ProductionFF(Config):
     GC_ORGANISATIONS_BUCKET_NAME = "dev-gc-organisations"
     FF_RTL = False
     FF_ANNUAL_LIMIT = False
-    FF_OPTIONAL_PHONE = False
 
 
 class Production(Config):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -406,26 +406,6 @@ class RegisterUserFormOptional(StripWhitespaceForm):
             raise ValidationError(_l("Read and agree to continue"))
 
 
-# TODO: remove this class when FF_OPTIONAL_PHONE is removed
-class RegisterUserFromInviteForm(RegisterUserForm):
-    def __init__(self, invited_user):
-        super().__init__(
-            service=invited_user.service,
-            email_address=invited_user.email_address,
-            auth_type=invited_user.auth_type,
-            name=guess_name_from_email_address(invited_user.email_address),
-        )
-
-    mobile_number = InternationalPhoneNumber(_l("Mobile number"), validators=[])
-    service = HiddenField("service")
-    email_address = HiddenField("email_address")
-    auth_type = HiddenField("auth_type", validators=[DataRequired()])
-
-    def validate_mobile_number(self, field):
-        if self.auth_type.data == "sms_auth" and not field.data:
-            raise ValidationError(_l("This cannot be empty"))
-
-
 class RegisterUserFromInviteFormOptional(RegisterUserForm):
     def __init__(self, invited_user):
         super().__init__(

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -61,8 +61,7 @@ def invite_user(service_id):
         form.login_authentication.data = "sms_auth"
 
     # assume sms_auth - this will be updated when the user provides their phone number or not
-    if current_app.config.get("FF_OPTIONAL_PHONE"):
-        form.login_authentication.data = "email_auth"
+    form.login_authentication.data = "email_auth"
 
     current_app.logger.info(
         "User {} attempting to invite user to service {} using 2FA {}".format(

--- a/app/main/views/register.py
+++ b/app/main/views/register.py
@@ -1,13 +1,11 @@
 from datetime import datetime, timedelta
 
-from flask import abort, current_app, redirect, render_template, session, url_for
+from flask import abort, redirect, render_template, session, url_for
 from flask_login import current_user
 
 from app.main import main
 from app.main.forms import (
-    RegisterUserForm,
     RegisterUserFormOptional,
-    RegisterUserFromInviteForm,
     RegisterUserFromInviteFormOptional,
     RegisterUserFromOrgInviteForm,
 )
@@ -20,10 +18,7 @@ def register():
     if current_user and current_user.is_authenticated:
         return redirect(url_for("main.show_accounts_or_dashboard"))
 
-    if current_app.config.get("FF_OPTIONAL_PHONE"):
-        form = RegisterUserFormOptional()
-    else:
-        form = RegisterUserForm()
+    form = RegisterUserFormOptional()
 
     if form.validate_on_submit():
         _do_registration(form, send_sms=False)
@@ -38,47 +33,30 @@ def register_from_invite():
     if not invited_user:
         abort(404)
 
-    if current_app.config.get("FF_OPTIONAL_PHONE"):
-        form = RegisterUserFromInviteFormOptional(invited_user)
+    form = RegisterUserFromInviteFormOptional(invited_user)
 
-        if form.validate_on_submit():
-            # if no number provided, set auth_type to email
-            if not form.mobile_number.data:
-                form.auth_type.data = "email_auth"
-            else:
-                form.auth_type.data = "sms_auth"
+    if form.validate_on_submit():
+        # if no number provided, set auth_type to email
+        if not form.mobile_number.data:
+            form.auth_type.data = "email_auth"
+        else:
+            form.auth_type.data = "sms_auth"
 
-            if form.service.data != invited_user.service or form.email_address.data != invited_user.email_address:
-                abort(400)
+        if form.service.data != invited_user.service or form.email_address.data != invited_user.email_address:
+            abort(400)
 
-            _do_registration(form, send_email=False, send_sms=True if form.mobile_number.data else False)
+        _do_registration(form, send_email=False, send_sms=True if form.mobile_number.data else False)
 
-            invited_user.accept_invite()
+        invited_user.accept_invite()
 
-            if form.mobile_number.data:
-                return redirect(url_for("main.verify"))
-            else:
-                # we've already proven this user has email because they clicked the invite link,
-                # so just activate them straight away
-                return activate_user(session["user_details"]["id"])
+        if form.mobile_number.data:
+            return redirect(url_for("main.verify"))
+        else:
+            # we've already proven this user has email because they clicked the invite link,
+            # so just activate them straight away
+            return activate_user(session["user_details"]["id"])
 
-        return render_template("views/register-from-invite.html", invited_user=invited_user, form=form)
-    else:
-        form = RegisterUserFromInviteForm(invited_user)
-
-        if form.validate_on_submit():
-            if form.service.data != invited_user.service or form.email_address.data != invited_user.email_address:
-                abort(400)
-            _do_registration(form, send_email=False, send_sms=invited_user.sms_auth)
-            invited_user.accept_invite()
-            if invited_user.sms_auth:
-                return redirect(url_for("main.verify"))
-            else:
-                # we've already proven this user has email because they clicked the invite link,
-                # so just activate them straight away
-                return activate_user(session["user_details"]["id"])
-
-        return render_template("views/register-from-invite.html", invited_user=invited_user, form=form)
+    return render_template("views/register-from-invite.html", invited_user=invited_user, form=form)
 
 
 @main.route("/register-from-org-invite", methods=["GET", "POST"])

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -20,7 +20,6 @@ from app import user_api_client
 from app.main import main
 from app.main.forms import (
     ChangeEmailForm,
-    ChangeMobileNumberForm,
     ChangeMobileNumberFormOptional,
     ChangeNameForm,
     ChangePasswordForm,
@@ -127,13 +126,10 @@ def user_profile_email_confirm(token):
 def user_profile_mobile_number():
     from_send_page = False
 
-    if current_app.config["FF_OPTIONAL_PHONE"]:
-        form = ChangeMobileNumberFormOptional(mobile_number=current_user.mobile_number)
+    form = ChangeMobileNumberFormOptional(mobile_number=current_user.mobile_number)
 
-        # determine if we are coming from the send page
-        from_send_page = session.get("from_send_page", False)
-    else:
-        form = ChangeMobileNumberForm(mobile_number=current_user.mobile_number)
+    # determine if we are coming from the send page
+    from_send_page = session.get("from_send_page", False)
 
     if request.method == "POST":
         # get button presses

--- a/app/templates/views/manage-users/permissions.html
+++ b/app/templates/views/manage-users/permissions.html
@@ -21,17 +21,3 @@
   </p>
 {% endif %}
 
-{% if not config["FF_OPTIONAL_PHONE"] %}
-  {% if service_has_email_auth %}
-    {% set hint_txt = _('Not available because {} has not added a phone&nbsp;number to their profile').format(user and user.name or _('this team member')) %}
-    {% if not mobile_number %}
-      {{ radios(
-        form.login_authentication,
-        disable=['sms_auth'],
-        option_hints={'sms_auth': hint_txt|safe}
-      ) }}
-    {% else %}
-      {{ radios(form.login_authentication) }}
-    {% endif %}
-  {% endif %}
-{% endif %}

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -18,19 +18,10 @@
     </p>
     {% call form_wrapper() %}
       {{ textbox(form.name, width='w-full md:w-3/4') }}
-      {% if config["FF_OPTIONAL_PHONE"] %}
-        {% set txt = _('We’ll send you a security code by text message') %}
-        <div class="extra-tracking">
-          {{ textbox(form.mobile_number, width='w-full md:w-3/4', hint=txt, autocomplete='tel') }}
-        </div>
-      {% else %}
-        {% if invited_user.auth_type == 'sms_auth' %}
-          {% set txt = _('We’ll send you a security code by text message') %}
-          <div class="extra-tracking">
-            {{ textbox(form.mobile_number, width='w-full md:w-3/4', hint=txt, autocomplete='tel') }}
-          </div>
-        {% endif %}
-      {% endif %}
+      {% set txt = _('We’ll send you a security code by text message') %}
+      <div class="extra-tracking">
+        {{ textbox(form.mobile_number, width='w-full md:w-3/4', hint=txt, autocomplete='tel') }}
+      </div>
       {% set txt = _('Must be at least 8 characters and hard to guess') %}
       {{ textbox(form.password, hint=txt, width='w-full md:w-3/4', autocomplete='new-password') }}
       {% set txt = _('Continue') %}

--- a/app/templates/views/user-profile/manage-phones.html
+++ b/app/templates/views/user-profile/manage-phones.html
@@ -32,9 +32,7 @@
                 </div>
             </div>
             <div class="w-full sm:w-1/4 sm:text-right">
-                {% if config["FF_OPTIONAL_PHONE"] %}
-                    <button data-button-id="btn" type="submit" name="remove" value="remove" class="button-link">{{_("Remove")}}</button>
-                {% endif %}
+                <button data-button-id="btn" type="submit" name="remove" value="remove" class="button-link">{{_("Remove")}}</button>
             </div>
         </div>
     </div>

--- a/tests/app/main/test_validation_summary.py
+++ b/tests/app/main/test_validation_summary.py
@@ -2,8 +2,6 @@ import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
 
-from tests.conftest import set_config
-
 register_field_names = ("name", "email_address", "mobile_number", "password")
 
 
@@ -46,20 +44,19 @@ def test_validation_summary(
     expected_errors,
     app_,
 ):
-    with set_config(app_, "FF_OPTIONAL_PHONE", True):  # TODO: REMOVE WHEN FF_OPTIONAL_PHONE IS REMOVED
-        data["tou_agreed"] = "true"
+    data["tou_agreed"] = "true"
 
-        response = client.post(url_for("main.register"), data=data, follow_redirects=True)
-        assert response.status_code == 200
+    response = client.post(url_for("main.register"), data=data, follow_redirects=True)
+    assert response.status_code == 200
 
-        # ensure the validation summary is has as many items as expected
-        page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-        assert len(page.select("[data-testid='validation_summary'] li")) == expected_errors
+    # ensure the validation summary is has as many items as expected
+    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+    assert len(page.select("[data-testid='validation_summary'] li")) == expected_errors
 
-        if expected_errors > 0:
-            # ensure each link in the validation summary point to an element that exists
-            for link in page.select("[data-testid='validation_summary'] li a"):
-                assert len(page.select(f"[id={link['href'][1:]}]")) == 1
-        else:
-            # ensure the validation summary is not present when no errors are expected
-            assert len(page.select("[data-testid='validation_summary']")) == 0
+    if expected_errors > 0:
+        # ensure each link in the validation summary point to an element that exists
+        for link in page.select("[data-testid='validation_summary'] li a"):
+            assert len(page.select(f"[id={link['href'][1:]}]")) == 1
+    else:
+        # ensure the validation summary is not present when no errors are expected
+        assert len(page.select("[data-testid='validation_summary']")) == 0

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
-from tests.conftest import ORGANISATION_ID, captured_templates, normalize_spaces, set_config
+from tests.conftest import ORGANISATION_ID, captured_templates, normalize_spaces
 
 from app.models.user import InvitedOrgUser
 
@@ -375,10 +375,9 @@ class TestOrgInvite:
         fake_uuid,
         app_,
     ):
-        with set_config(app_, "FF_OPTIONAL_PHONE", True):
-            page = client_request.get(
-                ".manage_org_users",
-                org_id=ORGANISATION_ID,
-            )
-            link = page.find("a", class_="button button-secondary", text=lambda x: x and "Invite team member" in x.strip())
-            assert link is None
+        page = client_request.get(
+            ".manage_org_users",
+            org_id=ORGANISATION_ID,
+        )
+        link = page.find("a", class_="button button-secondary", text=lambda x: x and "Invite team member" in x.strip())
+        assert link is None

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -737,9 +737,7 @@ def test_invite_user(
     mock_get_organisations,
     app_,
 ):
-    # default auth w/o FF: "email_auth", default with FF on "sms_auth"
-    # TODO when FF_OPTIONAL_PHONE is removed this can be hardcoded as "email_auth"
-    expected_default_auth = "email_auth" if app_.config["FF_OPTIONAL_PHONE"] is True else "sms_auth"
+    expected_default_auth = "email_auth"
 
     sample_invite["email_address"] = "test@tbs-sct.gc.ca"
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -15,7 +15,6 @@ from tests.conftest import (
     create_active_user_with_permissions,
     normalize_spaces,
     sample_uuid,
-    set_config,
 )
 
 
@@ -213,34 +212,6 @@ def test_should_show_caseworker_on_overview_page(
     )
 
 
-# TODO: remove this test when FF_OPTIONAL_PHONE is removed
-@pytest.mark.parametrize(
-    "endpoint, extra_args, service_has_email_auth, auth_options_hidden",
-    [
-        ("main.edit_user_permissions", {"user_id": sample_uuid()}, True, False),
-        ("main.edit_user_permissions", {"user_id": sample_uuid()}, False, True),
-        ("main.invite_user", {}, True, False),
-        ("main.invite_user", {}, False, True),
-    ],
-)
-def test_service_with_no_email_auth_hides_auth_type_options_REMOVE_FF(
-    client_request,
-    endpoint,
-    extra_args,
-    service_has_email_auth,
-    auth_options_hidden,
-    service_one,
-    mock_get_users_by_service,
-    mock_get_template_folders,
-    app_,
-):
-    with set_config(app_, "FF_OPTIONAL_PHONE", False):
-        if service_has_email_auth:
-            service_one["permissions"].append("email_auth")
-        page = client_request.get(endpoint, service_id=service_one["id"], **extra_args)
-        assert (page.find("input", attrs={"name": "login_authentication"}) is None) == auth_options_hidden
-
-
 @pytest.mark.parametrize(
     "endpoint, extra_args, service_has_email_auth, auth_options_hidden",
     [
@@ -261,9 +232,8 @@ def test_service_with_no_email_auth_hides_auth_type_options(
     mock_get_template_folders,
     app_,
 ):
-    with set_config(app_, "FF_OPTIONAL_PHONE", True):
-        page = client_request.get(endpoint, service_id=service_one["id"], **extra_args)
-        assert (page.find("input", attrs={"name": "login_authentication"}) is None) == auth_options_hidden
+    page = client_request.get(endpoint, service_id=service_one["id"], **extra_args)
+    assert (page.find("input", attrs={"name": "login_authentication"}) is None) == auth_options_hidden
 
 
 @pytest.mark.parametrize("service_has_caseworking", (True, False))
@@ -369,58 +339,6 @@ def test_does_not_show_you_should_have_at_least_two_members_when_user_does_not_h
 
 
 @pytest.mark.parametrize(
-    "sms_option_disabled, mobile_number, expected_label",
-    [
-        (
-            True,
-            None,
-            """
-            Text message code
-            Not available because Test User has not added a
-            phone number to their profile
-        """,
-        ),
-        (
-            False,
-            "9025555555",
-            """
-            Text message code
-        """,
-        ),
-    ],
-)
-def test_user_with_no_mobile_number_cant_be_set_to_sms_auth_REMOVE_FF(
-    client_request,
-    mock_get_users_by_service,
-    mock_get_template_folders,
-    api_user_active,
-    sms_option_disabled,
-    mobile_number,
-    expected_label,
-    service_one,
-    mocker,
-    fake_uuid,
-    active_user_with_permissions,
-    app_,
-):
-    with set_config(app_, "FF_OPTIONAL_PHONE", False):
-        active_user_with_permissions["mobile_number"] = mobile_number
-
-        service_one["permissions"].append("email_auth")
-        mocker.patch("app.user_api_client.get_user", return_value=active_user_with_permissions)
-
-        page = client_request.get(
-            "main.edit_user_permissions",
-            service_id=service_one["id"],
-            user_id=sample_uuid(),
-        )
-
-        sms_auth_radio_button = page.select_one('input[value="sms_auth"]')
-        assert sms_auth_radio_button.has_attr("disabled") == sms_option_disabled
-        assert normalize_spaces(page.select_one("label[for=login_authentication-0]").text) == normalize_spaces(expected_label)
-
-
-@pytest.mark.parametrize(
     "endpoint, extra_args, expected_checkboxes",
     [
         (
@@ -466,31 +384,14 @@ def test_should_show_page_for_one_user(
         assert checkboxes[index].has_attr("checked") == expected_checked
 
 
-# TODO: remove this test when FF_OPTIONAL_PHONE is removed
 def test_invite_user_not_allowed_to_choose_auth(
     client_request, mock_get_users_by_service, mock_get_template_folders, service_one, app_
 ):
-    with set_config(app_, "FF_OPTIONAL_PHONE", True):
-        service_one["permissions"].append("email_auth")
-        page = client_request.get("main.invite_user", service_id=SERVICE_ONE_ID)
+    service_one["permissions"].append("email_auth")
+    page = client_request.get("main.invite_user", service_id=SERVICE_ONE_ID)
 
-        sms_auth_radio_button = page.select_one('input[value="sms_auth"]')
-        assert sms_auth_radio_button is None
-
-
-def test_invite_user_allows_to_choose_auth_REMOVE_FF(
-    client_request,
-    mock_get_users_by_service,
-    mock_get_template_folders,
-    service_one,
-    app_,
-):
-    with set_config(app_, "FF_OPTIONAL_PHONE", False):
-        service_one["permissions"].append("email_auth")
-        page = client_request.get("main.invite_user", service_id=SERVICE_ONE_ID)
-
-        sms_auth_radio_button = page.select_one('input[value="sms_auth"]')
-        assert sms_auth_radio_button.has_attr("disabled") is False
+    sms_auth_radio_button = page.select_one('input[value="sms_auth"]')
+    assert sms_auth_radio_button is None
 
 
 def test_invite_user_has_correct_email_field(
@@ -884,76 +785,6 @@ def test_invite_user(
         app.invite_api_client.create_invite.assert_not_called()
 
 
-# TODO: Remove this test when FF_OPTIONAL_PHONE is removed
-@pytest.mark.parametrize("auth_type", [("sms_auth"), ("email_auth")])
-@pytest.mark.parametrize(
-    "email_address, gov_user",
-    [("test@tbs-sct.gc.ca", True), ("test@nonsafelist.com", False)],
-)
-def test_invite_user_with_email_auth_service_REMOVE_FF(
-    client_request,
-    service_one,
-    active_user_with_permissions,
-    sample_invite,
-    email_address,
-    gov_user,
-    mocker,
-    auth_type,
-    mock_get_organisations,
-    mock_get_template_folders,
-    mock_get_security_keys,
-    app_,
-):
-    with set_config(app_, "FF_OPTIONAL_PHONE", False):
-        service_one["permissions"].append("email_auth")
-        sample_invite["email_address"] = email_address
-
-        assert is_gov_user(email_address) is gov_user
-        mocker.patch("app.models.user.InvitedUsers.client", return_value=[sample_invite])
-        mocker.patch("app.models.user.Users.client", return_value=[active_user_with_permissions])
-        mocker.patch("app.invite_api_client.create_invite", return_value=sample_invite)
-
-        page = client_request.post(
-            "main.invite_user",
-            service_id=SERVICE_ONE_ID,
-            _data={
-                "email_address": email_address,
-                "view_activity": "y",
-                "send_messages": "y",
-                "manage_templates": "y",
-                "manage_service": "y",
-                "manage_api_keys": "y",
-                "login_authentication": auth_type,
-            },
-            _follow_redirects=True,
-            _expected_status=200,
-        )
-
-        if gov_user:
-            assert page.h1.string.strip() == "Team members"
-            flash_banner = page.find("div", class_="banner-default-with-tick").string.strip()
-            assert flash_banner == "Invite sent to test@tbs-sct.gc.ca"
-            expected_permissions = {
-                "manage_api_keys",
-                "manage_service",
-                "manage_templates",
-                "send_messages",
-                "view_activity",
-            }
-
-            app.invite_api_client.create_invite.assert_called_once_with(
-                sample_invite["from_user"],
-                sample_invite["service"],
-                email_address,
-                expected_permissions,
-                auth_type,
-                [],
-            )
-        else:
-            assert page.h1.string.strip() == "Invite a team member"
-            app.invite_api_client.create_invite.assert_not_called()
-
-
 @pytest.mark.parametrize("auth_type", [("sms_auth"), ("email_auth")])
 @pytest.mark.parametrize(
     "email_address, gov_user",
@@ -973,54 +804,53 @@ def test_invite_user_with_email_auth_service(
     mock_get_security_keys,
     app_,
 ):
-    with set_config(app_, "FF_OPTIONAL_PHONE", True):
-        service_one["permissions"].append("email_auth")
-        sample_invite["email_address"] = email_address
+    service_one["permissions"].append("email_auth")
+    sample_invite["email_address"] = email_address
 
-        assert is_gov_user(email_address) is gov_user
-        mocker.patch("app.models.user.InvitedUsers.client", return_value=[sample_invite])
-        mocker.patch("app.models.user.Users.client", return_value=[active_user_with_permissions])
-        mocker.patch("app.invite_api_client.create_invite", return_value=sample_invite)
+    assert is_gov_user(email_address) is gov_user
+    mocker.patch("app.models.user.InvitedUsers.client", return_value=[sample_invite])
+    mocker.patch("app.models.user.Users.client", return_value=[active_user_with_permissions])
+    mocker.patch("app.invite_api_client.create_invite", return_value=sample_invite)
 
-        page = client_request.post(
-            "main.invite_user",
-            service_id=SERVICE_ONE_ID,
-            _data={
-                "email_address": email_address,
-                "view_activity": "y",
-                "send_messages": "y",
-                "manage_templates": "y",
-                "manage_service": "y",
-                "manage_api_keys": "y",
-                "login_authentication": auth_type,
-            },
-            _follow_redirects=True,
-            _expected_status=200,
+    page = client_request.post(
+        "main.invite_user",
+        service_id=SERVICE_ONE_ID,
+        _data={
+            "email_address": email_address,
+            "view_activity": "y",
+            "send_messages": "y",
+            "manage_templates": "y",
+            "manage_service": "y",
+            "manage_api_keys": "y",
+            "login_authentication": auth_type,
+        },
+        _follow_redirects=True,
+        _expected_status=200,
+    )
+
+    if gov_user:
+        assert page.h1.string.strip() == "Team members"
+        flash_banner = page.find("div", class_="banner-default-with-tick").string.strip()
+        assert flash_banner == "Invite sent to test@tbs-sct.gc.ca"
+        expected_permissions = {
+            "manage_api_keys",
+            "manage_service",
+            "manage_templates",
+            "send_messages",
+            "view_activity",
+        }
+
+        app.invite_api_client.create_invite.assert_called_once_with(
+            sample_invite["from_user"],
+            sample_invite["service"],
+            email_address,
+            expected_permissions,
+            "email_auth",
+            [],
         )
-
-        if gov_user:
-            assert page.h1.string.strip() == "Team members"
-            flash_banner = page.find("div", class_="banner-default-with-tick").string.strip()
-            assert flash_banner == "Invite sent to test@tbs-sct.gc.ca"
-            expected_permissions = {
-                "manage_api_keys",
-                "manage_service",
-                "manage_templates",
-                "send_messages",
-                "view_activity",
-            }
-
-            app.invite_api_client.create_invite.assert_called_once_with(
-                sample_invite["from_user"],
-                sample_invite["service"],
-                email_address,
-                expected_permissions,
-                "email_auth",
-                [],
-            )
-        else:
-            assert page.h1.string.strip() == "Invite a team member"
-            app.invite_api_client.create_invite.assert_not_called()
+    else:
+        assert page.h1.string.strip() == "Invite a team member"
+        app.invite_api_client.create_invite.assert_not_called()
 
 
 def test_cancel_invited_user_cancels_user_invitations(

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -6,7 +6,6 @@ from bs4 import BeautifulSoup
 from flask import url_for
 
 from app.models.user import InvitedUser, User
-from tests.conftest import set_config
 
 
 def test_render_register_returns_template_with_form(client):
@@ -107,30 +106,29 @@ def test_register_works_without_phone_number(
     password,
     app_,
 ):
-    with set_config(app_, "FF_OPTIONAL_PHONE", True):
-        user_data = {
-            "name": "Some One Valid",
-            "email_address": "notfound@example.canada.ca",
-            "mobile_number": phone_number_to_register_with,
-            "password": password,
-            "auth_type": "email_auth",
-        }
-        user_data["tou_agreed"] = "true"
+    user_data = {
+        "name": "Some One Valid",
+        "email_address": "notfound@example.canada.ca",
+        "mobile_number": phone_number_to_register_with,
+        "password": password,
+        "auth_type": "email_auth",
+    }
+    user_data["tou_agreed"] = "true"
 
-        response = client.post(url_for("main.register"), data=user_data, follow_redirects=True)
-        assert response.status_code == 200
+    response = client.post(url_for("main.register"), data=user_data, follow_redirects=True)
+    assert response.status_code == 200
 
-        page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-        assert page.select("main p")[0].text == "An email has been sent to notfound@example.canada.ca."
+    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+    assert page.select("main p")[0].text == "An email has been sent to notfound@example.canada.ca."
 
-        mock_send_verify_email.assert_called_with(ANY, user_data["email_address"])
-        mock_register_user.assert_called_with(
-            user_data["name"],
-            user_data["email_address"],
-            None,
-            user_data["password"],
-            user_data["auth_type"],
-        )
+    mock_send_verify_email.assert_called_with(ANY, user_data["email_address"])
+    mock_register_user.assert_called_with(
+        user_data["name"],
+        user_data["email_address"],
+        None,
+        user_data["password"],
+        user_data["auth_type"],
+    )
 
 
 def test_register_continue_handles_missing_session_sensibly(
@@ -386,73 +384,6 @@ def test_register_from_invite_when_user_registers_in_another_browser(
     assert response.location == url_for("main.verify")
 
 
-# TODO: remove this test when FF_OPTIONAL_PHONE is removed
-@pytest.mark.parametrize("invite_email_address", ["gov-user@canada.ca", "non-gov-user@example.com"])
-def test_register_from_email_auth_invite_REMOVE_FF(
-    client,
-    sample_invite,
-    mock_email_is_not_already_in_use,
-    mock_register_user,
-    mock_get_user,
-    mock_send_verify_email,
-    mock_send_verify_code,
-    mock_accept_invite,
-    mock_create_event,
-    mock_add_user_to_service,
-    invite_email_address,
-    fake_uuid,
-    mocker,
-    app_,
-):
-    with set_config(app_, "FF_OPTIONAL_PHONE", False):
-        mock_login_user = mocker.patch("app.models.user.login_user")
-        sample_invite["auth_type"] = "email_auth"
-        sample_invite["email_address"] = invite_email_address
-        with client.session_transaction() as session:
-            session["invited_user"] = sample_invite
-
-        data = {
-            "name": "invited user",
-            "email_address": sample_invite["email_address"],
-            "mobile_number": "6502532222",
-            "password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02",
-            "service": sample_invite["service"],
-            "auth_type": "email_auth",
-        }
-
-        data["tou_agreed"] = "true"
-
-        resp = client.post(url_for("main.register_from_invite"), data=data)
-        assert resp.status_code == 302
-        assert resp.location == url_for("main.service_dashboard", service_id=sample_invite["service"])
-
-        # doesn't send any 2fa code
-        assert not mock_send_verify_email.called
-        assert not mock_send_verify_code.called
-        # creates user with email_auth set
-        mock_register_user.assert_called_once_with(
-            data["name"], data["email_address"], data["mobile_number"], data["password"], data["auth_type"]
-        )
-        mock_accept_invite.assert_called_once_with(sample_invite["service"], sample_invite["id"])
-        # just logs them in
-        mock_login_user.assert_called_once_with(
-            # This ID matches the return value of mock_register_user
-            User({"id": fake_uuid, "platform_admin": False})
-        )
-        mock_add_user_to_service.assert_called_once_with(
-            sample_invite["service"],
-            fake_uuid,  # This ID matches the return value of mock_register_user
-            {"manage_api_keys", "manage_service", "send_messages", "view_activity"},
-            [],
-        )
-
-        assert mock_add_user_to_service.called
-
-        with client.session_transaction() as session:
-            # invited user details are still there so they can get added to the service
-            assert session["invited_user"] == sample_invite
-
-
 @pytest.mark.parametrize("invite_email_address", ["gov-user@canada.ca", "non-gov-user@example.com"])
 def test_register_from_email_auth_invite(
     client,
@@ -470,50 +401,49 @@ def test_register_from_email_auth_invite(
     mocker,
     app_,
 ):
-    with set_config(app_, "FF_OPTIONAL_PHONE", True):  # TODO: remove this line when FF_OPTIONAL_PHONE is removed
-        mock_login_user = mocker.patch("app.models.user.login_user")
-        sample_invite["auth_type"] = "email_auth"
-        sample_invite["email_address"] = invite_email_address
-        with client.session_transaction() as session:
-            session["invited_user"] = sample_invite
+    mock_login_user = mocker.patch("app.models.user.login_user")
+    sample_invite["auth_type"] = "email_auth"
+    sample_invite["email_address"] = invite_email_address
+    with client.session_transaction() as session:
+        session["invited_user"] = sample_invite
 
-        data = {
-            "name": "invited user",
-            "email_address": sample_invite["email_address"],
-            "password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02",
-            "service": sample_invite["service"],
-            "auth_type": "email_auth",
-        }
+    data = {
+        "name": "invited user",
+        "email_address": sample_invite["email_address"],
+        "password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02",
+        "service": sample_invite["service"],
+        "auth_type": "email_auth",
+    }
 
-        data["tou_agreed"] = "true"
+    data["tou_agreed"] = "true"
 
-        resp = client.post(url_for("main.register_from_invite"), data=data)
-        assert resp.status_code == 302
-        assert resp.location == url_for("main.service_dashboard", service_id=sample_invite["service"])
+    resp = client.post(url_for("main.register_from_invite"), data=data)
+    assert resp.status_code == 302
+    assert resp.location == url_for("main.service_dashboard", service_id=sample_invite["service"])
 
-        # doesn't send any 2fa code
-        assert not mock_send_verify_email.called
-        assert not mock_send_verify_code.called
-        # creates user with email_auth set
-        mock_register_user.assert_called_once_with(data["name"], data["email_address"], None, data["password"], data["auth_type"])
-        mock_accept_invite.assert_called_once_with(sample_invite["service"], sample_invite["id"])
-        # just logs them in
-        mock_login_user.assert_called_once_with(
-            # This ID matches the return value of mock_register_user
-            User({"id": fake_uuid, "platform_admin": False})
-        )
-        mock_add_user_to_service.assert_called_once_with(
-            sample_invite["service"],
-            fake_uuid,  # This ID matches the return value of mock_register_user
-            {"manage_api_keys", "manage_service", "send_messages", "view_activity"},
-            [],
-        )
+    # doesn't send any 2fa code
+    assert not mock_send_verify_email.called
+    assert not mock_send_verify_code.called
+    # creates user with email_auth set
+    mock_register_user.assert_called_once_with(data["name"], data["email_address"], None, data["password"], data["auth_type"])
+    mock_accept_invite.assert_called_once_with(sample_invite["service"], sample_invite["id"])
+    # just logs them in
+    mock_login_user.assert_called_once_with(
+        # This ID matches the return value of mock_register_user
+        User({"id": fake_uuid, "platform_admin": False})
+    )
+    mock_add_user_to_service.assert_called_once_with(
+        sample_invite["service"],
+        fake_uuid,  # This ID matches the return value of mock_register_user
+        {"manage_api_keys", "manage_service", "send_messages", "view_activity"},
+        [],
+    )
 
-        assert mock_add_user_to_service.called
+    assert mock_add_user_to_service.called
 
-        with client.session_transaction() as session:
-            # invited user details are still there so they can get added to the service
-            assert session["invited_user"] == sample_invite
+    with client.session_transaction() as session:
+        # invited user details are still there so they can get added to the service
+        assert session["invited_user"] == sample_invite
 
 
 def test_can_register_email_auth_without_phone_number(
@@ -550,51 +480,14 @@ def test_can_register_email_auth_without_phone_number(
     mock_register_user.assert_called_once_with(ANY, ANY, None, ANY, ANY)  # mobile_number
 
 
-# TODO: remove this test when FF_OPTIONAL_PHONE is removed
-def test_cannot_register_with_sms_auth_and_missing_mobile_number_REMOVE_FF(
-    client, mock_send_verify_code, mock_get_user_by_email_not_found, mock_login, app_
-):
-    with set_config(app_, "FF_OPTIONAL_PHONE", False):
-        response = client.post(
-            url_for("main.register"),
-            data={
-                "name": "Missing Mobile",
-                "email_address": "missing_mobile@example.canada.ca",
-                "password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02",
-            },
-        )
-
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-        err = page.select_one(".error-message")
-        assert err.text.strip() == "This cannot be empty"
-        assert err.attrs["data-error-label"] == "mobile_number"
-
-
-# TODO: Remove this test when FF_OPTIONAL_PHONE is removed
-def test_register_from_invite_form_doesnt_show_mobile_number_field_if_email_auth_REMOVE_FF(client, sample_invite, app_):
-    with set_config(app_, "FF_OPTIONAL_PHONE", False):
-        sample_invite["auth_type"] = "email_auth"
-        with client.session_transaction() as session:
-            session["invited_user"] = sample_invite
-
-        response = client.get(url_for("main.register_from_invite"))
-
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-        assert page.find("input", attrs={"name": "auth_type"}).attrs["value"] == "email_auth"
-        assert page.find("input", attrs={"name": "mobile_number"}) is None
-
-
 def test_register_from_invite_form_doesnt_show_mobile_number_field_if_email_auth(client, sample_invite, app_):
-    with set_config(app_, "FF_OPTIONAL_PHONE", True):  # TODO: remove this line when FF_OPTIONAL_PHONE is removed
-        sample_invite["auth_type"] = "email_auth"
-        with client.session_transaction() as session:
-            session["invited_user"] = sample_invite
+    sample_invite["auth_type"] = "email_auth"
+    with client.session_transaction() as session:
+        session["invited_user"] = sample_invite
 
-        response = client.get(url_for("main.register_from_invite"))
+    response = client.get(url_for("main.register_from_invite"))
 
-        assert response.status_code == 200
-        page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
-        assert page.find("input", attrs={"name": "auth_type"}).attrs["value"] == "email_auth"
-        assert page.find("input", attrs={"name": "mobile_number"}) is not None
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+    assert page.find("input", attrs={"name": "auth_type"}).attrs["value"] == "email_auth"
+    assert page.find("input", attrs={"name": "mobile_number"}) is not None

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -3791,17 +3791,16 @@ def test_send_test_redirects_to_user_profile_if_no_mobile_and_ff_on(
     service_id = SERVICE_ONE_ID
     template_id = TEMPLATE_ONE_ID
 
-    with set_config(app_, "FF_OPTIONAL_PHONE", True):
-        client_request.login(active_user_no_mobile)
-        mock_get_service_template.return_value = {"data": {"id": template_id, "template_type": "sms", "name": "Test Template"}}
+    client_request.login(active_user_no_mobile)
+    mock_get_service_template.return_value = {"data": {"id": template_id, "template_type": "sms", "name": "Test Template"}}
 
-        response = client_request.get("main.send_test", service_id=service_id, template_id=template_id, _expected_status=302)
+    response = client_request.get("main.send_test", service_id=service_id, template_id=template_id, _expected_status=302)
 
-        assert url_for("main.user_profile_mobile_number") in normalize_spaces(response.contents)
-        with client_request.session_transaction() as session:
-            assert session["from_send_page"] is True
-            assert session["send_page_service_id"] == service_id
-            assert session["send_page_template_id"] == template_id
+    assert url_for("main.user_profile_mobile_number") in normalize_spaces(response.contents)
+    with client_request.session_transaction() as session:
+        assert session["from_send_page"] is True
+        assert session["send_page_service_id"] == service_id
+        assert session["send_page_template_id"] == template_id
 
 
 def test_send_test_doesnt_redirect_to_user_profile_if_no_mobile_and_email_and_ff_on(
@@ -3814,16 +3813,15 @@ def test_send_test_doesnt_redirect_to_user_profile_if_no_mobile_and_email_and_ff
     service_id = SERVICE_ONE_ID
     template_id = TEMPLATE_ONE_ID
 
-    with set_config(app_, "FF_OPTIONAL_PHONE", True):
-        client_request.login(active_user_no_mobile)
-        mock_get_service_email_template_without_placeholders.return_value = {
-            "data": {"id": template_id, "template_type": "email", "name": "Test Template"}
-        }
+    client_request.login(active_user_no_mobile)
+    mock_get_service_email_template_without_placeholders.return_value = {
+        "data": {"id": template_id, "template_type": "email", "name": "Test Template"}
+    }
 
-        response = client_request.get("main.send_test", service_id=service_id, template_id=template_id, _expected_status=302)
+    response = client_request.get("main.send_test", service_id=service_id, template_id=template_id, _expected_status=302)
 
-        assert url_for("main.user_profile_mobile_number") not in normalize_spaces(response.contents)
-        with client_request.session_transaction() as session:
-            assert "from_send_page" not in session
-            assert "send_page_service_id" not in session
-            assert "send_page_template_id" not in session
+    assert url_for("main.user_profile_mobile_number") not in normalize_spaces(response.contents)
+    with client_request.session_transaction() as session:
+        assert "from_send_page" not in session
+        assert "send_page_service_id" not in session
+        assert "send_page_template_id" not in session

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -14,7 +14,6 @@ from tests.conftest import (
     TEMPLATE_ONE_ID,
     captured_templates,
     create_api_user_active,
-    set_config,
     url_for_endpoint_with_token,
 )
 
@@ -458,28 +457,27 @@ class TestOptionalPhoneNumber:
         mock_send_change_email_verification,
         mock_get_security_keys,
     ):
-        with set_config(app_, "FF_OPTIONAL_PHONE", True):  # REMOVE LINE WHEN FF REMOVED
-            client_request.post(
-                "main.user_profile_mobile_number",
-                _data={"button_pressed": "edit"},
-                _expected_status=200,
-            )
+        client_request.post(
+            "main.user_profile_mobile_number",
+            _data={"button_pressed": "edit"},
+            _expected_status=200,
+        )
 
-            client_request.post(
-                "main.user_profile_mobile_number",
-                _data={"mobile_number": ""},
-                _expected_status=302,
-                _expected_redirect=url_for("main.user_profile_mobile_number_authenticate"),
-            )
+        client_request.post(
+            "main.user_profile_mobile_number",
+            _data={"mobile_number": ""},
+            _expected_status=302,
+            _expected_redirect=url_for("main.user_profile_mobile_number_authenticate"),
+        )
 
-            client_request.post(
-                "main.user_profile_mobile_number_authenticate",
-                _data={"password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02"},
-                _expected_status=302,
-                _expected_redirect=url_for(
-                    "main.user_profile",
-                ),
-            )
+        client_request.post(
+            "main.user_profile_mobile_number_authenticate",
+            _data={"password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02"},
+            _expected_status=302,
+            _expected_redirect=url_for(
+                "main.user_profile",
+            ),
+        )
 
     def test_should_verify_when_phone_number_set(
         self,
@@ -491,37 +489,36 @@ class TestOptionalPhoneNumber:
         mock_send_verify_code,
         mock_check_verify_code,
     ):
-        with set_config(app_, "FF_OPTIONAL_PHONE", True):  # REMOVE LINE WHEN FF REMOVED
-            client_request.post(
-                "main.user_profile_mobile_number",
-                _data={"button_pressed": "edit"},
-                _expected_status=200,
-            )
+        client_request.post(
+            "main.user_profile_mobile_number",
+            _data={"button_pressed": "edit"},
+            _expected_status=200,
+        )
 
-            client_request.post(
-                "main.user_profile_mobile_number",
-                _data={"mobile_number": "6135555555"},
-                _expected_status=302,
-                _expected_redirect=url_for("main.user_profile_mobile_number_authenticate"),
-            )
+        client_request.post(
+            "main.user_profile_mobile_number",
+            _data={"mobile_number": "6135555555"},
+            _expected_status=302,
+            _expected_redirect=url_for("main.user_profile_mobile_number_authenticate"),
+        )
 
-            client_request.post(
-                "main.user_profile_mobile_number_authenticate",
-                _data={"password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02"},
-                _expected_status=302,
-                _expected_redirect=url_for(
-                    "main.user_profile_mobile_number_confirm",
-                ),
-            )
-
-            client_request.post(
+        client_request.post(
+            "main.user_profile_mobile_number_authenticate",
+            _data={"password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02"},
+            _expected_status=302,
+            _expected_redirect=url_for(
                 "main.user_profile_mobile_number_confirm",
-                _data={"two_factor_code": "12345"},
-                _expected_status=302,
-                _expected_redirect=url_for(
-                    "main.user_profile",
-                ),
-            )
+            ),
+        )
+
+        client_request.post(
+            "main.user_profile_mobile_number_confirm",
+            _data={"two_factor_code": "12345"},
+            _expected_status=302,
+            _expected_redirect=url_for(
+                "main.user_profile",
+            ),
+        )
 
     def test_should_skip_sms_verify_when_remove_button_pressed(
         self,
@@ -531,39 +528,37 @@ class TestOptionalPhoneNumber:
         mock_verify_password,
         mock_send_change_email_verification,
     ):
-        with set_config(app_, "FF_OPTIONAL_PHONE", True):  # REMOVE LINE WHEN FF REMOVED
-            client_request.post(
-                "main.user_profile_mobile_number",
-                _data={"button_pressed": "edit"},
-                _expected_status=200,
-            )
+        client_request.post(
+            "main.user_profile_mobile_number",
+            _data={"button_pressed": "edit"},
+            _expected_status=200,
+        )
 
-            client_request.post(
-                "main.user_profile_mobile_number",
-                _data={"remove": "remove"},
-                _expected_status=302,
-                _expected_redirect=url_for("main.user_profile_mobile_number_authenticate"),
-            )
+        client_request.post(
+            "main.user_profile_mobile_number",
+            _data={"remove": "remove"},
+            _expected_status=302,
+            _expected_redirect=url_for("main.user_profile_mobile_number_authenticate"),
+        )
 
-            client_request.post(
-                "main.user_profile_mobile_number_authenticate",
-                _data={"password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02"},
-                _expected_status=302,
-                _expected_redirect=url_for(
-                    "main.user_profile",
-                ),
-            )
+        client_request.post(
+            "main.user_profile_mobile_number_authenticate",
+            _data={"password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02"},
+            _expected_status=302,
+            _expected_redirect=url_for(
+                "main.user_profile",
+            ),
+        )
 
     def test_should_jump_to_edit_page_when_phone_already_blank(
         self, client_request, platform_admin_user, app_, mock_verify_password, mock_send_change_email_verification, mocker
     ):
-        with set_config(app_, "FF_OPTIONAL_PHONE", True):
-            mocker.patch.object(
-                current_user, "update", side_effect=lambda mobile_number: setattr(current_user, "mobile_number", mobile_number)
-            )
-            current_user.update(mobile_number=None)
-            page = client_request.get("main.user_profile_mobile_number", _expected_status=200)
-            assert page.select_one("h1").text.strip() == "Add or change your mobile number"
+        mocker.patch.object(
+            current_user, "update", side_effect=lambda mobile_number: setattr(current_user, "mobile_number", mobile_number)
+        )
+        current_user.update(mobile_number=None)
+        page = client_request.get("main.user_profile_mobile_number", _expected_status=200)
+        assert page.select_one("h1").text.strip() == "Add or change your mobile number"
 
     def test_get_user_profile_mobile_from_send_page_shows_correct_message(
         self,
@@ -572,20 +567,19 @@ class TestOptionalPhoneNumber:
         mocker,
         active_user_no_mobile,
     ):
-        with set_config(app_, "FF_OPTIONAL_PHONE", True):
-            client_request.login(active_user_no_mobile)
-            with client_request.session_transaction() as session:
-                session["from_send_page"] = True
-                session["send_page_service_id"] = SERVICE_ONE_ID
-                session["send_page_template_id"] = TEMPLATE_ONE_ID
+        client_request.login(active_user_no_mobile)
+        with client_request.session_transaction() as session:
+            session["from_send_page"] = True
+            session["send_page_service_id"] = SERVICE_ONE_ID
+            session["send_page_template_id"] = TEMPLATE_ONE_ID
 
-            with captured_templates(app_) as templates:
-                page = client_request.get("main.user_profile_mobile_number")
+        with captured_templates(app_) as templates:
+            page = client_request.get("main.user_profile_mobile_number")
 
-                # assert page.status_code == 200
-                assert templates[0][0].name == "views/user-profile/change.html"
-                assert templates[0][1]["from_send_page"] is True
-                assert "If you add a number to your profile, you can text yourself test messages." in page.text
+            # assert page.status_code == 200
+            assert templates[0][0].name == "views/user-profile/change.html"
+            assert templates[0][1]["from_send_page"] is True
+            assert "If you add a number to your profile, you can text yourself test messages." in page.text
 
     def test_post_user_profile_mobile_number_confirm_redirects_to_send_test_when_from_send_page(
         self,
@@ -596,31 +590,30 @@ class TestOptionalPhoneNumber:
         mock_update_user_attribute,
         mock_check_verify_code,
     ):
-        with set_config(app_, "FF_OPTIONAL_PHONE", True):
-            client_request.login(active_user_no_mobile)
-            mocker.patch("app.user_api_client.get_user", return_value=active_user_no_mobile)
+        client_request.login(active_user_no_mobile)
+        mocker.patch("app.user_api_client.get_user", return_value=active_user_no_mobile)
 
-            with client_request.session_transaction() as session:
-                session["new-mob-password-confirmed"] = True
-                session["new-mob"] = "+16502532222"
-                session["from_send_page"] = True
-                session["send_page_service_id"] = SERVICE_ONE_ID
-                session["send_page_template_id"] = TEMPLATE_ONE_ID
+        with client_request.session_transaction() as session:
+            session["new-mob-password-confirmed"] = True
+            session["new-mob"] = "+16502532222"
+            session["from_send_page"] = True
+            session["send_page_service_id"] = SERVICE_ONE_ID
+            session["send_page_template_id"] = TEMPLATE_ONE_ID
 
-            client_request.post(
-                "main.user_profile_mobile_number_confirm",
-                _data={"two_factor_code": "12345"},
-                _expected_status=302,
-                _expected_redirect=url_for(
-                    "main.send_test",
-                    service_id=SERVICE_ONE_ID,
-                    template_id=TEMPLATE_ONE_ID,
-                ),
-            )
-            with client_request.session_transaction() as session:
-                assert "from_send_page" not in session
-                assert "send_page_service_id" not in session
-                assert "send_page_template_id" not in session
+        client_request.post(
+            "main.user_profile_mobile_number_confirm",
+            _data={"two_factor_code": "12345"},
+            _expected_status=302,
+            _expected_redirect=url_for(
+                "main.send_test",
+                service_id=SERVICE_ONE_ID,
+                template_id=TEMPLATE_ONE_ID,
+            ),
+        )
+        with client_request.session_transaction() as session:
+            assert "from_send_page" not in session
+            assert "send_page_service_id" not in session
+            assert "send_page_template_id" not in session
 
     def test_post_user_profile_mobile_number_confirm_redirects_to_profile_page_by_default(
         self,
@@ -631,23 +624,22 @@ class TestOptionalPhoneNumber:
         mock_update_user_attribute,
         mock_check_verify_code,
     ):
-        with set_config(app_, "FF_OPTIONAL_PHONE", True):
-            client_request.login(active_user_no_mobile)
-            mocker.patch("app.user_api_client.get_user", return_value=active_user_no_mobile)
+        client_request.login(active_user_no_mobile)
+        mocker.patch("app.user_api_client.get_user", return_value=active_user_no_mobile)
 
-            with client_request.session_transaction() as session:
-                session["new-mob-password-confirmed"] = True
-                session["new-mob"] = "+16502532222"
-                # Ensure these are not set for this test case
-                session.pop("from_send_page", None)
-                session.pop("send_page_service_id", None)
-                session.pop("send_page_template_id", None)
+        with client_request.session_transaction() as session:
+            session["new-mob-password-confirmed"] = True
+            session["new-mob"] = "+16502532222"
+            # Ensure these are not set for this test case
+            session.pop("from_send_page", None)
+            session.pop("send_page_service_id", None)
+            session.pop("send_page_template_id", None)
 
-            client_request.post(
-                "main.user_profile_mobile_number_confirm",
-                _data={"two_factor_code": "12345"},
-                _expected_status=302,
-                _expected_redirect=url_for("main.user_profile"),
-            )
-            with client_request.session_transaction() as session:
-                assert session["_flashes"][0][1] == "Mobile number +16502532222 saved to your profile"
+        client_request.post(
+            "main.user_profile_mobile_number_confirm",
+            _data={"two_factor_code": "12345"},
+            _expected_status=302,
+            _expected_redirect=url_for("main.user_profile"),
+        )
+        with client_request.session_transaction() as session:
+            assert session["_flashes"][0][1] == "Mobile number +16502532222 saved to your profile"


### PR DESCRIPTION
# Summary | Résumé

Remove `FF_OPTIONAL_PHONE`
We used this feature flag for the auth v1 release. Let's clean it up before we move on to auth v2.

# Test instructions | Instructions pour tester la modification

1. open the review app
2. you should be able to create a new account without providing a phone number