### PR TITLE
Add a relation between a select legend and a hint if it exists

### DIFF
--- a/app/templates/components/select-input.html
+++ b/app/templates/components/select-input.html
@@ -42,14 +42,14 @@
   {% set group = "radiogroup" if input == "radio" else "group" if input == "checkbox" %}
   <div class="form-group contain-floats box-border mb-gutterHalf md:mb-gutter {% if field.errors %} form-group-error{% endif %}" {% if is_collapsible %} data-module="collapsible-checkboxes" {% if collapsible_opts.field %} data-field-label="{{ collapsible_opts.field }}" {% endif %} {% endif %}>
     <fieldset id="{{ field.id }}" class="contain-floats w-full" role="{{ group }}" {% if use_aria_labelledby %} aria-labelledby="{{ field.id }}-label"{% endif %} {% if testid %}data-testid="{{testid}}"{% endif %}>
-      <legend id="{{ field.id }}-label"  class="form-label heading-small{% if legend_style != 'text' %} {{ legend_style }} {% endif %}">
+      <legend id="{{ field.id }}-label"  class="form-label heading-small{% if legend_style != 'text' %} {{ legend_style }} {% endif %}" aria-describedby="{{ field.id }}-hint">
         {% if is_page_heading %}<h1 class="heading-large">{% endif %}
         {% if hide_legend %}<span class="visually-hidden">{% endif %}
         {{ field.label.text|safe }}
         {% if hide_legend %}</span>{% endif %}
         {% if is_page_heading %}</h1>{% endif %}
         {% if hint %}
-          <span class="form-hint">
+          <span id="{{ field.id }}-hint" class="form-hint">
             {{ hint }}
           </span>
         {% endif %}


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/notification-planning/issues/2374

When we have a hint in a select macro, we can link the hint to the legend using aria-describedby

 
# Test instructions | Instructions pour tester la modification

- [ ] Find a radio or checkbox list where the group legend has a hint. For example categories when editing a template. 
- [ ] Inspect a11y properties of the legend. 
- [ ] Its accessible name should contain the legend itself, followed by the hint. 