### PR TITLE
A11y/toolbar textbox relationship

### DIFF
--- a/app/templates/components/checkbox.html
+++ b/app/templates/components/checkbox.html
@@ -29,7 +29,7 @@
 {% endmacro %}
 
 
-{% macro checkbox_input(id, name, data=None, value="y", class="", testid=None) %}
+{% macro checkbox_input(id, name, data=None, value="y", class="", testid=None, controls=None) %}
   <input
     id="{{ id }}" name="{{ name }}" type="checkbox" value="{{ value }}" class="{{ class }}"
     {% if data %}
@@ -37,6 +37,9 @@
     {% endif %}
     {% if testid %}
       data-testid="{{ testid }}"
+    {% endif %}
+    {% if controls %}
+      aria-controls="{{ controls }}"
     {% endif %}
   >
 {% endmacro %}

--- a/app/templates/components/template-content.html
+++ b/app/templates/components/template-content.html
@@ -5,11 +5,10 @@
     <!-- TODO: remove `use_styled_checkbox` and this if statement once we decide on the UI element to use here  -->
 
     <fieldset class="contain-floats w-full" role="radiogroup">
-        <legend class="mb-4">
+        <legend class="mb-4" {% if hint %}aria-describedby="{{ content_field.name }}-hint"{% endif %}>
             <span>{{ label }}</span>
         </legend>
         {% if hint %}
-            {% set describedby = content_field.name + '-hint ' %}
             <span id="{{ content_field.name }}-hint" class="form-hint pb-4">
                 {{ hint }}
             </span>

--- a/app/templates/components/template-content.html
+++ b/app/templates/components/template-content.html
@@ -15,8 +15,8 @@
         {% endif %}
         {% if config["FF_RTL"] %}
             <div class="p-2 bg-gray-300 flex items-center">
-                {{ checkbox_input(checkbox_field.id, checkbox_field.name, checkbox_field.data, class="h-8 w-8 mr-2", testid="template-rtl") }}
-                <label class="pb-0 inline-block text-small" for="text_direction_rtl">{{ _('Display') }}<span class="sr-only"> {{ _('email content') }} </span> {{ _('right to left') }}</label>
+                {{ checkbox_input(checkbox_field.id, checkbox_field.name, checkbox_field.data, class="h-8 w-8 mr-2", testid="template-rtl", controls=content_field.id) }}
+                <label class="pb-0 inline-block text-small" for="text_direction_rtl">{{ _('Display') }} {{ _('email content') }} {{ _('right to left') }}</label>
             </div>
         {% endif %}
         {{ textbox(content_field, highlight_tags=True, width='w-full', rows=8, testid="template-content", label_class="sr-only") }}


### PR DESCRIPTION
# Summary | Résumé

Fixes https://github.com/cds-snc/notification-planning/issues/2376

1. Adds a relationship between the text direction control and the textbox for email content. 
2. Fixes the relationship between the legend and the hint for that fieldset. 

# Test instructions | Instructions pour tester la modification

- [ ] Edit an email template
- [ ] Inspect the RTL checkbox a11 properties
- [ ] Its label should contain the label of the message content textbox. 