### PR TITLE
Remove `role="link"` from `label` element

### DIFF
--- a/app/templates/components/file-upload.html
+++ b/app/templates/components/file-upload.html
@@ -48,7 +48,7 @@
 
       {{ field(**{ 'class': 'file-upload-field', 'accept': accept, 'aria-describedby': 'file-description', 'data-error-msg': field.validators and field.validators[0].message, 'data-testid': field_testid}) }}
 
-      <label id="file-upload-button" class="file-upload-button button {{ button_class }}" for="{{ field.name }}" role="link">{{ button_text }}</label>
+      <label id="file-upload-button" class="file-upload-button button {{ button_class }}" for="{{ field.name }}">{{ button_text }}</label>
 
     <div class="file-upload-extra pt-gutterHalf flex flex-col gap-4">
       <span id="file-description">{{ _("No file currently selected") }}</span>


### PR DESCRIPTION
# Summary | Résumé

Remove `role="link"` from the "Choose a file" button/label element on the "upload a spreadsheet" page.

Issue: https://github.com/cds-snc/notification-planning/issues/2368

# Test instructions | Instructions pour tester la modification

1. open the review app
2. start on the flow to send to many recipients
3. verify the `role="link"` is not on the `label` element, and that you can still navigate the page with voiceover