### PR TITLE
Add missing pages to fullPageList for accessibility tests

### DIFF
--- a/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
+++ b/tests_cypress/cypress/e2e/admin/a11y/gca_pages.cy.js
@@ -26,6 +26,8 @@ const fullPageList = [
   { en: "/using-a-spreadsheet", fr: "/utiliser-une-feuille-de-calcul" },
   { en: "/by-and-for-gc", fr: "/par-et-pour-gc" },
   { en: "/new-features", fr: "/nouvelles-fonctionnalites" },
+  { en: "/getting-started", fr: "/decouvrir-notification-gc" },
+  { en: "/register-for-a-demo", fr: "/sinscrire-a-une-demo" },
   { en: "/terms", fr: "/terms" },
 ];
 


### PR DESCRIPTION
# Summary | Résumé

This pull request adds two new pages to the accessibility test suite for the admin section by updating the `fullPageList` in the Cypress end-to-end test file.

**Accessibility test coverage:**

* Added `/getting-started` (English) and `/decouvrir-notification-gc` (French) to the list of tested pages in `gca_pages.cy.js`.
* Added `/register-for-a-demo` (English) and `/sinscrire-a-une-demo` (French) to the list of tested pages in `gca_pages.cy.js`.

# Related cards
- https://github.com/cds-snc/notification-planning/issues/2122

# Test instructions | Instructions pour tester la modification
- Scheduled Cypress tests pass