### PR TITLE
Update sample templates yaml files and readme

### DIFF
--- a/app/sample_templates/README.md
+++ b/app/sample_templates/README.md
@@ -6,13 +6,14 @@
 2. Create a new file in this folder, for example `app/sample_templates/my_new_email_template_en_fr.yaml`
 3. Copy the contents of another template `.yaml` file so you have a starting point. Make sure you copy from a template file of the same notification type - i.e. sms or email
 4. Copy the contents of your new Notify template and paste it into the yaml file below the `content:` line. Select all the text you have pasted and click `<tab>` to make sure it is indented. 
-5. Replace the `id` with a new uuid you have generated. You can use [this online tool](https://www.uuidgenerator.net/version4).
-6. Edit the other values in the file, such as the english and french names that will be displayed to the notify user under: 
+5. Copy what will be displayed on the preview page to `example_content:`. This should have no variables or explanation text.
+6. Replace the `id` with a new uuid you have generated. You can use [this online tool](https://www.uuidgenerator.net/version4).
+7. Edit the other values in the file, such as the english and french names that will be displayed to the notify user under: 
     ```
     template_name:
       en: "My Template"
       fr: "Mon Gabarit"
     ```
     Pay close attention to the indentation.
-7. Make a draft PR and open the review app
-8. Navigate to your new sample template in the review app and verify that the sample template is displayed correctly
+8. Make a draft PR and open the review app
+9. Navigate to your new sample template in the review app and verify that the sample template is displayed correctly

--- a/app/sample_templates/appointment_reminder_en_fr.yaml
+++ b/app/sample_templates/appointment_reminder_en_fr.yaml
@@ -1,7 +1,7 @@
 id: "aee077c5-6f3d-4cb7-8d85-7b4dd0a6ee86"
 template_name:
-  en: "EN/FR Appointment reminder"
-  fr: "EN/FR FR Appointment reminder"
+  en: "EN | fr Appointment reminder"
+  fr: "EN | fr FR Appointment reminder"
 notification_type: "email"
 template_category: "reminder"
 pinned: false

--- a/app/sample_templates/appointment_reminder_en_fr.yaml
+++ b/app/sample_templates/appointment_reminder_en_fr.yaml
@@ -4,10 +4,6 @@ template_name:
   fr: "EN/FR FR Appointment reminder"
 notification_type: "email"
 template_category: "reminder"
-personalisation:
-  date_en: "May 26, 2025"
-  date_fr: "26 mai 2025"
-  name: "Jane Smith"
 pinned: false
 subject: "Appointment: ((date_en)) | FR Appointment: ((date_fr))"
 content: |
@@ -20,6 +16,19 @@ content: |
 
   [[fr]]
   Bonjour ((name)),
+
+  FR Sample template content
+  [[/fr]]
+example_content: |
+  [[en]]
+  Hello Jane Smith,
+  Sample template content
+  [[/en]]
+  
+  ---
+
+  [[fr]]
+  Bonjour Jane Smith,
 
   FR Sample template content
   [[/fr]]

--- a/app/sample_templates/two_fa_email_en_fr.yaml
+++ b/app/sample_templates/two_fa_email_en_fr.yaml
@@ -1,7 +1,7 @@
 id: "2c42e715-22b0-4d55-9263-7316f3093411"
 template_name:
-  en: "EN/FR Two-Factor Security Code"
-  fr: "EN/FR FR Two-Factor Security Code"
+  en: "EN | fr Two-Factor Security Code"
+  fr: "EN | fr FR Two-Factor Security Code"
 notification_type: "email"
 template_category: "authentication"
 pinned: true

--- a/app/sample_templates/two_fa_email_en_fr.yaml
+++ b/app/sample_templates/two_fa_email_en_fr.yaml
@@ -4,9 +4,6 @@ template_name:
   fr: "EN/FR FR Two-Factor Security Code"
 notification_type: "email"
 template_category: "authentication"
-personalisation:
-  name: "Jane Smith"
-  verify_code: "12345"
 pinned: true
 subject: "Sign in | Connectez-vous"
 content: |
@@ -26,4 +23,22 @@ content: |
   Voici votre code de sécurité pour vous connecter à -FR application name-:
 
   ^ ((verify_code))
+  [[/fr]]
+example_content:
+  [[en]]
+  Hi Jane Smith,
+
+  Here is your security code to log in to GC Notify:
+
+  ^ 12345
+  [[/en]]
+
+  ---
+
+  [[fr]]
+  Bonjour Jane Smith,
+
+  Voici votre code de sécurité pour vous connecter à Notification GC:
+
+  ^ 12345
   [[/fr]]

--- a/app/sample_templates/two_fa_email_fr_en.yaml
+++ b/app/sample_templates/two_fa_email_fr_en.yaml
@@ -4,9 +4,6 @@ template_name:
   fr: "FR/EN FR Two-Factor Security Code"
 notification_type: "email"
 template_category: "authentication"
-personalisation:
-  name: "Jane Smith"
-  verify_code: "12345"
 pinned: false
 subject: "Connectez-vous | Sign in"
 content: |
@@ -26,4 +23,22 @@ content: |
   Here is your security code to log in to -application name-:
 
   ^ ((verify_code))
+  [[/en]]
+example_content: |
+  [[fr]]
+  Bonjour Jane Smith,
+
+  Voici votre code de sécurité pour vous connecter à Notification GC:
+
+  ^ 12345
+  [[/fr]]
+
+  ---
+
+  [[en]]
+  Hi Jane Smith,
+
+  Here is your security code to log in to GC Notify:
+
+  ^ 12345
   [[/en]]

--- a/app/sample_templates/two_fa_email_fr_en.yaml
+++ b/app/sample_templates/two_fa_email_fr_en.yaml
@@ -1,7 +1,7 @@
 id: "31062d26-5369-4743-9a49-3002fc896bfd"
 template_name:
-  en: "FR/EN Two-Factor Security Code"
-  fr: "FR/EN FR Two-Factor Security Code"
+  en: "FR | en Two-Factor Security Code"
+  fr: "FR | en FR Two-Factor Security Code"
 notification_type: "email"
 template_category: "authentication"
 pinned: false

--- a/app/sample_templates/two_fa_sms_en_fr.yaml
+++ b/app/sample_templates/two_fa_sms_en_fr.yaml
@@ -1,4 +1,4 @@
-id: "2c42e715-22b0-4d55-9263-7316f3093411"
+id: "7e877f34-65d4-42d7-a33e-51789cb3bf55"
 template_name:
   en: "EN | fr Two-Factor Security Code"
   fr: "EN | fr FR Two-Factor Security Code"

--- a/app/sample_templates/two_fa_sms_en_fr.yaml
+++ b/app/sample_templates/two_fa_sms_en_fr.yaml
@@ -1,7 +1,7 @@
 id: "2c42e715-22b0-4d55-9263-7316f3093411"
 template_name:
-  en: "EN/FR Two-Factor Security Code"
-  fr: "EN/FR FR Two-Factor Security Code"
+  en: "EN | fr Two-Factor Security Code"
+  fr: "EN | fr FR Two-Factor Security Code"
 notification_type: "sms"
 template_category: "authentication"
 pinned: true

--- a/app/sample_templates/two_fa_sms_en_fr.yaml
+++ b/app/sample_templates/two_fa_sms_en_fr.yaml
@@ -4,8 +4,8 @@ template_name:
   fr: "EN/FR FR Two-Factor Security Code"
 notification_type: "sms"
 template_category: "authentication"
-personalisation:
-  verify_code: "12345"
 pinned: true
 content: |
   ((verify_code)) is your -application name- authentication code | ((verify_code)) est votre code d'authentification de -FR application name-
+example_content: |
+  12345 is your GC Notify authentication code | 12345 est votre code d'authentification de Notification GC

--- a/app/sample_templates/two_fa_sms_fr_en.yaml
+++ b/app/sample_templates/two_fa_sms_fr_en.yaml
@@ -1,7 +1,7 @@
 id: "0ce60dab-b77d-4289-ab01-954261467c20"
 template_name:
-  en: "FR/EN Two-Factor Security Code"
-  fr: "FR/EN FR Two-Factor Security Code"
+  en: "FR | en Two-Factor Security Code"
+  fr: "FR | en FR Two-Factor Security Code"
 notification_type: "sms"
 template_category: "authentication"
 pinned: false

--- a/app/sample_templates/two_fa_sms_fr_en.yaml
+++ b/app/sample_templates/two_fa_sms_fr_en.yaml
@@ -4,8 +4,8 @@ template_name:
   fr: "FR/EN FR Two-Factor Security Code"
 notification_type: "sms"
 template_category: "authentication"
-personalisation:
-  verify_code: "12345"
 pinned: false
 content: |
   ((verify_code)) est votre code d'authentification de -FR application name- | ((verify_code)) is your -application name- authentication code
+example_content: |
+  12345 est votre code d'authentification de Notification GC | 12345 is your GC Notify authentication code


### PR DESCRIPTION
# Summary | Résumé

This PR:
- removes the personalization variables from the yaml files since we won't need them
- adds a new variable `example_content` to the yaml files, this will contain the markdown for the template preview page
- updated the sample template names
- updated the README instructions
- updated a uuid that was a duplicate of another one

# Test instructions | Instructions pour tester la modification

1. log into the review app
2. visit the sample template library page
3. verify that it looks okay