### PR TITLE
Ensure select lists are properly labeled

### DIFF
--- a/app/templates/components/select-input.html
+++ b/app/templates/components/select-input.html
@@ -6,10 +6,12 @@
     field, hint, disable, option_hints, hide_legend, collapsible_opts, legend_style, input, is_page_heading, use_aria_labelledby, testid, optional
   ) %}
   {% for option in field %}
-    {{ select_input(option, disable, option_hints, input=input, option_conditionals=option_conditionals, testid=option.data, badge_options=badge_options, bordered=bordered) }}
+    {{ select_input(option, disable, option_hints, input=input, option_conditionals=option_conditionals, testid=option.data, badge_options=badge_options, bordered=bordered, use_aria_labelledby=use_aria_labelledby) }}
   {% endfor %}
   {% endcall %}
 {% endmacro %}
+
+
 {% macro select_list(options, child_map, disable=[], option_hints={}, input="radio") %}
   <ul>
     {% for option in options %}
@@ -23,6 +25,8 @@
     {% endfor %}
   </ul>
 {% endmacro %}
+
+
 {% macro select_nested(field, child_map, hint=None, disable=[], option_hints={}, hide_legend=False, collapsible_opts={}, legend_style="text", input="radio") %}
   {% call select_wrapper(
     field, hint, disable, option_hints, hide_legend, collapsible_opts, legend_style, input
@@ -37,6 +41,8 @@
   </div>
   {% endcall %}
 {% endmacro %}
+
+
 {% macro select_wrapper(field, hint=None, disable=[], option_hints={}, hide_legend=False, collapsible_opts={}, legend_style="text", input="radio", is_page_heading=False, use_aria_labelledby=True, testid=None, optional=False) %}
   {% set is_collapsible = collapsible_opts|length %}
   <div class="form-group contain-floats box-border mb-gutterHalf md:mb-gutter {% if field.errors %} form-group-error{% endif %}" {% if is_collapsible %} data-module="collapsible-checkboxes" {% if collapsible_opts.field %} data-field-label="{{ collapsible_opts.field }}" {% endif %} {% endif %}>
@@ -65,7 +71,9 @@
     </fieldset>
   </div>
 {% endmacro %}
-{% macro select_input(option, disable=[], option_hints={}, data_target=None, as_list_item=False, input="radio", option_conditionals={}, testid=None, badge_options=None, bordered=None) %}
+
+
+{% macro select_input(option, disable=[], option_hints={}, data_target=None, as_list_item=False, input="radio", option_conditionals={}, testid=None, badge_options=None, bordered=None, use_aria_labelledby=True) %}
   {% set has_conditional = option_conditionals[option.data] %}
   {% if as_list_item %}
     <li class="multiple-choice" {% if data_target %} data-target="{{ data_target }}" {% endif %}>
@@ -73,7 +81,7 @@
       {% set border_class = ' border-b-1 border-gray-200' if bordered else '' %}
       <div class="multiple-choice{{ ' w-3/4' if bordered else '' }}{{ border_class }}{{ ' has-conditional' if has_conditional}}" {% if data_target %} data-target="{{ data_target }}" {% endif %}>
       {% endif %}
-      <input id="{{ option.id }}" name="{{ option.name }}" type="{{ input }}" value="{{ option.data }}" {% if testid %} data-testid="{{ testid }}" {% endif %} {% if option.data in disable %} disabled {% endif %} {% if option.checked %} checked {% endif %}>
+      <input id="{{ option.id }}" name="{{ option.name }}" type="{{ input }}" value="{{ option.data }}" {% if testid %} data-testid="{{ testid }}" {% endif %} {% if option.data in disable %} disabled {% endif %} {% if option.checked %} checked {% endif %} {% if use_aria_labelledby %} aria-labelledby="{{ option.id }}" {% endif %}>
         <label class="block-label w-full" for="{{ option.id }}">
           {{ option.label.text.split("||")[0] if '||' in option.label.text else option.label.text }}
           {% if badge_options and badge_options[option.data] %}

--- a/app/templates/views/service-settings/use-case.html
+++ b/app/templates/views/service-settings/use-case.html
@@ -29,9 +29,9 @@
         {% if display_org_question %}
           {{ textbox(form.department_org_name, autocomplete='organization') }}
         {% endif %}
-        {{ checkboxes(form.main_use_case, option_hints=form.main_use_case_hints, use_aria_labelledby=false) }}
+        {{ checkboxes(form.main_use_case, option_hints=form.main_use_case_hints) }}
         {{ textbox(form.other_use_case, width="w-full", rows=3, required=false) }}
-        {{ checkboxes(form.intended_recipients, use_aria_labelledby=false) }}
+        {{ checkboxes(form.intended_recipients) }}
 
       {% elif current_step == "about-notifications" %}
 
@@ -39,18 +39,18 @@
           {{ _("This information helps us set sending limits and budget accordingly.") }}
         </p>
         <h2 class="heading-medium">{{ _("Emails") }}</h2>
-        {{ select(form.daily_email_volume, option_conditionals=form.volume_conditionals, use_aria_labelledby=false) }}
-        {{ select(form.annual_email_volume, option_conditionals=form.volume_conditionals, use_aria_labelledby=false) }}
-        
+        {{ select(form.daily_email_volume, option_conditionals=form.volume_conditionals) }}
+        {{ select(form.annual_email_volume, option_conditionals=form.volume_conditionals) }}
+
         <h2 class="heading-medium">{{ _("Text messages") }}</h2>
-        {{ select(form.daily_sms_volume, option_conditionals=form.volume_conditionals, use_aria_labelledby=false) }}
-        {{ select(form.annual_sms_volume, option_conditionals=form.volume_conditionals, use_aria_labelledby=false) }}
+        {{ select(form.daily_sms_volume, option_conditionals=form.volume_conditionals) }}
+        {{ select(form.annual_sms_volume, option_conditionals=form.volume_conditionals) }}
 
 
         <!-- Coming from the previous step. If it's not included, checkboxes will be reset -->
         <div class="hidden">
-          {{ checkboxes(form.intended_recipients, use_aria_labelledby=false) }}
-          {{ checkboxes(form.main_use_case, use_aria_labelledby=false) }}
+          {{ checkboxes(form.intended_recipients) }}
+          {{ checkboxes(form.main_use_case) }}
         </div>
       {% endif %}
 


### PR DESCRIPTION
# Summary | Résumé

This PR fixes https://github.com/cds-snc/notification-planning/issues/2289.

- Add aria-labelledby to checkbox and radio button inputs which are part of select input groups
- Removed explicit non-use of aria-labelledby for select lists in the go-live checklist pages


# Test instructions | Instructions pour tester la modification
1. On a trial services click `Request to go live` -> `Tell us about how you intend to use GC Notify`
2. Turn on VoiceOver and select one of the checkboxes
3. Note that `label`, `hint`, and associated `fieldset legend` are announced
4. Completed the first step -> on the second step select a radio button in one of the groups
5. Note the same behaviour as in step 3, minus the `hint` as there are none for these radio buttons.