### PR TITLE
Remove manual group attr from fieldset

### DIFF
--- a/app/templates/components/select-input.html
+++ b/app/templates/components/select-input.html
@@ -39,9 +39,8 @@
 {% endmacro %}
 {% macro select_wrapper(field, hint=None, disable=[], option_hints={}, hide_legend=False, collapsible_opts={}, legend_style="text", input="radio", is_page_heading=False, use_aria_labelledby=True, testid=None) %}
   {% set is_collapsible = collapsible_opts|length %}
-  {% set group = "radiogroup" if input == "radio" else "group" if input == "checkbox" %}
   <div class="form-group contain-floats box-border mb-gutterHalf md:mb-gutter {% if field.errors %} form-group-error{% endif %}" {% if is_collapsible %} data-module="collapsible-checkboxes" {% if collapsible_opts.field %} data-field-label="{{ collapsible_opts.field }}" {% endif %} {% endif %}>
-    <fieldset id="{{ field.id }}" class="contain-floats w-full" role="{{ group }}" {% if use_aria_labelledby %} aria-labelledby="{{ field.id }}-label"{% endif %} {% if testid %}data-testid="{{testid}}"{% endif %}>
+    <fieldset id="{{ field.id }}" class="contain-floats w-full" {% if use_aria_labelledby %} aria-labelledby="{{ field.id }}-label"{% endif %} {% if testid %}data-testid="{{testid}}"{% endif %}>
       <legend id="{{ field.id }}-label"  class="form-label heading-small{% if legend_style != 'text' %} {{ legend_style }} {% endif %}">
         {% if is_page_heading %}<h1 class="heading-large">{% endif %}
         {% if hide_legend %}<span class="visually-hidden">{% endif %}


### PR DESCRIPTION
# Summary | Résumé

Fixes https://github.com/cds-snc/notification-planning/issues/2375

We don't need to specify that a fieldset is a group if it contains a legend and some inputs of type radio or checkbox

# Test instructions | Instructions pour tester la modification

- [ ] Find a radio or checkbox list
- [ ] Inspect html and see that the role attr is not re-defined. 