### PR TITLE
Add the blank bilingual templates

### DIFF
--- a/app/sample_template_utils.py
+++ b/app/sample_template_utils.py
@@ -106,7 +106,7 @@ def create_temporary_sample_template(template_id: str, current_user_id) -> Dict[
     if not template_data:
         raise ValueError(f"Template with ID {template_id} not found")
     template_categories = template_category_api_client.get_all_template_categories()
-    new_template_data = {}
+    new_template_data: dict[str, Any] = {}
     new_template_data["template_category_id"] = None
     new_template_data["template_category"] = None
     for category in template_categories:

--- a/app/sample_template_utils.py
+++ b/app/sample_template_utils.py
@@ -107,6 +107,8 @@ def create_temporary_sample_template(template_id: str, current_user_id) -> Dict[
         raise ValueError(f"Template with ID {template_id} not found")
     template_categories = template_category_api_client.get_all_template_categories()
     new_template_data = {}
+    new_template_data["template_category_id"] = None
+    new_template_data["template_category"] = None
     for category in template_categories:
         if category["name_en"].lower() == template_data.get("template_category", "").lower():
             new_template_data["template_category_id"] = category["id"]

--- a/app/sample_templates/bilingual_email_en_fr.yaml
+++ b/app/sample_templates/bilingual_email_en_fr.yaml
@@ -1,7 +1,7 @@
 id: "1126e773-abd1-4930-a4e1-1ee20cf579d3"
 template_name:
   en: "EN | fr Blank bilingual template"
-  fr: "EN | fr Gabarit bilingue vierge"
+  fr: "EN | fr Gabarit vide bilingue"
 notification_type: "email"
 template_category: "information blast"
 pinned: false

--- a/app/sample_templates/bilingual_email_en_fr.yaml
+++ b/app/sample_templates/bilingual_email_en_fr.yaml
@@ -3,7 +3,7 @@ template_name:
   en: "EN | fr Blank bilingual template"
   fr: "EN | fr Gabarit vide bilingue"
 notification_type: "email"
-template_category: "information blast"
+template_category: "general communication"
 pinned: false
 subject: "General communication | Communication générale"
 content: |

--- a/app/sample_templates/bilingual_email_en_fr.yaml
+++ b/app/sample_templates/bilingual_email_en_fr.yaml
@@ -1,7 +1,7 @@
 id: "1126e773-abd1-4930-a4e1-1ee20cf579d3"
 template_name:
   en: "EN | fr Blank bilingual template"
-  fr: "EN | fr FR Blank bilingual template"
+  fr: "EN | fr Gabarit bilingue vierge"
 notification_type: "email"
 template_category: "information blast"
 pinned: false

--- a/app/sample_templates/bilingual_email_en_fr.yaml
+++ b/app/sample_templates/bilingual_email_en_fr.yaml
@@ -1,0 +1,44 @@
+id: "1126e773-abd1-4930-a4e1-1ee20cf579d3"
+template_name:
+  en: "EN | fr Blank bilingual template"
+  fr: "EN | fr FR Blank bilingual template"
+notification_type: "email"
+template_category: "information blast"
+pinned: false
+subject: "General communication | Communication générale"
+content: |
+  [[fr]]
+  *La version française suit*
+  [[/fr]]
+  [[en]]
+  Hi ((name)),
+  [[/en]]
+  [[fr]]
+  *Fin de la version anglaise*
+  [[/fr]]
+  ---
+  [[fr]]
+  Bonjour ((name)),
+
+  *Fin de la version française*
+  [[/fr]]
+example_content: |
+  [[fr]]
+  *La version française suit*
+  [[/fr]]
+  [[en]]
+  Hi Jane Smith,
+
+  This section of the message is marked as English content. Screen readers will read this section with an English voice. 
+  [[/en]]
+  [[fr]]
+  *Fin de la version anglaise*
+  [[/fr]]
+  ---
+  [[fr]]
+  Bonjour Jane Smith,
+
+  Cette portion du message est balisé pour être en français. Les lecteurs d'écran lirons cette portion avec une voix française. 
+
+  *Fin de la version française*
+  [[/fr]]

--- a/app/sample_templates/bilingual_email_fr_en.yaml
+++ b/app/sample_templates/bilingual_email_fr_en.yaml
@@ -1,0 +1,48 @@
+id: "7ff33d76-dd30-4507-9879-6f8151208292"
+template_name:
+  en: "FR | en Blank bilingual template"
+  fr: "FR | en FR Blank bilingual template"
+notification_type: "email"
+template_category: "information blast"
+pinned: false
+subject: "Communication générale | General communication"
+content: |
+  [[en]]
+  *English version follows.*
+  [[/en]]
+  [[fr]]
+  Bonjour ((name)),
+
+  Cette portion du message est balisé pour être en français. Les lecteurs d'écran lirons cette portion avec une voix française. 
+  [[/fr]]
+  [[en]]
+  *End of the French version*
+  [[/en]]
+  ---
+  [[en]]
+  Hi ((name)),
+
+  This section of the message is marked as English content. Screen readers will read this section with an English voice. 
+
+  *End of the English version*
+  [[/en]]
+example_content: |
+  [[en]]
+  *English version follows.*
+  [[/en]]
+  [[fr]]
+  Bonjour Jane Smith,
+
+  Cette portion du message est balisé pour être en français. Les lecteurs d'écran lirons cette portion avec une voix française. 
+  [[/fr]]
+  [[en]]
+  *End of the French version*
+  [[/en]]
+  ---
+  [[en]]
+  Hi Jane Smith,
+
+  This section of the message is marked as English content. Screen readers will read this section with an English voice. 
+
+  *End of the English version*
+  [[/en]]

--- a/app/sample_templates/bilingual_email_fr_en.yaml
+++ b/app/sample_templates/bilingual_email_fr_en.yaml
@@ -1,7 +1,7 @@
 id: "7ff33d76-dd30-4507-9879-6f8151208292"
 template_name:
   en: "FR | en Blank bilingual template"
-  fr: "FR | en FR Blank bilingual template"
+  fr: "FR | en Gabarit bilingue vierge"
 notification_type: "email"
 template_category: "information blast"
 pinned: false

--- a/app/sample_templates/bilingual_email_fr_en.yaml
+++ b/app/sample_templates/bilingual_email_fr_en.yaml
@@ -1,7 +1,7 @@
 id: "7ff33d76-dd30-4507-9879-6f8151208292"
 template_name:
   en: "FR | en Blank bilingual template"
-  fr: "FR | en Gabarit bilingue vierge"
+  fr: "FR | en Gabarit vide bilingue"
 notification_type: "email"
 template_category: "information blast"
 pinned: false

--- a/app/sample_templates/bilingual_email_fr_en.yaml
+++ b/app/sample_templates/bilingual_email_fr_en.yaml
@@ -3,7 +3,7 @@ template_name:
   en: "FR | en Blank bilingual template"
   fr: "FR | en Gabarit vide bilingue"
 notification_type: "email"
-template_category: "information blast"
+template_category: "general communication"
 pinned: false
 subject: "Communication générale | General communication"
 content: |


### PR DESCRIPTION
# Summary | Résumé

Add the blank bilingual templates from here:
https://notification.canada.ca/services/9d98c6be-92bc-4ef2-9156-e06d88888815/templates/all/folders/e04cf5c4-722f-4247-bcf0-62609d391e91

I also fixed an issue where we would get an error if the template category doesn't match an existing category - in this case the user just has to select the category themselves.

# Test instructions | Instructions pour tester la modification

Open the review app and check that the new sample templates match what you see in the service above.