### PR TITLE
Remove pin from sample sms template

### DIFF
--- a/app/sample_templates/two_fa_sms_en_fr.yaml
+++ b/app/sample_templates/two_fa_sms_en_fr.yaml
@@ -4,7 +4,7 @@ template_name:
   fr: "EN|fr Code de vérification à deux étapes"
 notification_type: "sms"
 template_category: "authentication"
-pinned: true
+pinned: false
 content: |
   ((verify_code)) is your -application name- verification code | ((verify_code)) est votre code de vérification de -nom de l'application-
 example_content: |


### PR DESCRIPTION
# Summary | Résumé

Remove pin from sample sms template - we forgot to include this with today's release.

# Test instructions | Instructions pour tester la modification

In the review app, navigate to the sample library page, click the sms tab, and verify that there are no pinned templates.