### PR TITLE
Show template categories on edit sample templates

### DIFF
--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -78,18 +78,10 @@
       {% set hint = _('GC Notify uses markdown to format emails. This screen shows sample content in markdown. After editing content, select preview for the formatted version.<br/><br/>For help adding or changing formatting, read Guidance on {}').format(link_html) %}
       {{ template_content(form.template_content, form.text_direction_rtl, hint=hint, ) }}
 
-      {% if not is_sample_template %}
-        <h2 class="heading-medium">{{ _('Template category') }}</h2>
-        {% call template_category(form.template_category_id, true if template_category_mode == 'expand' else false) %}
-        {{ select(
-          form.template_category_id,
-          hint=_('Template categories help improve delivery of your messages'),
-          option_hints=template_category_hints, option_conditionals=other_category,
-          testid="template-categories",
-          use_aria_labelledby=false
-        ) }}
-        {% endcall %}
-      {% endif %}
+      <h2 class="heading-medium">{{ _('Template category') }}</h2>
+      {% call template_category(form.template_category_id, true if template_category_mode == 'expand' else false) %}
+        {{ select(form.template_category_id, hint=_('Template categories help improve delivery of your messages'), option_hints=template_category_hints, option_conditionals=other_category, testid="template-categories", use_aria_labelledby=false) }}
+      {% endcall %}
 
       {% if current_user.platform_admin %}
         {{ radios(form.process_type, hint=_('This is only manageable by platform admins'), use_aria_labelledby=false) }}


### PR DESCRIPTION
# Summary | Résumé
This PR ensures that the template category list is displayed on both the `edit-[sms|email]-template` page.

# Test instructions | Instructions pour tester la modification
1. Open the sample template library
2. Open an email template and click edit
3. Note that the template categories are shown
4. Repeat these steps for an SMS sample template