### PR TITLE
Add an `example_subject` field

### DIFF
--- a/app/sample_template_utils.py
+++ b/app/sample_template_utils.py
@@ -121,7 +121,7 @@ def create_temporary_sample_template(template_id: str, current_user_id) -> Dict[
     new_template_data["name"] = template_data.get("template_name", {}).get("en", "")
     new_template_data["name_fr"] = template_data.get("template_name", {}).get("fr", "")
     new_template_data["content"] = template_data.get("example_content", "")
-    new_template_data["subject"] = template_data.get("subject", "")
+    new_template_data["subject"] = template_data.get("example_subject", "")
     new_template_data["template_type"] = template_data.get("notification_type", None)
 
     new_template_data["created_at"] = datetime.utcnow().isoformat()

--- a/app/sample_templates/appointment_reminder_en_fr.yaml
+++ b/app/sample_templates/appointment_reminder_en_fr.yaml
@@ -6,6 +6,7 @@ notification_type: "email"
 template_category: "reminder"
 pinned: false
 subject: "Appointment: ((date_en)) / Rendez-vous du ((date_fr))"
+example_subject: "Appointment: May 26, 2025 / Rendez-vous du 26 mai 2025"
 content: |
   [[fr]]
   _La version française suit_

--- a/app/sample_templates/appointment_reminder_fr_en.yaml
+++ b/app/sample_templates/appointment_reminder_fr_en.yaml
@@ -6,6 +6,7 @@ notification_type: "email"
 template_category: "reminder"
 pinned: false
 subject: "Rendez-vous du ((date_fr)) / Appointment: ((date_en))"
+example_subject: "Rendez-vous du 26 mai 2025 / Appointment: May 26, 2025"
 content: |
   [[en]]
   _The English version follows_

--- a/app/sample_templates/bilingual_email_en_fr.yaml
+++ b/app/sample_templates/bilingual_email_en_fr.yaml
@@ -6,6 +6,7 @@ notification_type: "email"
 template_category: "general communication"
 pinned: false
 subject: "General communication | Communication générale"
+example_subject: "General communication | Communication générale"
 content: |
   [[fr]]
   *La version française suit*

--- a/app/sample_templates/bilingual_email_fr_en.yaml
+++ b/app/sample_templates/bilingual_email_fr_en.yaml
@@ -6,6 +6,7 @@ notification_type: "email"
 template_category: "general communication"
 pinned: false
 subject: "Communication générale | General communication"
+example_subject: "Communication générale | General communication"
 content: |
   [[en]]
   *English version follows.*

--- a/app/sample_templates/two_fa_email_en_fr.yaml
+++ b/app/sample_templates/two_fa_email_en_fr.yaml
@@ -6,6 +6,7 @@ notification_type: "email"
 template_category: "authentication"
 pinned: true
 subject: "Sign in | Connectez-vous"
+example_subject: "Sign in | Connectez-vous"
 content: |
   [[en]]
   Hi ((name)),

--- a/app/sample_templates/two_fa_email_fr_en.yaml
+++ b/app/sample_templates/two_fa_email_fr_en.yaml
@@ -6,6 +6,7 @@ notification_type: "email"
 template_category: "authentication"
 pinned: false
 subject: "Connectez-vous | Sign in"
+example_subject: "Connectez-vous | Sign in"
 content: |
   [[fr]]
   Bonjour ((name)),


### PR DESCRIPTION
# Summary | Résumé

This is so we can fill variables in the subject with example content and display that on the preview page.

Figma:


# Test instructions | Instructions pour tester la modification

Open the review app and navigate to some of the sample template preview pages. For the Appointment reminder templates should not have a variable in the subject on the preview page.