### PR TITLE
Update cypress's email fetching

### DIFF
--- a/tests_cypress/cypress/plugins/email-account.js
+++ b/tests_cypress/cypress/plugins/email-account.js
@@ -76,8 +76,8 @@ const emailAccount = async () => {
             try {
                 connection = await imaps.connect(emailConfig);
 
-                // grab up to 50 emails from the inbox
-                await connection.openBox('INBOX');
+                // Open Gmail's All Mail folder instead of INBOX
+                await connection.openBox('[Gmail]/All Mail');
                 const searchCriteria = ['UNSEEN'];
                 const fetchOptions = {
                     bodies: [''],
@@ -93,8 +93,9 @@ const emailAccount = async () => {
                     for (const message of messages) {
                         const mail = await simpleParser(message.parts[0].body);
                         const to_address = mail.to.value[0].address;
+                        const subject = mail.subject;
 
-                        if (to_address == emailAddress) {
+                        if (to_address == emailAddress && subject === 'Sign in | Connectez-vous') {
                             uidsToDelete.push(message.attributes.uid);
                             latestMail = {
                                 subject: mail.subject,

--- a/tests_cypress/cypress/support/commands.js
+++ b/tests_cypress/cypress/support/commands.js
@@ -118,7 +118,11 @@ Cypress.Commands.add('login', (agreeToTerms = true) => {
         Cypress.env('ADMIN_USER_ID', acct.admin.id);
         Cypress.env('REGULAR_USER_ID', acct.regular.id);
         cy.session([acct.regular.email_address, agreeToTerms], () => {
-            LoginPage.Login(acct.regular.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);
+            if (CONFIG.env && CONFIG.env.ENV === 'LOCAL') {
+                LoginPage.LoginLocal(acct.regular.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);
+            } else {
+                LoginPage.Login(acct.regular.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);
+            }
         });
     });
 });
@@ -133,7 +137,11 @@ Cypress.Commands.add('loginAsPlatformAdmin', (agreeToTerms = true) => {
         Cypress.env('ADMIN_USER_ID', acct.admin.id);
         Cypress.env('REGULAR_USER_ID', acct.regular.id);
         cy.session([acct.admin.email_address, agreeToTerms], () => {
-            LoginPage.Login(acct.admin.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);
+            if (CONFIG.env && CONFIG.env.ENV === 'LOCAL') {
+                LoginPage.LoginLocal(acct.admin.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);
+            } else {
+                LoginPage.Login(acct.admin.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);
+            }
         });
     });
 });


### PR DESCRIPTION
# Summary | Résumé

This PR updates the email checking logic to look in `ALL MAIL` instead of `inbox`.  It was observed that mail was being automatically moved to this location by google.  It also updates the login process to check emails on staging (but skip checking on local).
