### PR TITLE
Prevent report gen on jobs older than retention

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -81,7 +81,6 @@ class Config(object):
     FF_RTL = env.bool("FF_RTL", True)
     FF_ANNUAL_LIMIT = env.bool("FF_ANNUAL_LIMIT", False)
     FF_CARETAKER = env.bool("FF_CARETAKER", False)
-    FF_ASYNC_REPORTS = env.bool("FF_ASYNC_REPORTS", False)
     FF_AUTH_V2 = env.bool("FF_AUTH_V2", False)
 
     FREE_YEARLY_EMAIL_LIMIT = env.int("FREE_YEARLY_EMAIL_LIMIT", 20_000_000)

--- a/app/config.py
+++ b/app/config.py
@@ -81,6 +81,7 @@ class Config(object):
     FF_RTL = env.bool("FF_RTL", True)
     FF_ANNUAL_LIMIT = env.bool("FF_ANNUAL_LIMIT", False)
     FF_CARETAKER = env.bool("FF_CARETAKER", False)
+    FF_ASYNC_REPORTS = env.bool("FF_ASYNC_REPORTS", False)
     FF_AUTH_V2 = env.bool("FF_AUTH_V2", False)
 
     FREE_YEARLY_EMAIL_LIMIT = env.int("FREE_YEARLY_EMAIL_LIMIT", 20_000_000)

--- a/app/templates/partials/jobs/notifications_header.html
+++ b/app/templates/partials/jobs/notifications_header.html
@@ -2,7 +2,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/problem-email-checkbox.html" import problem_email_checkbox %}
 
-<div class="ajax-block-container" aria-labelledby='pill-selected-item'> 
+<div class="ajax-block-container" aria-labelledby='pill-selected-item'>
   {% if job.job_status == 'scheduled' %}
     {% set btn_txt = _('Cancel scheduled send') %}
     <div class="page-footer">
@@ -17,7 +17,7 @@
     <div class="mb-12 clear-both contain-floats">
       {{ problem_email_checkbox() }}
     </div>
-    {% if notifications %}
+    {% if notifications and not config["FF_ASYNC_REPORTS"] %}
       <div class="dashboard-table mt-12 mb-12 clear-both contain-floats">
         {% if percentage_complete < 100 %}
           {{ _('Report is') }} {{ "{:.0f}%".format(percentage_complete * 0.99) }} {{ _('complete…') }}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -98,8 +98,8 @@
       {% else %}
 
       {{ empty_list(
-          _("GC Notify disposed of the information in this report on <time class='local-datetime-short'>{}</time>").format(job.updated_at), 
-          _('After {} days, we keep only non-identifying statistics.').format(svc_retention_days), 
+          _("GC Notify disposed of the information in this report on <time class='local-datetime-short'>{}</time>").format(job.updated_at),
+          _('After {} days, we keep only non-identifying statistics.').format(svc_retention_days),
           'emptyBirdHole'
         )
       }}
@@ -117,17 +117,17 @@
     {% else %}
       <div>&nbsp;</div>
     {% endif %}
-  
-    {% if config["FF_ASYNC_REPORTS"] %}
-    <div class="js-stick-at-bottom-when-scrolling" >
-      {% call form_wrapper(action=action) %}
-        {{ ajax_block(
-          partials,
-          url_for('.view_reports_updates', service_id=current_service.id),
-          'report-footer',
-        ) }}
-      {% endcall %}
-    </div>
+
+    {% if not job.archived %}
+      <div class="js-stick-at-bottom-when-scrolling" >
+        {% call form_wrapper(action=action) %}
+          {{ ajax_block(
+            partials,
+            url_for('.view_reports_updates', service_id=current_service.id),
+            'report-footer',
+          ) }}
+        {% endcall %}
+      </div>
     {% endif %}
 
 {% endblock %}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -118,7 +118,7 @@
       <div>&nbsp;</div>
     {% endif %}
 
-    {% if not job.archived %}
+    {% if not job.archived and config["FF_ASYNC_REPORTS"] %}
       <div class="js-stick-at-bottom-when-scrolling" >
         {% call form_wrapper(action=action) %}
           {{ ajax_block(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -456,6 +456,7 @@ def job_json(
     job_status="finished",
     scheduled_for="",
     api_key=None,
+    archived=False,
 ):
     if job_id is None:
         job_id = str(generate_uuid())
@@ -482,6 +483,7 @@ def job_json(
         ),
         "scheduled_for": scheduled_for,
         "api_key": api_key,
+        "archived": archived,
     }
     return data
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -15,6 +15,7 @@ from tests.conftest import (
     create_template,
     mock_get_notifications,
     normalize_spaces,
+    set_config,
 )
 
 
@@ -199,15 +200,6 @@ def test_should_show_page_for_one_job(
         status=status_argument,
         pe_filter="",
     )
-    csv_link = page.select_one("a[download]")
-    assert csv_link["href"] == url_for(
-        "main.view_job_csv",
-        service_id=SERVICE_ONE_ID,
-        job_id=fake_uuid,
-        status=status_argument,
-    )
-    assert csv_link.text == "Download this report"
-    assert page.find("time", {"id": "time-left"}).text.split(" ")[0] == "2016-01-09"
 
     assert normalize_spaces(dashboard_table.select_one("tbody tr").text) == normalize_spaces(
         "6502532222 " "template content " "No " "Delivered 11:10:00.061258"
@@ -272,13 +264,15 @@ def test_should_show_job_in_progress(
     mock_get_reports,
     mock_get_service_data_retention,
     fake_uuid,
+    app_,
 ):
-    page = client_request.get(
-        "main.view_job",
-        service_id=service_one["id"],
-        job_id=fake_uuid,
-    )
-    assert page.find("div", {"class": "dashboard-table"}).text.strip() == "Report is 50% complete…"
+    with set_config(app_, "FF_ASYNC_REPORTS", False):
+        page = client_request.get(
+            "main.view_job",
+            service_id=service_one["id"],
+            job_id=fake_uuid,
+        )
+        assert page.find("div", {"class": "dashboard-table"}).text.strip() == "Report is 50% complete…"
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
@@ -521,7 +515,7 @@ def test_should_not_show_cancelled_job(
     )
 
 
-def test_should_hide_download_link_and_prepare_report_footer_job_outside_of_retention_period(
+def test_should_hide_prepare_report_footer_job_outside_of_retention_period(
     client_request,
     active_user_with_permissions,
     mock_get_job_sent_outside_retention_period,
@@ -533,7 +527,6 @@ def test_should_hide_download_link_and_prepare_report_footer_job_outside_of_rete
 ):
     page = client_request.get("main.view_job", service_id=SERVICE_ONE_ID, job_id=fake_uuid)
 
-    assert page.find("a[download]") is None
     assert page.find("div[class*='report-footer-container']") is None
 
 

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -521,6 +521,22 @@ def test_should_not_show_cancelled_job(
     )
 
 
+def test_should_hide_download_link_and_prepare_report_footer_job_outside_of_retention_period(
+    client_request,
+    active_user_with_permissions,
+    mock_get_job_sent_outside_retention_period,
+    mock_get_service_data_retention,
+    mock_get_service_template,
+    mock_get_reports,
+    mock_get_notifications,
+    fake_uuid,
+):
+    page = client_request.get("main.view_job", service_id=SERVICE_ONE_ID, job_id=fake_uuid)
+
+    assert page.find("a[download]") is None
+    assert page.find("div[class*='report-footer-container']") is None
+
+
 def test_should_cancel_letter_job(client_request, mocker, active_user_with_permissions):
     job_id = uuid.uuid4()
     job = job_json(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2370,6 +2370,22 @@ def mock_get_job_in_progress(mocker, api_user_active):
 
 
 @pytest.fixture(scope="function")
+def mock_get_job_sent_outside_retention_period(mocker, api_user_active):
+    def _get_job(service_id, job_id):
+        return {
+            "data": job_json(
+                service_id,
+                api_user_active,
+                job_id=job_id,
+                job_status="finished",
+                archived=True,
+            )
+        }
+
+    return mocker.patch("app.job_api_client.get_job", side_effect=_get_job)
+
+
+@pytest.fixture(scope="function")
 def mock_has_jobs(mocker):
     mocker.patch("app.job_api_client.has_jobs", return_value=True)
 


### PR DESCRIPTION
# Summary | Résumé

This PR updates the `view_job` page when viewing archived jobs i.e. Jobs that are older than the services retention period.

- Ensure that the "download report" section is hidden
- Ensure that the "prepare report" footer is hidden.
- Removed the `FF_ASYNC_REPORTS` feature flag

# Test instructions | Instructions pour tester la modification
1. Perform a bulk send
2. Find the job in the DB and set `archived` to `True`
3. View the job from the dashboard
4. Note that both the download report section and prepare report footer is not visible

Alternatively / even better: If you have a service with jobs send > 7 days ago try viewing one of those jobs instead.