### PR TITLE
Add aria label to the row preview links on the CSV upload page

### DIFF
--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -42,8 +42,9 @@
           ] + recipients.column_headers
         ) %}
         {% call index_field() %}
-          <a class="text-small" href="{{url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=(item.index + 2), original_file_name=original_file_name, _anchor='ok-preview')}}">
-            {{item.index + 2}}
+          {% set row_index = item.index + 2 %}
+          <a class="text-small" href="{{url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=row_index, original_file_name=original_file_name, _anchor='ok-preview')}}" aria-label="{{'Preview row {} of {}'.format(row_index, original_file_name)}}""></a>
+            {{row_index}}
           </a>
         {% endcall %}
 

--- a/app/templates/views/check/ok.html
+++ b/app/templates/views/check/ok.html
@@ -43,7 +43,7 @@
         ) %}
         {% call index_field() %}
           {% set row_index = item.index + 2 %}
-          <a class="text-small" href="{{url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=row_index, original_file_name=original_file_name, _anchor='ok-preview')}}" aria-label="{{'Preview row {} of {}'.format(row_index, original_file_name)}}""></a>
+          <a class="text-small" href="{{url_for('.check_messages', service_id=current_service.id, template_id=template.id, upload_id=upload_id, row_index=row_index, original_file_name=original_file_name, _anchor='ok-preview')}}" aria-label="{{'Preview row {} of {}'.format(row_index, original_file_name)}}">
             {{row_index}}
           </a>
         {% endcall %}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2329,3 +2329,4 @@
 "templates found","gabarits trouvés"
 "Moved {} items to the '{}' folder","{} items déplacés vers le dossier '{}'"
 "Moved {} item to the '{}' folder","{} item déplacé vers le dossier '{}'"
+"Preview row {} of {}","Aperçu de la ligne {} de {}"


### PR DESCRIPTION
# Summary | Résumé

Add aria label to the row preview links on the CSV upload page

Fixes: https://github.com/cds-snc/notification-planning/issues/2357

# Test instructions | Instructions pour tester la modification

1. open the review app
2. select a template to send and upload a csv file 
3. Verify that the row number links have an `aria-label`:
<img width="1424" height="168" alt="Screenshot 2025-09-11 at 2 52 36 PM" src="https://github.com/user-attachments/assets/ba41f5b0-a059-4fb3-beb0-cdf3c50eb743" />
