### PR TITLE
Update some content: Fido2 key -> security key

### DIFF
--- a/app/templates/views/two-factor-fido.html
+++ b/app/templates/views/two-factor-fido.html
@@ -10,7 +10,7 @@
 <div id='two-factor-fido' class="grid-row contain-floats">
   <div class="md:w-2/3 float-left py-0 px-0 px-gutterHalf box-border">
     <h1 class="heading-large">{{ _(title) }}</h1>
-    <p>{{ _('We have found a Fido2 key associated with your account.') }}</p>
+    <p>{{ _('We have found a security key associated with your account.') }}</p>
     <p>{{ _('Follow the browser window instructions to authenticate.') }}</p>
     {{ page_footer(
       secondary_link=url_for('main.email_not_received'),

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -723,7 +723,7 @@
 "When we receive your request we’ll get back to you within one working day.","Dès réception de votre demande, nous vous répondrons dans un délai d’un jour ouvrable."
 "Please enter the security code.","Veuillez entrer le code de sécurité"
 "Didn’t get an email?","Vous n’avez pas reçu de courriel?"
-"We have found a Fido2 key associated with your account.","Nous avons trouvé une clé Fido2 associée à votre compte."
+"We have found a security key associated with your account.","Nous avons trouvé une clé de sécurité associée à votre compte."
 "Follow the browser window instructions to authenticate.","Suivez les instructions dans la fenêtre du navigateur pour vous authentifier."
 "Text verification","Vérification par message texte"
 "Check your phone messages","Consultez vos messages texte"


### PR DESCRIPTION
# Summary | Résumé

Update some content: Fido2 key -> security key

When signing in with a security key, you should no longer see content that mentions a Fido2 key.

# Test instructions | Instructions pour tester la modification

1. in staging, set your 2fa method to "use existing security keys"
2. start the log flow in the review app
3. verify that you see the new content in the sign in flow: "We have found a security key associated with your account."