### PR TITLE
fix(fido2): update fetch URL for FIDO2 authentication endpoint

### DIFF
--- a/app/assets/javascripts/fido2.js
+++ b/app/assets/javascripts/fido2.js
@@ -3,7 +3,7 @@
 
   $(document).on("ready", function () {
     if ($("#two-factor-fido").length) {
-      fetch("/user-profile/security_keys/authenticate", {
+      fetch("/user-profile/security_keys/authenticate-fido2", {
         method: "POST",
         headers: {
           "X-CSRFToken": csrf_token,

--- a/tests_cypress/cypress/support/commands.js
+++ b/tests_cypress/cypress/support/commands.js
@@ -137,7 +137,7 @@ Cypress.Commands.add('loginAsPlatformAdmin', (agreeToTerms = true) => {
         Cypress.env('ADMIN_USER_ID', acct.admin.id);
         Cypress.env('REGULAR_USER_ID', acct.regular.id);
         cy.session([acct.admin.email_address, agreeToTerms], () => {
-            if (CONFIG.env && CONFIG.env.ENV === 'LOCAL') {
+            if (CONFIG.ENV === 'LOCAL') {
                 LoginPage.LoginLocal(acct.admin.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);
             } else {
                 LoginPage.Login(acct.admin.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);


### PR DESCRIPTION
# Summary | Résumé

This PR updates the endpoint used for security key authentication to the correct one.

# Test instructions | Instructions pour tester la modification
- Choose security key as your 2fa auth
- log out and log in
- [ ] Ensure site accepts your security key