### PR TITLE
Fix 500 error when changing to an empty mobile number

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -45,7 +45,6 @@ from wtforms.widgets import CheckboxInput, ListWidget
 
 from app import current_service, format_thousands, format_thousands_localized
 from app.main.validators import (
-    Blocklist,
     CsvFileValidator,
     DoesNotStartWithDoubleZero,
     LettersNumbersAndFullStopsOnly,
@@ -177,13 +176,7 @@ def password(label=_l("Password")):
     return PasswordField(
         label,
         validators=[
-            DataRequired(message=_l("This cannot be empty")),
-            Length(8, 255, message=_l("Must be at least 8 characters")),
-            Blocklist(
-                message=_l(
-                    "A password that is hard to guess contains: uppercase and lowercase letters, numbers and special characters, and words separated by a space."
-                )
-            ),
+            DataRequired(),
         ],
     )
 
@@ -972,6 +965,22 @@ class ChangeMobileNumberForm(StripWhitespaceForm):
 
 class ChangeMobileNumberFormOptional(StripWhitespaceForm):
     mobile_number = InternationalPhoneNumber(_l("Mobile number"))
+
+    def validate(self, extra_validators=None):
+        def valid_phone_number(self, num):
+            try:
+                validate_phone_number(num.data)
+                return True
+            except InvalidPhoneError:
+                raise ValidationError(_l("Must be a valid phone number"))
+
+        self.mobile_number.validators = [
+            DataRequired(),
+            Length(min=5, max=20),
+            valid_phone_number,
+        ]
+
+        return super().validate(extra_validators)
 
 
 class ChooseTimeForm(StripWhitespaceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -45,6 +45,7 @@ from wtforms.widgets import CheckboxInput, ListWidget
 
 from app import current_service, format_thousands, format_thousands_localized
 from app.main.validators import (
+    Blocklist,
     CsvFileValidator,
     DoesNotStartWithDoubleZero,
     LettersNumbersAndFullStopsOnly,
@@ -176,7 +177,13 @@ def password(label=_l("Password")):
     return PasswordField(
         label,
         validators=[
-            DataRequired(),
+            DataRequired(message=_l("This cannot be empty")),
+            Length(8, 255, message=_l("Must be at least 8 characters")),
+            Blocklist(
+                message=_l(
+                    "A password that is hard to guess contains: uppercase and lowercase letters, numbers and special characters, and words separated by a space."
+                )
+            ),
         ],
     )
 
@@ -967,19 +974,9 @@ class ChangeMobileNumberFormOptional(StripWhitespaceForm):
     mobile_number = InternationalPhoneNumber(_l("Mobile number"))
 
     def validate(self, extra_validators=None):
-        def valid_phone_number(self, num):
-            try:
-                validate_phone_number(num.data)
-                return True
-            except InvalidPhoneError:
-                raise ValidationError(_l("Must be a valid phone number"))
-
         self.mobile_number.validators = [
             DataRequired(),
-            Length(min=5, max=20),
-            valid_phone_number,
         ]
-
         return super().validate(extra_validators)
 
 

--- a/tests/app/main/views/test_user_profile.py
+++ b/tests/app/main/views/test_user_profile.py
@@ -145,6 +145,42 @@ def test_should_redirect_after_mobile_number_change(
     )
 
 
+@pytest.mark.parametrize(
+    "bad_phone_number,expected_error_message",
+    [
+        ("123", "Not a valid phone number"),
+        ("abc123", "Not a valid phone number"),
+        ("+1", "Not a valid phone number"),
+        ("", "This field is required"),  # Empty input
+        ("12345678901234567890123", "Not a valid phone number"),  # Too long
+    ],
+)
+def test_user_profile_mobile_number_form_validation_with_bad_inputs(
+    client_request,
+    bad_phone_number,
+    expected_error_message,
+):
+    """Test that the user_profile_mobile_number view handles form validation errors correctly for bad phone number inputs."""
+    # First, trigger the edit mode by posting with "edit" button
+    client_request.post(
+        "main.user_profile_mobile_number",
+        _data={"button_pressed": "edit"},
+        _expected_status=200,
+    )
+
+    # Now post with bad phone number data
+    page = client_request.post(
+        "main.user_profile_mobile_number",
+        _data={"mobile_number": bad_phone_number},
+        _expected_status=200,  # Should stay on same page due to validation error
+    )
+
+    # Check that the error message is displayed
+    assert expected_error_message in page.text
+    # Check that we're still on the mobile number change page
+    assert "Add or change your mobile number" in page.text
+
+
 def test_should_show_authenticate_after_mobile_number_change(
     client_request,
 ):


### PR DESCRIPTION
# Summary | Résumé

We were getting a 500 error when someone took the following steps:
1. log into staging
2. visit the user profile page
3. Click "change number" on `/user-profile/mobile-number`
4. make the input field empty and click "Save"
5. Observe the 500 error

 I added some more validation to the form to make it a "required" field and added a test.

# Test instructions | Instructions pour tester la modification

1. log onto the review app
2. follow steps 2-4 above
3. observe that you now get an error message that says "this field is required"