### PR TITLE
Make button sticky on preview sample template page

### DIFF
--- a/app/templates/views/templates/view_sample_template.html
+++ b/app/templates/views/templates/view_sample_template.html
@@ -33,7 +33,7 @@
     </div>
 
 
-    <div role='group' id="add_new_template_form" class="mt-8 mb-16">
+    <div role='group' id="add_new_template_form" class="mt-8 js-stick-at-bottom-when-scrolling">
         <a class="button" href="{{ url_for('.create_from_sample_template', service_id=current_service.id, template_id=template.id, template_type=template.template_type, template_folder_id=None) }}">
             {{ _('Edit this template') }}
         </a>


### PR DESCRIPTION
# Summary | Résumé

This pull request makes a small UI improvement to the template view page. The change ensures that the "Edit this template" button remains visible at the bottom of the screen when scrolling.

# Test instructions | Instructions pour tester la modification

- Make sure "Edit this template" button is shown on initial load when the template content is long