### PR TITLE
Fix sample template edit/ preview flow

### DIFF
--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -3155,7 +3155,9 @@ class TestCreateFromSampleTemplate:
                     "button_pressed": "preview",
                 },
                 _expected_status=302,
-                _expected_redirect=url_for("main.preview_template", service_id=SERVICE_ONE_ID),
+                _expected_redirect=url_for(
+                    "main.preview_template", service_id=SERVICE_ONE_ID, sample_template_id=sample_email_id
+                ),
             )
         assert mocked_set_preview.call_count == 1
         payload = mocked_set_preview.call_args[0][0]
@@ -3213,7 +3215,7 @@ class TestCreateFromSampleTemplate:
                     "button_pressed": "preview",
                 },
                 _expected_status=302,
-                _expected_redirect=url_for("main.preview_template", service_id=SERVICE_ONE_ID),
+                _expected_redirect=url_for("main.preview_template", service_id=SERVICE_ONE_ID, sample_template_id=sample_sms_id),
             )
         payload = mocked_set_preview.call_args[0][0]
         assert payload["template_type"] == "sms"


### PR DESCRIPTION
# Summary | Résumé

Fix sample template edit/ preview flow

# Test instructions | Instructions pour tester la modification

Case 1:
1. Edit a sample template (not just click edit, but add data)
2. Click preview
3. Save

Case 2:
1. Try a different template from Case 1, edit a sample template (not just click edit, but add data)
2. Click preview
3. Click the backlink
4. Your data should be the one from (1)
5. Save

Case 3:
1. Edit a sample template (not just click edit, but add data)
2. click preview
3. Click the dashboard
4. Go back to viewing the same sample template from (1) - it should NOT have your data
5. Preview the templat (it should not have any changes)
