### PR TITLE
We do not verify the phone number on creation of an account anymore

### DIFF
--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -60,8 +60,11 @@ def verify_email(token):
     if not user.mobile_number:
         return activate_user(user.id)
 
-    user.send_verify_code()
-    return redirect(url_for("main.verify"))
+    if current_app.config["FF_AUTH_V2"]:
+        return activate_user(user.id)
+    else:
+        user.send_verify_code()
+        return redirect(url_for("main.verify"))
 
 
 def activate_user(user_id):

--- a/app/templates/views/register-from-invite.html
+++ b/app/templates/views/register-from-invite.html
@@ -18,7 +18,7 @@
     </p>
     {% call form_wrapper() %}
       {{ textbox(form.name, width='w-full md:w-3/4') }}
-      {% set txt = _('We’ll send you a security code by text message') %}
+      {% set txt = _('A work number where we can reach you') %}
       <div class="extra-tracking">
         {{ textbox(form.mobile_number, width='w-full md:w-3/4', hint=txt, autocomplete='tel') }}
       </div>

--- a/app/templates/views/register-from-org-invite.html
+++ b/app/templates/views/register-from-org-invite.html
@@ -16,7 +16,7 @@
     {% call form_wrapper() %}
       {{ textbox(form.name, width='w-full md:w-3/4', autocomplete='name') }}
       <div class="extra-tracking">
-        {% set txt = _('We’ll send you a security code by text message') %}
+        {% set txt = _('A work number where we can reach you') %}
         {{ textbox(form.mobile_number, width='w-full md:w-3/4', hint=txt, autocomplete='tel') }}
       </div>
       {% set txt = _('Must be at least 8 characters and hard to guess') %}

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -19,7 +19,7 @@
         {% set hint_txt = _('Use a government email address only you can access, not a shared inbox') %}
         {{ textbox(form.email_address, hint=hint_txt, width='w-full md:w-3/4', safe_error_message=True, autocomplete='email') }}
         <div class="extra-tracking">
-          {% set hint_txt = _('We’ll send you a security code by text message') %}
+          {% set hint_txt = _('A work number where we can reach you') %}
           {{ textbox(form.mobile_number, width='w-full md:w-3/4', hint=hint_txt, autocomplete='tel') }}
         </div>
         <input class="visually-hidden" aria-hidden="true" tabindex="-1" id="defeat-chrome-autocomplete" type="hidden">

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2233,3 +2233,4 @@
 "{} security key","FR {} security key"
 "{} security keys","FR {} security keys"
 "Add a new security key","FR Add a new security key"
+"A work number where we can reach you","FR A work number where we can reach you"


### PR DESCRIPTION
# Summary | Résumé

We don't want to verify the phone number on account creation anymore

## Test:

Without FF on:
1. create a new account (with a phone number)
2. Once you click the create, the verification flow is email -> and phone number verification

With FF on:
1. create a new account (with a phone number)
2. once you click create, we only verify email and not phone number