### PR TITLE
Pill component - fix issue with missing `aria-labelledby` id

### DIFF
--- a/app/templates/components/pill.html
+++ b/app/templates/components/pill.html
@@ -22,7 +22,7 @@
       {% set count = item[3] %}
       {% set icon = item[4] if item|length > 4 else None %}
       {% if current_value == option or (loop.index == 1 and ns.current_value_not_in_items) %}
-        <a href="{{ link }}" class='pill-selected-item' aria-current='true'>
+        <a href="{{ link }}" class='pill-selected-item' id="pill-selected-item" aria-current='true'>
       {% else %}
         <a href="{{ link }}" class='pill-unselected-item'>
       {% endif %}

--- a/app/templates/components/pill.html
+++ b/app/templates/components/pill.html
@@ -5,7 +5,8 @@
   current_value=None,
   big_number_args={'smaller': True},
   show_count=True,
-  label=""
+  label="",
+  include_id=True
 ) %}
   {% set ns = namespace(current_value_not_in_items=True) %}
   {% for item in items %}
@@ -22,7 +23,7 @@
       {% set count = item[3] %}
       {% set icon = item[4] if item|length > 4 else None %}
       {% if current_value == option or (loop.index == 1 and ns.current_value_not_in_items) %}
-        <a href="{{ link }}" class='pill-selected-item' id="pill-selected-item" aria-current='true'>
+        <a href="{{ link }}" class='pill-selected-item'{% if include_id %} id="pill-selected-item"{% endif %} aria-current='true'>
       {% else %}
         <a href="{{ link }}" class='pill-unselected-item'>
       {% endif %}

--- a/app/templates/partials/jobs/notifications.html
+++ b/app/templates/partials/jobs/notifications.html
@@ -10,7 +10,7 @@
 {% set heading_2 = _('Review Address') %}
 {% set heading_3 = right_aligned_field_heading(_('Status')) %}
 
-<div class="ajax-block-container" aria-labelledby='pill-selected-item'>
+<div class="ajax-block-container">
   {% if job.job_status != 'scheduled' %} 
     <div class="dashboard-table">
       {% call(item, row_number) list_table(

--- a/app/templates/partials/jobs/notifications_header.html
+++ b/app/templates/partials/jobs/notifications_header.html
@@ -2,7 +2,7 @@
 {% from "components/form.html" import form_wrapper %}
 {% from "components/problem-email-checkbox.html" import problem_email_checkbox %}
 
-<div class="ajax-block-container" aria-labelledby='pill-selected-item'>
+<div class="ajax-block-container">
   {% if job.job_status == 'scheduled' %}
     {% set btn_txt = _('Cancel scheduled send') %}
     <div class="page-footer">

--- a/app/templates/views/activity/notifications.html
+++ b/app/templates/views/activity/notifications.html
@@ -4,7 +4,7 @@
 {% from "components/is-problem-email.html" import is_probem_email %}
 {% from "components/empty-list.html" import empty_list  %}
 
-<div class="ajax-block-container" id='pill-selected-item'>
+<div class="ajax-block-container">
   {% set empty_txt = empty_list(_('You have not sent messages recently'), _('Messages sent within the last {} days will show up here. Start with one of your templates to send messages.').format(limit_days), 'emptyFlower', url_for('main.choose_template', service_id=service_id), _('Go to your templates')) %}
   {% set heading_1 = _('Recipient') %}
   {% set heading_2 = _('Review Address') %}

--- a/app/templates/views/dashboard/monthly.html
+++ b/app/templates/views/dashboard/monthly.html
@@ -75,7 +75,7 @@
    {% set heading_1 = _('Month') %}
    {% set heading_2 = _('Emails') %}
    {% set heading_3 = _('Text messages') %}
-    <div class="body-copy-table" id='pill-selected-item'>
+    <div class="body-copy-table">
       {% call(month, row_index) list_table(
         months,
         caption=spend_txt,

--- a/app/templates/views/jobs/job.html
+++ b/app/templates/views/jobs/job.html
@@ -90,21 +90,24 @@
         {{ ajax_block(partials, updates_url, 'status', finished=finished) }}
       {% endif %}
 
+      <!-- PILLS -->
       {{ ajax_block(partials, updates_url, 'counts', finished=finished) }}
 
-      {% if not job.archived %}
-        {{ ajax_block(partials, updates_url, 'notifications_header', finished=finished) }}
-        {{ ajax_block(partials, updates_url, 'notifications', finished=finished) }}
-      {% else %}
-
-      {{ empty_list(
-          _("GC Notify disposed of the information in this report on <time class='local-datetime-short'>{}</time>").format(job.updated_at),
-          _('After {} days, we keep only non-identifying statistics.').format(svc_retention_days),
-          'emptyBirdHole'
-        )
-      }}
-      {% endif %}
-
+      <div aria-labelledby='pill-selected-item' role="tabpanel">
+        {% if not job.archived %}
+          <!-- CHECKBOX only show -->
+          {{ ajax_block(partials, updates_url, 'notifications_header', finished=finished) }}
+          <!-- Notifications table -->
+          {{ ajax_block(partials, updates_url, 'notifications', finished=finished) }}
+        {% else %}
+          {{ empty_list(
+              _("GC Notify disposed of the information in this report on <time class='local-datetime-short'>{}</time>").format(job.updated_at),
+              _('After {} days, we keep only non-identifying statistics.').format(svc_retention_days),
+              'emptyBirdHole'
+            )
+          }}
+        {% endif %}
+      </div>
     {% endif %}
 
 

--- a/app/templates/views/storybook/pill.html
+++ b/app/templates/views/storybook/pill.html
@@ -14,7 +14,8 @@
         ],
         current_value='email',
         show_count=True,
-        label='Filter templates by type'
+        label='Filter templates by type',
+        include_id=False
     ) }}
 </div>
 
@@ -29,7 +30,8 @@
         ],
         current_value='all',
         show_count=False,
-        label='Filter notifications by type'
+        label='Filter notifications by type',
+        include_id=False
     ) }}
 </div>
 
@@ -43,7 +45,8 @@
         ],
         current_value='dashboard',
         show_count=False,
-        label='Navigation menu'
+        label='Navigation menu',
+        include_id=False
     ) }}
 </div>
 
@@ -58,7 +61,8 @@
         ],
         current_value='pending',
         show_count=False,
-        label='Status filter'
+        label='Status filter',
+        include_id=False
     ) }}
 </div>
 
@@ -75,7 +79,8 @@
         ],
         current_value='inbox-5',
         show_count=True,
-        label='Email folders'
+        label='Email folders',
+        include_id=False
     ) }}
 </div>
 
@@ -89,7 +94,8 @@
         ],
         current_value='sent-6',
         show_count=True,
-        label='Email folders 2'
+        label='Email folders 2',
+        include_id=False
     ) }}
 </div>
 
@@ -103,6 +109,7 @@
         ],
         current_value='drafts-7',
         show_count=True,
-        label='Email folders 3'
+        label='Email folders 3',
+        include_id=False
     ) }}
 </div>

--- a/app/templates/views/usage.html
+++ b/app/templates/views/usage.html
@@ -16,7 +16,7 @@
     <div class="mb-12 clear-both contain-floats">
       {{ pill(years, selected_year, big_number_args={'smallest': True}, label=_("Filter by year")) }}
     </div>
-    <div id='pill-selected-item'>
+    <div>
       <div class='grid-row contain-floats'>
         <div class='w-1/2 float-left py-0 px-0 px-gutterHalf box-border'>
           <h2 class='heading-small'>Emails</h2>


### PR DESCRIPTION
# Summary | Résumé

Fix for: https://github.com/cds-snc/notification-planning/issues/2349
Screenshot of issue: https://drive.google.com/drive/folders/121EPnNRWEbGrHPd9vKXNt6xw_SpAsh3V

Other elements on the page use `aria-labelledby="pill-selected-item"`, but no element with that ID exists on the page. This should point to the title of the currently selected tab (see w3c [example](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-manual/)).

I added the id to the currently selected tab.

# Test instructions | Instructions pour tester la modification

1. open the review app
3. navigate to a jobs page 
4. turn on voiceover and verify that the title of the currently selected tab is read out when you focus the "only show problem addresses" checkbox and the table

https://github.com/user-attachments/assets/da491902-700d-4b05-bfdb-4e81de655249


