### PR TITLE
Fix/invited user signup no sms verify

### DIFF
--- a/app/main/views/verify.py
+++ b/app/main/views/verify.py
@@ -78,6 +78,7 @@ def activate_user(user_id):
     invited_user = session.get("invited_user")
     if invited_user:
         service_id = _add_invited_user_to_service(invited_user)
+        session["service_id"] = service_id
         return redirect(url_for("main.service_dashboard", service_id=service_id))
 
     invited_org_user = session.get("invited_org_user")

--- a/tests/app/main/views/organisations/test_organisation_invites.py
+++ b/tests/app/main/views/organisations/test_organisation_invites.py
@@ -329,12 +329,7 @@ def test_org_user_registration(
         session["invited_org_user"]["email_address"],
         "+16502532222",
         "validPassword!",
-        "sms_auth",
-    )
-    mock_send_verify_code.assert_called_once_with(
-        "6ce466d0-fd6a-11e5-82f5-e0accb9d11a6",
-        "sms",
-        "+16502532222",
+        "email_auth",
     )
 
 

--- a/tests/app/main/views/test_accept_invite.py
+++ b/tests/app/main/views/test_accept_invite.py
@@ -364,68 +364,6 @@ def test_new_user_accept_invite_with_malformed_token(
     )
 
 
-def test_new_user_accept_invite_completes_new_registration_redirects_to_verify(
-    client,
-    service_one,
-    sample_invite,
-    api_user_active,
-    mock_check_invite_token,
-    mock_dont_get_user_by_email,
-    mock_email_is_not_already_in_use,
-    mock_register_user,
-    mock_send_verify_code,
-    mock_accept_invite,
-    mock_get_users_by_service,
-    mock_add_user_to_service,
-    mock_get_service,
-    mocker,
-    app_,
-):
-    expected_service = service_one["id"]
-    expected_email = sample_invite["email_address"]
-    expected_from_user = service_one["users"][0]
-    expected_redirect_location = "/register-from-invite"
-
-    response = client.get(url_for("main.accept_invite", token="thisisnotarealtoken"))
-    with client.session_transaction() as session:
-        assert response.status_code == 302
-        assert response.location == expected_redirect_location
-        invited_user = session.get("invited_user")
-        assert invited_user
-        assert expected_service == invited_user["service"]
-        assert expected_email == invited_user["email_address"]
-        assert expected_from_user == invited_user["from_user"]
-
-    data = {
-        "service": invited_user["service"],
-        "email_address": invited_user["email_address"],
-        "from_user": invited_user["from_user"],
-        "password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02",
-        "mobile_number": "+447890123456",
-        "name": "Invited User",
-        "auth_type": "email_auth",
-    }
-
-    data["tou_agreed"] = "true"
-
-    expected_redirect_location = "/verify"
-    response = client.post(url_for("main.register_from_invite"), data=data)
-    assert response.status_code == 302
-    assert response.location == expected_redirect_location
-
-    mock_send_verify_code.assert_called_once_with(ANY, "sms", data["mobile_number"])
-
-    mock_register_user.assert_called_with(
-        data["name"],
-        data["email_address"],
-        data["mobile_number"],
-        data["password"],
-        "sms_auth",
-    )
-
-    assert mock_accept_invite.call_count == 1
-
-
 def test_signed_in_existing_user_cannot_use_anothers_invite(
     client_request,
     mocker,
@@ -487,8 +425,6 @@ def test_new_invited_user_verifies_and_added_to_service(
     mock_dont_get_user_by_email,
     mock_email_is_not_already_in_use,
     mock_register_user,
-    mock_send_verify_code,
-    mock_check_verify_code,
     mock_get_user,
     mock_update_user_attribute,
     mock_add_user_to_service,
@@ -517,18 +453,12 @@ def test_new_invited_user_verifies_and_added_to_service(
         "password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02",
         "mobile_number": "+447890123456",
         "name": "Invited User",
-        "auth_type": "sms_auth",
+        "auth_type": "email_auth",
     }
     data["tou_agreed"] = "true"
 
-    response = client.post(url_for("main.register_from_invite"), data=data)
-    assert response.status_code == 302
-    assert response.location == url_for("main.verify")
-
-    # that sends user on to verify
-    response = client.post(url_for("main.verify"), data={"two_factor_code": "12345"}, follow_redirects=True)
+    response = client.post(url_for("main.register_from_invite"), follow_redirects=True, data=data)
     assert response.status_code == 200
-
     # when they post codes back to admin user should be added to
     # service and sent on to dash board
     expected_permissions = {
@@ -542,7 +472,7 @@ def test_new_invited_user_verifies_and_added_to_service(
         new_user_id = session["user_id"]
         mock_add_user_to_service.assert_called_with(data["service"], new_user_id, expected_permissions, [])
         mock_accept_invite.assert_called_with(data["service"], sample_invite["id"])
-        mock_check_verify_code.assert_called_once_with(new_user_id, "12345", "sms")
+
         assert service_one["id"] == session["service_id"]
 
     raw_html = response.data.decode("utf-8")

--- a/tests/app/main/views/test_register.py
+++ b/tests/app/main/views/test_register.py
@@ -306,7 +306,10 @@ def test_register_from_invite(
     fake_uuid,
     mock_email_is_not_already_in_use,
     mock_register_user,
-    mock_send_verify_code,
+    mock_login,
+    mock_activate_user,
+    mock_add_user_to_service,
+    mock_get_user,
     mock_accept_invite,
 ):
     invited_user = InvitedUser(
@@ -318,40 +321,45 @@ def test_register_from_invite(
             "permissions": ["manage_users"],
             "status": "pending",
             "created_at": datetime.utcnow(),
-            "auth_type": "sms_auth",
+            "auth_type": "email_auth",
             "folder_permissions": [],
             "blocked": True,
         }
     )
     with client.session_transaction() as session:
         session["invited_user"] = invited_user.serialize()
+        session["user_id"] = fake_uuid
     data = {
         "name": "Registered in another Browser",
         "email_address": invited_user.email_address,
         "mobile_number": "+16502532222",
         "service": str(invited_user.id),
         "password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02",
-        "auth_type": "sms_auth",
+        "auth_type": "email_auth",
     }
 
     data["tou_agreed"] = "true"
 
     response = client.post(url_for("main.register_from_invite"), data=data)
     assert response.status_code == 302
-    assert response.location == url_for("main.verify")
     mock_register_user.assert_called_once_with(
         "Registered in another Browser",
         invited_user.email_address,
         "+16502532222",
         "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02",
-        "sms_auth",
+        "email_auth",
     )
 
 
 def test_register_from_invite_when_user_registers_in_another_browser(
     client,
     api_user_active,
-    mock_get_user_by_email,
+    mock_email_is_not_already_in_use,
+    mock_register_user,
+    mock_login,
+    mock_activate_user,
+    mock_add_user_to_service,
+    mock_get_user,
     mock_accept_invite,
 ):
     invited_user = InvitedUser(
@@ -363,7 +371,7 @@ def test_register_from_invite_when_user_registers_in_another_browser(
             "permissions": ["manage_users"],
             "status": "pending",
             "created_at": datetime.utcnow(),
-            "auth_type": "sms_auth",
+            "auth_type": "email_auth",
             "folder_permissions": [],
             "blocked": False,
         }
@@ -377,14 +385,13 @@ def test_register_from_invite_when_user_registers_in_another_browser(
         "mobile_number": api_user_active["mobile_number"],
         "service": str(api_user_active["id"]),
         "password": "rZXdoBkuz6U37DDXIaAfpBR1OTJcSZOGICLCz4dMtmopS3KsVauIrtcgqs1eU02",
-        "auth_type": "sms_auth",
+        "auth_type": "email_auth",
     }
 
     data["tou_agreed"] = "true"
 
     response = client.post(url_for("main.register_from_invite"), data=data)
     assert response.status_code == 302
-    assert response.location == url_for("main.verify")
 
 
 @pytest.mark.parametrize("invite_email_address", ["gov-user@canada.ca", "non-gov-user@example.com"])


### PR DESCRIPTION
# Summary | Résumé
This PR removes phone number verification when signing up from invitations.

# Test instructions | Instructions pour tester la modification
1. Invite a user, who has not registered yet, to your service
2. Open the invitation link
3. Provide a phone number during sign up
4. Complete the sign up
5. Note that you are not prompted to verify your phone number after submitting
