### PR TITLE
Fix security key login when FF is off

### DIFF
--- a/app/main/views/sign_in.py
+++ b/app/main/views/sign_in.py
@@ -1,4 +1,4 @@
-from flask import abort, flash, redirect, render_template, request, session, url_for
+from flask import abort, current_app, flash, redirect, render_template, request, session, url_for
 from flask_babel import _
 from flask_login import current_user, logout_user
 
@@ -56,8 +56,9 @@ def sign_in():
             if user.email_auth or requires_email_login:
                 args = {"requires_email_login": True} if requires_email_login else {}
                 return redirect(url_for(".two_factor_email_sent", **args))
-            if user.security_key_auth:
-                return render_template("views/two-factor-fido.html")
+            if current_app.config["FF_AUTH_V2"]:
+                if user.security_key_auth:
+                    return render_template("views/two-factor-fido.html")
 
         # Vague error message for login in case of user not known, inactive or password not verified
         flash(_("The email address or password you entered is incorrect."))

--- a/tests/app/main/views/test_sign_in.py
+++ b/tests/app/main/views/test_sign_in.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 from flask import current_app, url_for
 
 from app.models.user import User
-from tests.conftest import normalize_spaces
+from tests.conftest import normalize_spaces, set_config
 
 
 def test_render_sign_in_template_for_new_user(client_request):
@@ -464,6 +464,7 @@ def test_sign_in_renders_two_factor_fido_for_security_key_auth(
     mock_get_user_security_key_auth,
     mock_verify_password,
     mock_get_security_keys,
+    app_,
 ):
     # Patch to return the real user dict and User object
     mocker.patch("app.user_api_client.get_user_by_email", return_value=api_user_active_security_key_auth)
@@ -471,9 +472,10 @@ def test_sign_in_renders_two_factor_fido_for_security_key_auth(
         "app.models.user.User.from_email_address_and_password_or_none", return_value=User(api_user_active_security_key_auth)
     )
 
-    response = client.post(
-        url_for("main.sign_in"),
-        data={"email_address": "valid@example.canada.ca", "password": "val1dPassw0rd!"},
-    )
+    with set_config(app_, "FF_AUTH_V2", True):
+        response = client.post(
+            url_for("main.sign_in"),
+            data={"email_address": "valid@example.canada.ca", "password": "val1dPassw0rd!"},
+        )
     assert response.status_code == 200
     assert b"two-factor-fido" in response.data


### PR DESCRIPTION
# Summary | Résumé
- Previously if the FF was off, users with security keys would not be able to log in with their security key. Prior to having an auth_type for security key we blindly routed the user to the security key sign in flow if they had security keys. But their auth_type would still be set to sms or email.
- This PR re-instates the hard-coded routing and wrapped it in a FF check



# Test instructions | Instructions pour tester la modification
1. Before launching locally, set `FF_AUTH_V2` to `False`
2. Set your 2FA to email
3. Add a security key to your profile
4. Log out, and clear your `user-<id>` redis key
5. Log back in
6. Note that you're taken to the security key sign in flow despite your auth_type set to `email_auth` in the DB
