### PR TITLE
Feat/make lang more distinct

### DIFF
--- a/app/templates/components/template_name.html
+++ b/app/templates/components/template_name.html
@@ -1,0 +1,23 @@
+
+{# 
+    Macro: sample_template_name
+    --------------------------
+    Renders a sample template block with the given template name.  If the template name begins with 'en|fr' or 'fr|en', the language code will be displayed more distinctly.
+
+    Parameters:
+        tmpl_name (str): The name of the template to be rendered or referenced.
+
+    Usage:
+        Call this macro with the desired template name to include or display a specific template section.        
+#}
+{% macro sample_template_name(tmpl_name) %}
+  {% set t = tmpl_name or '' %}
+  {% set prefix = t[:5].lower() %}
+  {% if prefix in ['en|fr', 'fr|en'] %}
+    <span class="inline-block text-center px-2 py-1 min-w-[70px] rounded-md bg-[#d7f1ff] mr-3">
+      <strong>{{ t[:2] | e }}</strong>{{ t[2:5] | e }}
+    </span>{{ t[6:] | e }}
+  {% else %}
+    {{ t | e }}
+  {% endif %}
+{% endmacro %}

--- a/app/templates/views/templates/sample_library.html
+++ b/app/templates/views/templates/sample_library.html
@@ -1,6 +1,7 @@
 {% from "components/pill.html" import pill %}
 {% from "components/page-footer.html" import page_footer %}
 {% from "components/table.html" import list_table, field %}
+{% from "components/template_name.html" import sample_template_name %}
 
 {% extends "admin_template.html" %}
 
@@ -38,7 +39,7 @@
             <i class="fa-solid fa-thumbtack mr-4 text-yellow-300"></i>
           {% endif %}
           <a href="{{ url_for('main.view_sample_template', service_id=current_service.id, template_id=item.id) }}">
-            {{ item.template_name.get(lang) }}
+            {{ sample_template_name(item.template_name.get(lang)) }}
           </a>
         </div>
       {% endcall %}

--- a/app/templates/views/templates/sample_library.html
+++ b/app/templates/views/templates/sample_library.html
@@ -34,7 +34,7 @@
       testid="sample-templates-table"
     ) %}
       {% call field() %}
-        <div class="flex items-center">
+        <div class="flex items-center ml-3">
           {% if item.pinned %}
             <i class="fa-solid fa-thumbtack mr-4 text-yellow-300"></i>
           {% endif %}

--- a/app/templates/views/templates/view_sample_template.html
+++ b/app/templates/views/templates/view_sample_template.html
@@ -8,7 +8,7 @@
 {% from "components/page-header.html" import multi_line_page_header %}
 
 {% block service_page_title %}
-  {{ page_title }}
+    {{ (page_title | join(' ')) | e }}
 {% endblock %}
 
 {% block maincolumn_content %}


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces a new macro to standardize the display of sample template names, particularly for bilingual templates, and updates the sample library view to use this macro. Additionally, it makes a minor improvement to the page title rendering in the sample template view.

# Before
<img width="1067" height="460" alt="image" src="https://github.com/user-attachments/assets/10e0fc4d-a5c0-4e2a-a0d3-5dcd4c406e19" />

# After
<img width="1122" height="507" alt="image" src="https://github.com/user-attachments/assets/c56587dd-b113-4421-af32-a1d41395ce82" />
