### PR TITLE
Fix typo in yaml file

### DIFF
--- a/app/sample_templates/two_fa_email_en_fr.yaml
+++ b/app/sample_templates/two_fa_email_en_fr.yaml
@@ -24,7 +24,7 @@ content: |
 
   ^ ((verify_code))
   [[/fr]]
-example_content:
+example_content: |
   [[en]]
   Hi Jane Smith,
 


### PR DESCRIPTION
# Summary | Résumé

Fix a typo in one of the sample template yaml files that was causing one of the templates to not be displayed. There should now be 3 templates in the email list:

<img width="1120" height="584" alt="Screenshot 2025-07-31 at 4 56 07 PM" src="https://github.com/user-attachments/assets/9a709739-f048-49aa-ad70-6368af5b51f8" />

# Test instructions | Instructions pour tester la modification

Verify you can see 3 templates in the email list.