### PR TITLE
Add FR for code not found

### DIFF
--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2257,3 +2257,4 @@
 "Notification type","FR Notification type"
 "No sample templates available.","FR No sample templates available."
 "Filter templates by type","FR Filter templates by type"
+"Code not found","Code non trouvé"

--- a/scripts/test-translations.py
+++ b/scripts/test-translations.py
@@ -19,6 +19,7 @@ extra_keys_in_app = set(
         "Code has expired",  # api
         "Code already sent",  # api
         "Code has already been used",  # api
+        "Code not found",  # api - 2FA validation error message
         "as an email reply-to address.",  # api
         "You cannot remove the only user for a service",  # api
         "Cannot send to international mobile numbers",  # api


### PR DESCRIPTION
# Summary | Résumé

Add the FR translation for "Code not found" error message:

<img width="898" height="759" alt="Screenshot 2025-07-23 at 3 59 00 PM" src="https://github.com/user-attachments/assets/094d4af5-42c8-4b84-a534-e76a4f940254" />

# Test instructions | Instructions pour tester la modification

1. log into the review app
2. change your phone number
3. switch the app language to FR
4. update your 2fa to be sms
6. enter the wrong 5 digit code - 12345
7. observe that you see the error message in french: "Code non trouvé"
