### PR TITLE
Changed a few control flows for auth types

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -147,6 +147,9 @@ def user_profile_mobile_number():
 
         # if they are posting the button "edit"
         if edit_or_cancel_pressed == "edit":
+            current_user.update(verified_phonenumber=False)
+            if current_user.auth_type == "sms_auth":
+                current_user.update(auth_type="email_auth")
             return render_template(
                 "views/user-profile/change.html",
                 thing=_("mobile number"),
@@ -179,6 +182,9 @@ def user_profile_mobile_number():
     else:
         # if they dont have a number set, just go right to the edit page
         if current_user.mobile_number is None:
+            current_user.update(mobile_number=None, verified_phonenumber=False)
+            if current_user.auth_type == "sms_auth":
+                current_user.update(auth_type="email_auth")
             return render_template(
                 "views/user-profile/change.html",
                 thing=_("mobile number"),
@@ -299,6 +305,10 @@ def user_profile_password():
 @main.route("/user-profile/security_keys", methods=["GET", "POST"])
 @user_is_logged_in
 def user_profile_security_keys():
+    from_send_page = session.get("from_send_page", False)
+    if from_send_page == "user_profile_2fa":
+        return redirect(url_for(".user_profile_2fa"))
+        # If we are coming from the send page, we need to clear the session flags
     return render_template("views/user-profile/security-keys.html")
 
 
@@ -501,6 +511,7 @@ def user_profile_2fa():
                     return redirect(url_for(".verify_mobile_number"))
             elif new_auth_type == "new_key":
                 # Redirect to add a new security key
+                session["from_send_page"] = "user_profile_2fa"
                 return redirect(url_for(".user_profile_add_security_keys"))
             # todo: add a case for existing security keys
             else:

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -502,10 +502,9 @@ class TestOptionalPhoneNumber:
     def test_should_jump_to_edit_page_when_phone_already_blank(
         self, client_request, platform_admin_user, app_, mock_verify_password, mock_send_change_email_verification, mocker
     ):
-        mocker.patch.object(
-            current_user, "update", side_effect=lambda mobile_number: setattr(current_user, "mobile_number", mobile_number)
-        )
-        current_user.update(mobile_number=None)
+        mocker.patch("app.user_api_client.update_user_attribute")
+        current_user.mobile_number = None
+        current_user.verified_phonenumber = False
         page = client_request.get("main.user_profile_mobile_number", _expected_status=200)
         assert page.select_one("h1").text.strip() == "Add or change your mobile number"
 


### PR DESCRIPTION
# Summary | Résumé

Changed a few control flows for auth types

# Test instructions | Instructions pour tester la modification

### Change your phone number
1. Have an exsiting verified phone number on your profile, and sms_auth type
2. Go an edit the phone number (not remove)
3. Number should be unverified
4. Auth type should be email

# Change security key, redirect
1. Delete existing security keys 
2. Go to the 2fa change page
3. Click on the add security key
4. After you add the security key, you should be redirected to the 2fa page 
