### PR TITLE
Feat/make e2e testing easier

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -30,7 +30,7 @@ from app.main.forms import (
     TwoFactorForm,
 )
 from app.models.user import User
-from app.utils import user_is_gov_user, user_is_logged_in
+from app.utils import _get_2fa_code_for_testing, _get_verify_url_for_testing, user_is_gov_user, user_is_logged_in
 
 # Session keys
 NEW_EMAIL = "new-email"
@@ -96,7 +96,8 @@ def user_profile_email_authenticate():
 
     if form.validate_on_submit():
         user_api_client.send_change_email_verification(current_user.id, session[NEW_EMAIL])
-        return render_template("views/change-email-continue.html", new_email=session[NEW_EMAIL])
+        verify_url = _get_verify_url_for_testing(current_user.id)
+        return render_template("views/change-email-continue.html", new_email=session[NEW_EMAIL], verify_url=verify_url)
 
     return render_template(
         "views/user-profile/authenticate.html",
@@ -245,11 +246,9 @@ def user_profile_mobile_number_confirm():
             # Default redirect to user profile
             return redirect(url_for(".user_profile"))
 
-    return render_template(
-        "views/user-profile/confirm.html",
-        form_field=form.two_factor_code,
-        thing=_("mobile number"),
-    )
+    code = _get_2fa_code_for_testing(current_user.id)
+
+    return render_template("views/user-profile/confirm.html", form_field=form.two_factor_code, thing=_("mobile number"), key=code)
 
 
 @main.route("/user-profile/mobile-number/resend", methods=["GET", "POST"])

--- a/app/templates/components/render_test_codes_in_dev.html
+++ b/app/templates/components/render_test_codes_in_dev.html
@@ -1,0 +1,5 @@
+{% macro render_test_codes_in_dev(key) %}
+  {% if key and config["NOTIFY_ENVIRONMENT"] == "development" and "notification.canada.ca" not in request.host %}
+    <input type="hidden" data-testid="auth_key" value="{{ key }}">
+  {% endif %}
+{% endmacro %}

--- a/app/templates/views/change-email-continue.html
+++ b/app/templates/views/change-email-continue.html
@@ -1,4 +1,5 @@
 {% extends  "admin_template.html" %}
+{% from "components/render_test_codes_in_dev.html" import render_test_codes_in_dev  %}
 
 {% block per_page_title %}
   {{ _('Check your email') }}
@@ -9,5 +10,7 @@
   <h1 class="heading-large">{{ _('Check your email​') }}</h1>
   <p>{{ _('An email has been sent to') }} {{ new_email }}.</p>
   <p>{{ _('Click the link in the email to confirm the change to your email address.') }}</p>
-
+  
+  {{ render_test_codes_in_dev(verify_url) }}
+  
 {% endblock %}

--- a/app/templates/views/user-profile/confirm.html
+++ b/app/templates/views/user-profile/confirm.html
@@ -3,6 +3,7 @@
 {% from "components/page-header.html" import page_header %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/form.html" import form_wrapper %}
+{% from "components/render_test_codes_in_dev.html" import render_test_codes_in_dev  %}
 
 {% set title = _("Check your phone messages") %}
 
@@ -38,4 +39,5 @@
     </div>
   </div>
 
+  {{ render_test_codes_in_dev(key) }}
 {% endblock %}

--- a/tests/app/main/template/components/test_render_test_codes_in_dev.py
+++ b/tests/app/main/template/components/test_render_test_codes_in_dev.py
@@ -1,0 +1,112 @@
+import pytest
+from flask import Flask, render_template_string
+
+
+@pytest.fixture
+def app():
+    """Create a Flask app with proper template configuration"""
+    app = Flask(__name__, template_folder="/workspace/app/templates")
+    return app
+
+
+def test_render_test_codes_in_dev_renders_when_all_conditions_met(app):
+    """Test that the macro renders the hidden input when all conditions are met"""
+    app.config["NOTIFY_ENVIRONMENT"] = "development"
+
+    with app.test_request_context("/", base_url="http://localhost:6012"):
+        with app.app_context():
+            result = render_template_string(
+                """
+                {% from 'components/render_test_codes_in_dev.html' import render_test_codes_in_dev %}
+                {{ render_test_codes_in_dev("123456") }}
+                """
+            )
+            assert '<input type="hidden" data-testid="auth_key" value="123456">' in result
+
+
+def test_render_test_codes_in_dev_renders_nothing_when_no_key(app):
+    """Test that the macro renders nothing when no key is provided"""
+    app.config["NOTIFY_ENVIRONMENT"] = "development"
+
+    with app.test_request_context("/", base_url="http://localhost:6012"):
+        with app.app_context():
+            result = render_template_string(
+                """
+                {% from 'components/render_test_codes_in_dev.html' import render_test_codes_in_dev %}
+                {{ render_test_codes_in_dev(None) }}
+                """
+            ).strip()
+            assert result == ""
+
+
+def test_render_test_codes_in_dev_renders_nothing_when_empty_key(app):
+    """Test that the macro renders nothing when empty key is provided"""
+    app.config["NOTIFY_ENVIRONMENT"] = "development"
+
+    with app.test_request_context("/", base_url="http://localhost:6012"):
+        with app.app_context():
+            result = render_template_string(
+                """
+                {% from 'components/render_test_codes_in_dev.html' import render_test_codes_in_dev %}
+                {{ render_test_codes_in_dev("") }}
+                """
+            ).strip()
+            assert result == ""
+
+
+def test_render_test_codes_in_dev_renders_nothing_when_not_development(app):
+    """Test that the macro renders nothing when not in development environment"""
+    app.config["NOTIFY_ENVIRONMENT"] = "production"
+
+    with app.test_request_context("/", base_url="http://localhost:6012"):
+        with app.app_context():
+            result = render_template_string(
+                """
+                {% from 'components/render_test_codes_in_dev.html' import render_test_codes_in_dev %}
+                {{ render_test_codes_in_dev("123456") }}
+                """
+            ).strip()
+            assert result == ""
+
+
+def test_render_test_codes_in_dev_renders_nothing_when_notify_domain(app):
+    """Test that the macro renders nothing when host contains notification.canada.ca"""
+    app.config["NOTIFY_ENVIRONMENT"] = "development"
+
+    with app.test_request_context("/", base_url="https://notification.canada.ca"):
+        with app.app_context():
+            result = render_template_string(
+                """
+                {% from 'components/render_test_codes_in_dev.html' import render_test_codes_in_dev %}
+                {{ render_test_codes_in_dev("123456") }}
+                """
+            ).strip()
+            assert result == ""
+
+
+@pytest.mark.parametrize(
+    "environment,host,key,expected",
+    [
+        ("development", "localhost:6012", "123456", True),
+        ("production", "localhost:6012", "123456", False),
+        ("development", "notification.canada.ca", "123456", False),
+        ("development", "localhost:6012", None, False),
+    ],
+)
+def test_render_test_codes_in_dev_parameterized(app, environment, host, key, expected):
+    """Parameterized test covering all combinations of conditions"""
+    app.config["NOTIFY_ENVIRONMENT"] = environment
+
+    with app.test_request_context("/", base_url=f"http://{host}"):
+        with app.app_context():
+            result = render_template_string(
+                """
+                {% from 'components/render_test_codes_in_dev.html' import render_test_codes_in_dev %}
+                {{ render_test_codes_in_dev(key) }}
+                """,
+                key=key,
+            ).strip()
+            if expected:
+                assert f'<input type="hidden" data-testid="auth_key" value="{key}">' in result
+            else:
+                assert result == ""


### PR DESCRIPTION
# Summary | Résumé

This PR adds a utility method to display 2FA codes/links when the app is running in "development" mode.  It contains redundant checks to ensure that these codes will never be rendered in any environment running a config other than "development", and never in an environment hosted on `notification.canada.ca`.

It implements these in the 2fa settings screens, so that when a user verifies their email address or phone number, we can easily do end 2 end testing.

# Test instructions | Instructions pour tester la modification

## Codes available locally / SMS
- Locally, sign in and go to your user profile
- Remove your phone number
- Add it back
- Enter your password if challenged
- [ ] Inspect the page, ensure you see an input with `data-testid="auth_key"`
- Enter the code into the verify box
- [ ] Ensure you successfully added your phone number

## Codes available locally / email
- Locally, sign in and go to your user profile
- Change your email address (for example add +1 to the end)
- Enter your password if challenged
- [ ] Inspect the page, ensure you see an input with `data-testid="auth_key"`
- Follow the link in the input
- Ensure your email address was updated
