### PR TITLE
Add aria label to validation summary

### DIFF
--- a/app/templates/components/validation-summary.html
+++ b/app/templates/components/validation-summary.html
@@ -1,7 +1,11 @@
 {% macro validation_summary(form=None, field_order=None) %}
   {% if form and form.errors %}
-    <div role="alert" tabindex="-1" class="border-4 border-red focus:outline-yellow mb-gutter p-gutter space-y-gutterHalf" id="validation-summary" data-testid="validation_summary" autofocus>
-      <h2 class="heading-medium m-0">{{ _('There was a problem') }}</h2>
+    <div role="alert" tabindex="-1"
+         class="border-4 border-red focus:outline-yellow mb-gutter p-gutter space-y-gutterHalf"
+         id="validation-summary"
+         data-testid="validation_summary"
+         aria-labelledby="validation-summary-heading">
+      <h2 id="validation-summary-heading" class="heading-medium m-0">{{ _('There was a problem') }}</h2>
       <ol class="list list-number list-outside m-0">
         {# Get a list of error keys #}
         {% set error_fields = form.errors.keys()|list %}
@@ -20,13 +24,13 @@
           {% if form[field].type != 'HiddenField' %}
             <li>
               <a class="link:text-red text-red visited:text-red" href="#{{ field }}">
-                <span class="font-bold">{{ form[field].label.text}}</span>: 
+                <span class="font-bold">{{ form[field].label.text}}</span>:
                 {{ form.errors[field][0] }}
               </a>
             </li>
           {% endif %}
         {% endfor %}
-      </ul>
+      </ol>
     </div>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
# Summary | Résumé

Added aria-labelledby="error-heading-id" where the heading has id="error-heading-id" (e.g.,
There was a problem
).

# Test instructions | Instructions pour tester la modification

1. Added an ID to h2 heading
2. fixed the ol/ul tags