### PR TITLE
Remove FF_ASNYC_REPORTS

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -81,7 +81,6 @@ class Config(object):
     FF_RTL = env.bool("FF_RTL", True)
     FF_ANNUAL_LIMIT = env.bool("FF_ANNUAL_LIMIT", False)
     FF_CARETAKER = env.bool("FF_CARETAKER", False)
-    FF_ASYNC_REPORTS = env.bool("FF_ASYNC_REPORTS", False)
     FF_AUTH_V2 = env.bool("FF_AUTH_V2", False)
 
     FREE_YEARLY_EMAIL_LIMIT = env.int("FREE_YEARLY_EMAIL_LIMIT", 20_000_000)

--- a/app/templates/partials/jobs/notifications_header.html
+++ b/app/templates/partials/jobs/notifications_header.html
@@ -17,7 +17,7 @@
     <div class="mb-12 clear-both contain-floats">
       {{ problem_email_checkbox() }}
     </div>
-    {% if notifications and not config["FF_ASYNC_REPORTS"] %}
+    {% if notifications %}
       <div class="dashboard-table mt-12 mb-12 clear-both contain-floats">
         {% if percentage_complete < 100 %}
           {{ _('Report is') }} {{ "{:.0f}%".format(percentage_complete * 0.99) }} {{ _('complete…') }}

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -118,7 +118,7 @@
       <div>&nbsp;</div>
     {% endif %}
 
-    {% if not job.archived and config["FF_ASYNC_REPORTS"] %}
+    {% if not job.archived %}
       <div class="js-stick-at-bottom-when-scrolling" >
         {% call form_wrapper(action=action) %}
           {{ ajax_block(

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -15,7 +15,6 @@ from tests.conftest import (
     create_template,
     mock_get_notifications,
     normalize_spaces,
-    set_config,
 )
 
 
@@ -266,13 +265,12 @@ def test_should_show_job_in_progress(
     fake_uuid,
     app_,
 ):
-    with set_config(app_, "FF_ASYNC_REPORTS", False):
-        page = client_request.get(
-            "main.view_job",
-            service_id=service_one["id"],
-            job_id=fake_uuid,
-        )
-        assert page.find("div", {"class": "dashboard-table"}).text.strip() == "Report is 50% complete…"
+    page = client_request.get(
+        "main.view_job",
+        service_id=service_one["id"],
+        job_id=fake_uuid,
+    )
+    assert page.find("div", {"class": "dashboard-table"}).text.strip() == "Report is 50% complete…"
 
 
 @freeze_time("2016-01-01 11:09:00.061258")


### PR DESCRIPTION
# Summary | Résumé
This PR removes the feature flag `FF_ASYNC_REPORTS` to go live with the async job reports feature.

# Test instructions | Instructions pour tester la modification
1. Send a job
2. View the job
3. Note the footer to prepare and download a report
4. Prepare the report, download it, and ensure that the data is correct.
