### PR TITLE
Add result announcement when filtering templates

### DIFF
--- a/app/assets/javascripts/liveSearch.js
+++ b/app/assets/javascripts/liveSearch.js
@@ -3,30 +3,69 @@
 
   let normalize = (string) => string.toLowerCase().replace(/ /g, "");
 
-  let filter = ($searchBox, $targets) => () => {
-    let query = normalize($searchBox.val());
+  // Debounce utility function
+  let debounce = (func, delay) => {
+    let timeoutId;
+    return function (...args) {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => func.apply(this, args), delay);
+    };
+  };
 
-    $targets.each(function () {
-      let content = $(".live-search-relevant", this).text() || $(this).text();
+  let updateAriaLiveStatus = ($targets, query) => {
+    let visibleCount = $targets.filter(":visible").length;
+    let statusElement = document.getElementById("template-list-status");
 
-      if ($(this).has(":checked").length) {
-        $(this).show();
-        return;
+    if (statusElement) {
+      if (query === "") {
+        statusElement.textContent = `${$targets.length} results found`;
+      } else {
+        statusElement.textContent = `${visibleCount} results found for "${query}"`;
       }
-
-      if (query == "") {
-        $(this).css("display", "");
-        return;
-      }
-
-      $(this).toggle(normalize(content).indexOf(normalize(query)) > -1);
-    });
-
-    // make sticky JS recalculate its cache of the element's position
-    // because live search can change the height document
-    if ("stickAtBottomWhenScrolling" in GOVUK) {
-      GOVUK.stickAtBottomWhenScrolling.recalculate();
     }
+  };
+
+  let filter = ($searchBox, $targets) => {
+    let immediateFilter = () => {
+      let query = normalize($searchBox.val());
+
+      $targets.each(function () {
+        let content = $(".live-search-relevant", this).text() || $(this).text();
+
+        if ($(this).has(":checked").length) {
+          $(this).show();
+          return;
+        }
+
+        if (query == "") {
+          $(this).css("display", "");
+          return;
+        }
+
+        $(this).toggle(normalize(content).indexOf(normalize(query)) > -1);
+      });
+
+      // make sticky JS recalculate its cache of the element's position
+      // because live search can change the height document
+      if ("stickAtBottomWhenScrolling" in GOVUK) {
+        GOVUK.stickAtBottomWhenScrolling.recalculate();
+      }
+    };
+
+    let debouncedAriaUpdate = debounce(() => {
+      let query = $searchBox.val().trim();
+      updateAriaLiveStatus($targets, query);
+    }, 1000);
+
+    return () => {
+      // Immediate visual filtering
+      immediateFilter();
+      // Delayed aria-live announcement to ensure that:
+      // 1. The user isn't overwhelmed with announcements
+      // 2. The filtered results announcement isn't skipped by the subsequent re-announcement of the
+      //    search textbox content / currently focused element
+      debouncedAriaUpdate();
+    };
   };
 
   Modules.LiveSearch = function () {

--- a/app/templates/views/templates/_template_list.html
+++ b/app/templates/views/templates/_template_list.html
@@ -28,7 +28,10 @@
       <fieldset>
         <legend class="sr-only">{{ _("Select templates and folders")}}</legend>
     {% endif %}
-    <div id="template-list-container">
+    <div id="template-list-container" aria-label="Search results" aria-live="polite" role="region">
+      <span class="sr-only" id="template-list-status" aria-live="polite">
+        {{ template_list | length }} results found
+      </span>
       {% set template_list_length = template_list | length %}
       {% for item in template_list %}
         <div class="template-list-item {% if display_checkboxes %}template-list-item-with-checkbox{% endif %} {% if item.ancestors %}template-list-item-hidden-by-default{% endif %} {% if not item.ancestors %}template-list-item-without-ancestors{% endif %}" data-notification-type="{{ item.hint }}" data-template-category="{{ _('Other') if item.template_category.hidden else item.template_category[template_category_name_col] }}" data-testid="template-row">


### PR DESCRIPTION
# Summary | Résumé
This PR adds a results announcement when filtering the template list

# Test instructions | Instructions pour tester la modification
1. Navigate to the templates page
2. Turn on voice over and filter a template by name with the text box
3. Note the announcement "X templates found" 
4. Note that focus is maintained on the search box
5. Note that the content of the text box is announced after the result announcement.
6. Note that the 
