### PR TITLE
Task/fix invite

### DIFF
--- a/app/main/views/invites.py
+++ b/app/main/views/invites.py
@@ -65,11 +65,6 @@ def accept_invite(token):
             service = Service.from_id(invited_user.service)
             if current_app.config["FF_AUTH_V2"]:
                 try:
-                    existing_user.update(auth_type=invited_user.auth_type)
-                except Exception as e:
-                    current_app.logger.info(f"[UPDATE_EXISTING_USER]: Error on `existing_user.update()`: {e}")
-
-                try:
                     existing_user.add_to_service(
                         service_id=invited_user.service,
                         permissions=invited_user.permissions,

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -28,6 +28,7 @@ from app.main.forms import (
 )
 from app.models.roles_and_permissions import permissions
 from app.models.user import InvitedUser, User
+from app.notify_client import user_api_client
 from app.utils import is_gov_user, redact_mobile_number, user_has_permissions
 
 
@@ -65,12 +66,13 @@ def invite_user(service_id):
         )
         if form.validate_on_submit():
             email_address = form.email_address.data
+            existing_user = user_api_client.get_user_by_email(email_address)
             invited_user = InvitedUser.create(
                 current_user.id,
                 service_id,
                 email_address,
                 form.permissions,
-                form.login_authentication.data,
+                existing_user.auth_type if existing_user else form.login_authentication.data,
                 form.folder_permissions.data,
             )
 

--- a/app/main/views/manage_users.py
+++ b/app/main/views/manage_users.py
@@ -12,7 +12,7 @@ from flask_babel import lazy_gettext as _l
 from flask_login import current_user
 from notifications_python_client.errors import HTTPError
 
-from app import current_service, service_api_client
+from app import current_service, service_api_client, user_api_client
 from app.event_handlers import (
     create_email_change_event,
     create_mobile_number_change_event,
@@ -28,7 +28,6 @@ from app.main.forms import (
 )
 from app.models.roles_and_permissions import permissions
 from app.models.user import InvitedUser, User
-from app.notify_client import user_api_client
 from app.utils import is_gov_user, redact_mobile_number, user_has_permissions
 
 
@@ -66,13 +65,13 @@ def invite_user(service_id):
         )
         if form.validate_on_submit():
             email_address = form.email_address.data
-            existing_user = user_api_client.get_user_by_email(email_address)
+            existing_user = user_api_client.get_user_by_email_or_none(email_address)
             invited_user = InvitedUser.create(
                 current_user.id,
                 service_id,
                 email_address,
                 form.permissions,
-                existing_user.auth_type if existing_user else form.login_authentication.data,
+                existing_user["auth_type"] if existing_user else form.login_authentication.data,
                 form.folder_permissions.data,
             )
 

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -965,7 +965,7 @@ def test_invite_user_with_email_auth_service(
                 sample_invite["service"],
                 email_address,
                 expected_permissions,
-                "email_auth",
+                api_user_active["auth_type"],
                 [],
             )
         else:

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -770,6 +770,7 @@ def test_invite_user(
     sample_invite,
     email_address,
     gov_user,
+    api_user_active,
     mock_get_template_folders,
     mock_get_organisations,
     app_,
@@ -782,6 +783,7 @@ def test_invite_user(
     mocker.patch("app.models.user.InvitedUsers.client", return_value=[sample_invite])
     mocker.patch("app.models.user.Users.client", return_value=[active_user_with_permissions])
     mocker.patch("app.invite_api_client.create_invite", return_value=sample_invite)
+    mocker.patch("app.user_api_client.get_user_by_email_or_none", return_value=None)
     page = client_request.post(
         "main.invite_user",
         service_id=SERVICE_ONE_ID,
@@ -833,6 +835,7 @@ def test_invite_user_with_email_auth_service_REMOVE_FF(
     sample_invite,
     email_address,
     gov_user,
+    api_user_active,
     mocker,
     auth_type,
     mock_get_organisations,
@@ -849,11 +852,13 @@ def test_invite_user_with_email_auth_service_REMOVE_FF(
         sample_invite["status"] = "pending"
         service_one["permissions"].append("email_auth")
         sample_invite["email_address"] = email_address
+        api_user_active["auth_type"] = auth_type
 
         assert is_gov_user(email_address) is gov_user
         mocker.patch("app.models.user.InvitedUsers.client", return_value=[sample_invite])
         mocker.patch("app.models.user.Users.client", return_value=[active_user_with_permissions])
         mocker.patch("app.invite_api_client.create_invite", return_value=sample_invite)
+        mocker.patch("app.user_api_client.get_user_by_email_or_none", return_value=api_user_active)
 
         page = client_request.post(
             "main.invite_user",
@@ -888,7 +893,7 @@ def test_invite_user_with_email_auth_service_REMOVE_FF(
                 sample_invite["service"],
                 email_address,
                 expected_permissions,
-                "email_auth",
+                auth_type,
                 [],
             )
         else:
@@ -908,6 +913,7 @@ def test_invite_user_with_email_auth_service(
     sample_invite,
     email_address,
     gov_user,
+    api_user_active,
     mocker,
     auth_type,
     mock_get_organisations,
@@ -929,6 +935,7 @@ def test_invite_user_with_email_auth_service(
         mocker.patch("app.models.user.InvitedUsers.client", return_value=[sample_invite])
         mocker.patch("app.models.user.Users.client", return_value=[active_user_with_permissions])
         mocker.patch("app.invite_api_client.create_invite", return_value=sample_invite)
+        mocker.patch("app.user_api_client.get_user_by_email_or_none", return_value=api_user_active)
 
         page = client_request.post(
             "main.invite_user",

--- a/tests/app/main/views/test_manage_users.py
+++ b/tests/app/main/views/test_manage_users.py
@@ -770,7 +770,6 @@ def test_invite_user(
     sample_invite,
     email_address,
     gov_user,
-    api_user_active,
     mock_get_template_folders,
     mock_get_organisations,
     app_,
@@ -835,7 +834,6 @@ def test_invite_user_with_email_auth_service_REMOVE_FF(
     sample_invite,
     email_address,
     gov_user,
-    api_user_active,
     mocker,
     auth_type,
     mock_get_organisations,
@@ -852,13 +850,11 @@ def test_invite_user_with_email_auth_service_REMOVE_FF(
         sample_invite["status"] = "pending"
         service_one["permissions"].append("email_auth")
         sample_invite["email_address"] = email_address
-        api_user_active["auth_type"] = auth_type
 
         assert is_gov_user(email_address) is gov_user
         mocker.patch("app.models.user.InvitedUsers.client", return_value=[sample_invite])
         mocker.patch("app.models.user.Users.client", return_value=[active_user_with_permissions])
         mocker.patch("app.invite_api_client.create_invite", return_value=sample_invite)
-        mocker.patch("app.user_api_client.get_user_by_email_or_none", return_value=api_user_active)
 
         page = client_request.post(
             "main.invite_user",
@@ -887,13 +883,12 @@ def test_invite_user_with_email_auth_service_REMOVE_FF(
                 "send_messages",
                 "view_activity",
             }
-
             app.invite_api_client.create_invite.assert_called_once_with(
                 sample_invite["from_user"],
                 sample_invite["service"],
                 email_address,
                 expected_permissions,
-                auth_type,
+                "email_auth",
                 [],
             )
         else:


### PR DESCRIPTION
# Summary | Résumé

When inviting a user, we need to respect their existing auth type if it is already set.

# Test instructions | Instructions pour tester la modification

Case 1: exisitng user
1. Set your existing user(A)'s auth type to sms
2. Sign in with a new account (B) and set up a service
3. Invite (A) to the new service
4. A's auth type should be SMS

Case 2: new user
1. Invite a user to your service that doesn't exist in the Notify systems
2. When you login with that user - the auth type should be set to email