### PR TITLE
Fix job report availability by retention

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -186,6 +186,7 @@ class Development(Config):
     DEBUG = True
     DEBUG_KEY = "debug"
     MOU_BUCKET_NAME = "notify.tools-mou"
+    REPORTS_BUCKET_NAME = os.getenv("REPORTS_BUCKET_NAME", "notification-canada-ca-staging-reports")
     REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
     SECRET_KEY = env.list("SECRET_KEY", ["dev-notify-secret-key"])
     SESSION_COOKIE_SECURE = False

--- a/app/templates/views/reports/reports-table.html
+++ b/app/templates/views/reports/reports-table.html
@@ -1,6 +1,6 @@
 {% from "components/table.html" import list_table, field, right_aligned_field_heading, row_heading %}
 {% from "components/empty-list.html" import empty_list  %}
-  
+
   {% set heading_1 = _('Report') %}
   {% set heading_2 = right_aligned_field_heading(_('Status')) %}
   {% set empty_txt = empty_list(
@@ -11,7 +11,7 @@
       _('Visit dashboard'))
   %}
   <div class='reports-table'>
-  
+
   {% call(item, row_number) list_table(
     reports,
     caption="Recent activity",
@@ -41,7 +41,7 @@
         </div>
       </div>
     {% endcall %}
-    
+
     {% call field(align='right') %}
       <div class="flex flex-col justify-end">
         <div class="mb-4">
@@ -58,11 +58,15 @@
                 {{ _("Download before") }}
                 <span><time class="local-datetime-short">{{item.expires_at}}</time></span>
             </div>
+        {% elif item.status == "retention_exceeded" %}
+            <div class="file-list-hint">
+                {{ _("Unavailable. Report includes expired data.") }}
+            </div>
         {% elif item.status == "error" %}
           <div class="file-list-hint text-red">{{ _("Failed. Try again") }}</div>
         {% elif item.status == "expired" %}
           <div class="file-list-hint text-red">
-            {{ _("Deleted at") }} 
+            {{ _("Deleted at") }}
             <span><time class="local-datetime-short">{{item.expires_at}}</time></span>
           </div>
         {% else %}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2210,3 +2210,4 @@
 "Code by text message","FR Code by text message"
 "Security key","FR Security key"
 "Contact number","FR Contact number"
+"Unavailable. Report includes expired data.","Indisponible. Le rapport comprend des données périmées."

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -197,6 +197,7 @@ def service_json(
     organisation_type="central",
     prefix_sms=True,
     contact_link=None,
+    data_retention=None,
     organisation_id=None,
     sending_domain=None,
     go_live_user=None,
@@ -209,6 +210,8 @@ def service_json(
         permissions = ["email", "sms"]
     if inbound_api is None:
         inbound_api = []
+    if data_retention is None:
+        data_retention = []
     service_dict = {
         "id": id_,
         "name": name,
@@ -246,6 +249,7 @@ def service_json(
         "go_live_user": go_live_user,
         "organisation_notes": organisation_notes,
         "sensitive_service": sensitive_service,
+        "data_retention": data_retention,
     }
     service: Service = dotdict(service_dict)
     return service
@@ -683,5 +687,5 @@ def assert_url_expected(actual: str, expected: str):
             assert parse_qs(expected_parts.query) == parse_qs(actual_parts.query)
         else:
             assert getattr(actual_parts, attribute) == getattr(expected_parts, attribute), (
-                "Expected redirect: {}\n" "Actual redirect: {}"
+                "Expected redirect: {}\nActual redirect: {}"
             ).format(expected, actual)

--- a/tests/app/s3_client/test_s3_csv_client.py
+++ b/tests/app/s3_client/test_s3_csv_client.py
@@ -1,8 +1,10 @@
 from unittest.mock import Mock
 
+import pytest
+from botocore.exceptions import ClientError
 from flask import current_app
 
-from app.s3_client.s3_csv_client import set_metadata_on_csv_upload
+from app.s3_client.s3_csv_client import get_report_metadata, set_metadata_on_csv_upload
 
 
 def test_sets_metadata(client, mocker):
@@ -21,3 +23,57 @@ def test_sets_metadata(client, mocker):
         MetadataDirective="REPLACE",
         ServerSideEncryption="AES256",
     )
+
+
+def test_get_report_metadata_returns_metadata(mocker, client, mock_current_app):
+    mock_key = Mock()
+    mock_key.metadata = {"foo": "bar"}
+    mock_get_s3_object = mocker.patch(
+        "app.s3_client.s3_csv_client.get_s3_object",
+        return_value=mock_key,
+    )
+    result = get_report_metadata("service_id", "report_id")
+    mock_get_s3_object.assert_called_once_with("test-bucket", mocker.ANY)
+    assert result == {"foo": "bar"}
+
+
+def test_get_report_metadata_returns_empty_dict_when_no_metadata(mocker, client, mock_current_app):
+    mock_key = Mock()
+    mock_key.metadata = None
+    mocker.patch(
+        "app.s3_client.s3_csv_client.get_s3_object",
+        return_value=mock_key,
+    )
+    result = get_report_metadata("service_id", "report_id")
+    assert result == {}
+
+
+def test_get_report_metadata_returns_none_on_404(mocker, client, mock_current_app):
+    error = ClientError(error_response={"Error": {"Code": "404"}}, operation_name="GetObject")
+    mocker.patch(
+        "app.s3_client.s3_csv_client.get_s3_object",
+        side_effect=error,
+    )
+    mock_logger = mock_current_app.logger
+    result = get_report_metadata("service_id", "report_id")
+    assert result is None
+    assert mock_logger.info.called
+
+
+def test_get_report_metadata_raises_other_client_error(mocker, client, mock_current_app):
+    error = ClientError(error_response={"Error": {"Code": "500"}}, operation_name="GetObject")
+    mocker.patch(
+        "app.s3_client.s3_csv_client.get_s3_object",
+        side_effect=error,
+    )
+    mock_logger = mock_current_app.logger
+    with pytest.raises(ClientError):
+        get_report_metadata("service_id", "report_id")
+    assert mock_logger.error.called
+
+
+@pytest.fixture
+def mock_current_app(mocker):
+    mock_app = mocker.patch("app.s3_client.s3_csv_client.current_app")
+    mock_app.config = {"REPORTS_BUCKET_NAME": "test-bucket"}
+    return mock_app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3716,6 +3716,16 @@ def normalize_spaces(input):
     return normalize_spaces(" ".join(item.text for item in input))
 
 
+@pytest.fixture
+def mock_get_report_metadata(mocker):
+    return mocker.patch("app.main.views.reports.get_report_metadata")
+
+
+@pytest.fixture
+def mock_get_service_retention(mocker):
+    return mocker.patch("app.main.views.reports.get_service_retention", return_value=7)
+
+
 @pytest.fixture(scope="function")
 def mock_get_service_data_retention(mocker):
     data = {


### PR DESCRIPTION
# Summary | Résumé
- Services can no longer download job reports that contain notification data older than their retention period. This applies to services with retention periods <= 3 days
- Add inline hints to indicate why the service can no longer access a given job report


# Test instructions | Instructions pour tester la modification
TODO