### PR TITLE
Fix error relationship for TOU trigger button

### DIFF
--- a/app/templates/components/tou-dialog.html
+++ b/app/templates/components/tou-dialog.html
@@ -49,7 +49,7 @@
   {% endif %}
   <ul class="task-list mt-6">
     <li class="task-list-item">
-      <button type="button" class="font-bold" id="tou-dialog-trigger" aria-describedby="tou-status"
+      <button type="button" class="font-bold" id="tou-dialog-trigger" aria-describedby="tou-status{% if is_in_error_state %} tou-error-message{% endif %}"
         data-testid="tou-dialog-trigger">{{ button_text }}</button>
       <span id="tou-status">
         {{ task_list_item_complete('tou-complete', testid='tou-complete') }}

--- a/tests_cypress/cypress/e2e/admin/tou_dialog.cy.js
+++ b/tests_cypress/cypress/e2e/admin/tou_dialog.cy.js
@@ -80,11 +80,17 @@ describe("TOU Dialog", () => {
       RegisterPage.Components.TOUStatusComplete().should("be.visible");
     });
 
-    it("Displays error message/error summary if terms not agreed and user submits form", () => {
+    it.only("Displays error message/error summary if terms not agreed and user submits form", () => {
       RegisterPage.Continue();
       RegisterPage.Components.TOUErrorMessage().should("be.visible");
       RegisterPage.Components.TOUValidationSummaryErrorMessage().should(
         "be.visible",
+      );
+      // ensure #tou-dialog-trigger has aria-describedby="tou-status tou-error-message"
+      RegisterPage.Components.TOUTrigger().should(
+        "have.attr",
+        "aria-describedby",
+        "tou-status tou-error-message"
       );
     });
 

--- a/tests_cypress/cypress/e2e/admin/tou_dialog.cy.js
+++ b/tests_cypress/cypress/e2e/admin/tou_dialog.cy.js
@@ -90,7 +90,7 @@ describe("TOU Dialog", () => {
       RegisterPage.Components.TOUTrigger().should(
         "have.attr",
         "aria-describedby",
-        "tou-status tou-error-message"
+        "tou-status tou-error-message",
       );
     });
 


### PR DESCRIPTION
# Summary | Résumé
This pull request makes a targeted improvement to the accessibility of the Terms of Use dialog component. The change ensures that the `aria-describedby` attribute on the dialog trigger button dynamically includes the error message reference when the dialog is in an error state. This helps screen readers provide more accurate context to users.

# Test instructions | Instructions pour tester la modification
- go to register page (`/register`)
- [ ] Ensure the trigger button (id `tou-dialog-trigger`) has an `aria-describedby` attribute of `tou-status`
- Click **Continue**
- [ ] Ensure the trigger button (id `tou-dialog-trigger`) has an `aria-describedby` attribute of `tou-status tou-error-message`