### PR TITLE
Fix: dont make numbers clickable as phone numbers on mobile

### DIFF
--- a/app/templates/main_template.html
+++ b/app/templates/main_template.html
@@ -7,6 +7,7 @@
 ><!--<![endif]-->
 <head>
   <meta charset="utf-8"/>
+  <meta name="format-detection" content="telephone=no"/>
   <title>{% block page_title %}Notification{% endblock %}</title>
   {% include 'partials/newrelic-head.html' %}
   {% include 'partials/google-tag-manager-head.html' %}


### PR DESCRIPTION
# Summary | Résumé
Mobile safari is making it so that some of our statistics are clickable as phone numbers.  This fixes it so that no content across the site will be clickable as a phone number, since we don't have any phone numbers anywhere on the site.

# Test instructions | Instructions pour tester la modification
- On a phone running safari, visit the home page in french and ensure none of the statistics are clickable.
