### PR TITLE
Change service name h2 to a div

### DIFF
--- a/app/templates/partials/nav/gc_header.html
+++ b/app/templates/partials/nav/gc_header.html
@@ -83,9 +83,9 @@
 
     {% if current_user.is_authenticated and current_user.has_permissions() or platform_admin_view_ind %}
       <div class="flex flex-col items-start md:flex-row md:items-center">
-        <h2 class="font-bold text-titlelarge text-black inline mr-gutterHalf ">
+        <div class="font-bold text-titlelarge text-black inline mr-gutterHalf ">
           {{ url_text }}
-        </h2>
+        </div>
         {% if current_user.has_permissions() and not platform_admin_view_ind and current_service.trial_mode %}
         <a
           class="mt-2 min-h-target inline-flex flex-col items-start sm:flex-row sm:items-center focus:outline-none border-b-2 border-transparent focus:border-blue text-small underline visited:text-blue link:text-blue"


### PR DESCRIPTION
# Summary | Résumé

This PR takes the service name out of an H2 to make the heading structure of each page more clear and focused. 
This pull request makes a minor change to the navigation header template, replacing an `<h2>` element with a `<div>` for displaying the `url_text`. This change affects the semantics and possibly the styling of the header text.

## Related cards
- https://github.com/cds-snc/notification-planning/issues/2407

# Test instructions | Instructions pour tester la modification
- Page headings no longer include the service name
- Pages are visually unchanged
