### PR TITLE
Ensure the getConfig() consistently includes ENV

### DIFF
--- a/tests_cypress/cypress/support/utils.js
+++ b/tests_cypress/cypress/support/utils.js
@@ -58,7 +58,9 @@ export const getConfig = () => {
             .reduce((acc, [key, value]) => {
                 acc[key] = value;
                 return acc;
-            }, {})
+            }, {}),
+        // 4. Always include ENV property for downstream code
+        ENV: envName
     };
 
     return config;


### PR DESCRIPTION
# Summary | Résumé

This PR ensures that the `getConfig()` method always sets and includes the `ENV` variable. Previously some tests were failing to utilize dummy 2FA codes because of an environment variable mismatch between `getConfig()` and `Cypress.env()` calls.

# Test instructions | Instructions pour tester la modification
- CI is passing, specifically the a11y tests.
