### PR TITLE
fix(login): allow staging environment for local login flow

### DIFF
--- a/tests_cypress/cypress/support/commands.js
+++ b/tests_cypress/cypress/support/commands.js
@@ -118,7 +118,7 @@ Cypress.Commands.add('login', (agreeToTerms = true) => {
         Cypress.env('ADMIN_USER_ID', acct.admin.id);
         Cypress.env('REGULAR_USER_ID', acct.regular.id);
         cy.session([acct.regular.email_address, agreeToTerms], () => {
-            if (CONFIG.ENV === 'LOCAL') {
+            if (CONFIG.ENV === 'LOCAL' || CONFIG.ENV === 'STAGING') {
                 LoginPage.LoginLocal(acct.regular.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);
             } else {
                 LoginPage.Login(acct.regular.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);
@@ -137,7 +137,7 @@ Cypress.Commands.add('loginAsPlatformAdmin', (agreeToTerms = true) => {
         Cypress.env('ADMIN_USER_ID', acct.admin.id);
         Cypress.env('REGULAR_USER_ID', acct.regular.id);
         cy.session([acct.admin.email_address, agreeToTerms], () => {
-            if (CONFIG.ENV === 'LOCAL') {
+            if (CONFIG.ENV === 'LOCAL' || CONFIG.ENV === 'STAGING') {
                 LoginPage.LoginLocal(acct.admin.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);
             } else {
                 LoginPage.Login(acct.admin.email_address, CONFIG.CYPRESS_USER_PASSWORD, agreeToTerms);


### PR DESCRIPTION
# Summary | Résumé

This PR allows the e2e tests to use the code bypass functionality in staging.

> 1-3 sentence description of the changed you're proposing, including a link to
> a GitHub Issue # or Trello card if applicable.

> **Note**: Are you adding a new page from GC Articles? Make sure you add the endpoint to the [WAF rules](https://github.com/cds-snc/notification-utils/tree/main/.github/actions/waffles#supporting-a-new-url-within-gcnotify).

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

> **Note**: Ajoutez vous une nouvelle page par Articles GC? Assurez vous d'ajouter le chemin dans les [règles WAF](https://github.com/cds-snc/notification-utils/tree/main/.github/actions/waffles#supporting-a-new-url-within-gcnotify).

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
