### PR TITLE
changed how we display security keys

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -462,12 +462,10 @@ def user_profile_2fa():
         # IF they have not authenticated yet, do it now
         if not session.get(HAS_AUTHENTICATED):
             return redirect(url_for(".user_profile_2fa_authenticate"))
-        data = [
-            ("email", _("Receive a code by email")),
-            ("sms", _("Receive a code by text message")),
-            *[(f"key_{key['id']}", _("Use '{}' key").format(key["name"])) for key in getattr(current_user, "security_keys", [])],
-            ("new_key", _("Add a new security key")),
-        ]
+        data = [("email", _("Receive a code by email")), ("sms", _("Receive a code by text message"))]
+        if getattr(current_user, "security_keys", None) and current_user.security_keys != []:
+            data.extend([("security_key", _("Use existing security keys"))])
+        data.append(("new_key", _("Add a new security key")))
         hints = {
             "email": current_user.email_address,
             "sms": current_user.mobile_number

--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -464,7 +464,10 @@ def user_profile_2fa():
             return redirect(url_for(".user_profile_2fa_authenticate"))
         data = [("email", _("Receive a code by email")), ("sms", _("Receive a code by text message"))]
         if getattr(current_user, "security_keys", None) and current_user.security_keys != []:
-            data.extend([("security_key", _("Use existing security keys"))])
+            if len(current_user.security_keys) > 1:
+                data.extend([("security_key", _("Use existing security keys"))])
+            else:
+                data.extend([("security_key", _("Use existing security key"))])
         data.append(("new_key", _("Add a new security key")))
         hints = {
             "email": current_user.email_address,

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -29,7 +29,7 @@
         {{ profile_item(_('Two-step verification method'), text_field(_("Code by text message") + " (" + current_user.mobile_number + ")"), '.user_profile_2fa') }}
       {% elif current_user.auth_type == 'fido2_auth' %}
         <!-- This auth_type does not exist yet -->
-        {{ profile_item(_('Two-step verification method'), text_field(_("Security key"), '.user_profile_2fa') }}
+        {{ profile_item(_('Two-step verification method'), text_field(_("Security key")), '.user_profile_2fa') }}
       {% endif %}
 
       {{ profile_item(_('Security keys'), text_field(_("{} security key").format(num_keys) if num_keys == 1 else _("{} security keys").format(num_keys)), '.user_profile_security_keys') }}

--- a/app/templates/views/user-profile.html
+++ b/app/templates/views/user-profile.html
@@ -29,7 +29,7 @@
         {{ profile_item(_('Two-step verification method'), text_field(_("Code by text message") + " (" + current_user.mobile_number + ")"), '.user_profile_2fa') }}
       {% elif current_user.auth_type == 'fido2_auth' %}
         <!-- This auth_type does not exist yet -->
-        {{ profile_item(_('Two-step verification method'), text_field(_("Security key") + " (" + "placeholder" + ")"), '.user_profile_2fa') }}
+        {{ profile_item(_('Two-step verification method'), text_field(_("Security key"), '.user_profile_2fa') }}
       {% endif %}
 
       {{ profile_item(_('Security keys'), text_field(_("{} security key").format(num_keys) if num_keys == 1 else _("{} security keys").format(num_keys)), '.user_profile_security_keys') }}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2235,6 +2235,7 @@
 "Add a mobile number to your profile to use this option.","Ajoutez un numéro de téléphone portable à votre profil pour utiliser cette option."
 "Use '{}' key","Utiliser la clé '{}'"
 "Use existing security keys","Utiliser des clés de sécurité existantes"
+"Use existing security key","Utiliser la clé de sécurité existante"
 "Verified","Vérifié"
 "Not verified","Non vérifié"
 "Enter password to change profile settings","Entrez votre mot de passe pour modifier votre profil"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2234,6 +2234,7 @@
 "You must add a mobile number to your profile to use this option.","Vous devez ajouter un numéro de téléphone portable à votre profil pour utiliser cette option."
 "Add a mobile number to your profile to use this option.","Ajoutez un numéro de téléphone portable à votre profil pour utiliser cette option."
 "Use '{}' key","Utiliser la clé '{}'"
+"Use existing security keys","Utiliser des clés de sécurité existantes"
 "Verified","Vérifié"
 "Not verified","Non vérifié"
 "Enter password to change profile settings","Entrez votre mot de passe pour modifier votre profil"


### PR DESCRIPTION
# Summary | Résumé
We want users to be able to pick any security key to login

# Test instructions | Instructions pour tester la modification
Changed the wording on "use '{name_of_security_key}' security key" to "use existing security keys"
on the 2fa selection page.
This change should not show if there are no security keys for the user