### PR TITLE
Display the key name in the remove security key flash message

### DIFF
--- a/app/main/views/user_profile.py
+++ b/app/main/views/user_profile.py
@@ -360,7 +360,9 @@ def user_profile_security_keys_confirm_delete(keyid):
             else:
                 abort(500, e)
 
-    flash(_("Are you sure you want to remove security key {}?").format(keyid), "remove")
+    keys = dict([(key["id"], key["name"]) for key in current_user.security_keys])
+    key_name = keys.get(keyid, str(keyid))
+    flash(_("Are you sure you want to remove security key ‘{}’?").format(key_name), "remove")
     return render_template("views/user-profile/security-keys.html")
 
 

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1227,7 +1227,7 @@
 "Are you sure you want to remove","Êtes-vous certain de vouloir retirer"
 "Could not read {}. Try using a different file format. Ensure your file is encoded as UTF-8.","{} ne peut pas être lu. Veuillez essayer un format de fichier différent. Assurez-vous que votre fichier est encodé en UTF-8."
 "{} contains numbers or dates that GC Notify can’t understand. Try formatting all columns as ‘text’ or export your file as CSV.","{} contient des nombres ou des dates que Notification GC ne peut pas comprendre. Veuillez essayer de modifier le format des colonnes en «&thinsp;texte&thinsp;» ou exportez votre fichier en CSV."
-"Are you sure you want to remove security key {}?","Êtes-vous certain de vouloir retirer la clé de sécurité {}?"
+"Are you sure you want to remove security key ‘{}’?","Êtes-vous certain de vouloir retirer la clé de sécurité ‘{}’?"
 "You cannot accept an invite for another person.","Vous ne pouvez pas accepter une invitation pour une autre personne."
 "Upload a list of email addresses","Téléversez une liste d’adresse courriel"
 "Upload a list of phone numbers","Téléversez une liste de numéro de téléphone"


### PR DESCRIPTION
# Summary | Résumé

Previously we were displaying the key uuid. Switch to the key name:
<img width="1189" height="754" alt="Screenshot 2025-07-23 at 4 39 36 PM" src="https://github.com/user-attachments/assets/d4e8ad98-5835-4d31-8add-9c2d128b9446" />

# Test instructions | Instructions pour tester la modification

1. if you already have a security key on your staging account, you can test this in the review app
2. log into the review app
3. remove a security key from your profile
4. observe that you see the key name in the confirmation flash message