### PR TITLE
Improve accessibility of `more` menus

### DIFF
--- a/app/assets/javascripts/moreMenu.js
+++ b/app/assets/javascripts/moreMenu.js
@@ -1,7 +1,6 @@
 (function (Modules) {
   "use strict";
 
-  const registerKeyDownEscape = window.utils.registerKeyDownEscape;
   const registerKeyBasedMenuNavigation =
     window.utils.registerKeyBasedMenuNavigation;
 

--- a/app/assets/javascripts/moreMenu.js
+++ b/app/assets/javascripts/moreMenu.js
@@ -1,13 +1,24 @@
 (function (Modules) {
   "use strict";
 
+  const registerKeyDownEscape = window.utils.registerKeyDownEscape;
+  const registerKeyBasedMenuNavigation =
+    window.utils.registerKeyBasedMenuNavigation;
+
   // Toggles the visibility of the more menu and updates the aria-expanded attribute.
-  function toggleMenu($moreMenuButton, $moreMenu) {
+  function toggleMenu($moreMenuButton, $moreMenu, $items) {
     const isExpanded = $moreMenuButton.attr("aria-expanded") == "true";
     // Toggle the aria-expanded attribute FIRST
     $moreMenuButton.attr("aria-expanded", !isExpanded);
     // If true, class is added. To show the menu, we toggle with the inverse of isExpanded.
     $moreMenu.toggleClass("hidden", isExpanded);
+    // If opening the menu, set focus to the first item
+    if (!isExpanded) {
+      $moreMenuButton.selectedMenuItem = 0;
+      $items.children().find("[href]").attr("tabindex", "-1");
+      $items.children().first().find("[href]").trigger("focus");
+      $items.children().first().find("[href]").attr("tabindex", "0");
+    }
   }
 
   // Initializes the more menu functionality.
@@ -18,10 +29,80 @@
 
     const $menuItems = $(menuItemsId);
     const $moreMenu = $(menuContainerId);
+    const $moreMenuItems = $(
+      `#${$moreMenuButton.attr("data-module-menu-more-items")}`,
+    );
     let itemsWidth = 0;
+    //$moreMenuButton.selectedMenuItem = 0;
 
     // Attach click event handler
-    $moreMenuButton.click(() => toggleMenu($moreMenuButton, $moreMenu));
+    $moreMenuButton.click(() =>
+      toggleMenu($moreMenuButton, $moreMenu, $moreMenuItems),
+    );
+
+    // Bind Keypress events to the window so the user can use the arrow/home/end keys to navigate the drop down menu
+    registerKeyBasedMenuNavigation($(window), (event) =>
+      handleKeyBasedMenuNavigation(
+        event,
+        $moreMenuButton,
+        $moreMenu,
+        $moreMenuItems,
+      ),
+    );
+
+    // // Keep Escape key functionality for accessibility
+    // registerKeyDownEscape($(window), () => toggleMenu($moreMenuButton, $moreMenuItems));
+
+    /**
+     * Handles the keydown event for the $menu so the user can navigate the menu items via the keyboard.
+     * This function supports the following key presses:
+     * - Home/End to navigate to the first and last items in the menu
+     * - Up/Left/Shift + Tab to navigate to the previous item in the menu
+     * - Down/Right/Tab to navigate to the next item in the menu
+     * - Meta + (Left/Right OR Up/Down) to navigate to the first/last items in the menu
+     *
+     * @param {KeyboardEvent} event The keydown event object
+     * @param {jQuery Object} $menu The menu button that controls the disclosure menu items container
+     * @param {jQuery Object} $items The unordered list containing menu items
+     */
+    function handleKeyBasedMenuNavigation(event, $menu, $container, $items) {
+      if ($menu.attr("aria-expanded") == "true") {
+        // Menu Button Keyboard Interaction: https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/
+        // Left and Right arrows do nothing because we don't support sub menus
+        // Note the difference between menubar and menu in the above guidance. We made a menu, not a menubar.
+
+        var menuItems = $items.children();
+
+        if (event.key === "ArrowUp") {
+          // Up Arrow: Moves focus to and selects the previous option. If focus is on the first option, wraps to the last item.
+          event.preventDefault();
+          $menu.selectedMenuItem =
+            ($menu.selectedMenuItem - 1 + menuItems.length) % menuItems.length;
+        } else if (event.key === "ArrowDown") {
+          // Down Arrow: Moves focus to and selects the next option. If focus is on the last option, wraps to the first item.
+          event.preventDefault();
+          $menu.selectedMenuItem =
+            ($menu.selectedMenuItem + 1) % menuItems.length;
+        } else if (event.key === "Escape") {
+          // Escape: Close the menu that contains focus and return focus to the element or context, e.g., menu button or parent menuitem, from which the menu was opened.
+          event.preventDefault();
+          toggleMenu($menu, $container, $items);
+          $menu.trigger("focus");
+        } else if (event.key === "Tab") {
+          // Tab: Nothing. Should close the popup and move to the next interactive element on the page, so we will close the menu so it does not obscure anything.
+          toggleMenu($menu, $container, $items);
+          // We don't prevent default. We don't trigger focus, because the selectedMenuItem is in the collapsed menu.
+          return;
+        }
+        // Once we've determined the new selected menu item, we need to focus on it
+        var $selected_item = $($items.children()[$menu.selectedMenuItem]).find(
+          "[href]",
+        );
+        $selected_item.trigger("focus");
+        $items.children().find("[href]").attr("tabindex", "-1");
+        $selected_item.attr("tabindex", "0");
+      }
+    }
 
     // Determines whether an element overflows, excluding the more button.
     function shouldItemOverflow(element, containerWidth, moreButtonWidth) {

--- a/app/templates/views/storybook/more-menu.html
+++ b/app/templates/views/storybook/more-menu.html
@@ -12,15 +12,22 @@ When we have a lot of menu items, we can use a more menu to hide elements into a
             </li>
         {% endfor %}
     </ul>
+    <!-- $moreMenuButton -->
     <button id="more-menu-story-button" type="button"
         aria-expanded="false" aria-haspopup="true"
+        aria-label="{{ _('More menu items') }}"
         class="nav-menu-item justify-end px-4 w-min"
-        data-module-menu-container="more-menu-story-container" data-has-items="false"
-        data-module="more-menu" data-module-menu-items="more-menu-story">
+        data-module-menu-container="more-menu-story-container"
+        data-has-items="false"
+        data-module="more-menu"
+        data-module-menu-items="more-menu-story"
+        data-module-menu-more-items="more-menu-story-items">
         {{ _("More") }}
         <i aria-hidden="true" class="fa-solid fa-angle-down"></i>
       </button>
+      <!-- $moreMenu -->
       <div id="more-menu-story-container" class="relative self-end hidden">
+        <!-- $menuItems -->
         <ul id="more-menu-story-items" class="menu-overlay absolute right-0 text-right empty:hidden w-max top-full"></ul>
       </div>
 </nav>
@@ -38,15 +45,22 @@ More menu should remove itself once items fit in the menu.
             </li>
         {% endfor %}
     </ul>
+    <!-- $moreMenuButton -->
     <button id="more-menu-story-2-button" type="button"
-        aria-expanded="false" aria-haspopup="true"
+        aria-expanded="false"
+        aria-haspopup="true"
         class="nav-menu-item justify-end px-4 w-min"
-        data-module-menu-container="more-menu-story-2-container" data-has-items="false"
-        data-module="more-menu" data-module-menu-items="more-menu-story-2">
+        data-module-menu-container="more-menu-story-2-container"
+        data-has-items="false"
+        data-module="more-menu"
+        data-module-menu-items="more-menu-story-2"
+        data-module-menu-more-items="more-menu-story-2-items">
         {{ _("More") }}
         <i aria-hidden="true" class="fa-solid fa-angle-down"></i>
       </button>
+      <!-- $moreMenu -->
       <div id="more-menu-story-2-container" class="relative self-end hidden">
+        <!-- $menuItems -->
         <ul id="more-menu-story-2-items" class="menu-overlay absolute right-0 text-right empty:hidden w-max top-full"></ul>
       </div>
 </nav>

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2335,3 +2335,4 @@
 "Warning: nearing annual limits","Avertissement&nbsp;: approche de la limite annuelle"
 "Warning: nearing daily limit","Avertissement&nbsp;: approche de la limite quotidienne"
 "Within annual limits","Dans les limites annuelles"
+"More menu items","Plus d’éléments du menu"

--- a/tests_cypress/cypress/e2e/admin/components/more_menu.cy.js
+++ b/tests_cypress/cypress/e2e/admin/components/more_menu.cy.js
@@ -189,259 +189,62 @@ describe("Disclosure Menu components", () => {
     });
   });
 
-  let PageURL = "/_storybook?component=more-menu";
-
-  describe("Disclosure Menu components", () => {
-    // Add handler for ResizeObserver errors
-    Cypress.on("uncaught:exception", (err) => {
-      // Return false to prevent Cypress from failing the test
-      if (
-        err.message.includes(
-          "ResizeObserver loop completed with undelivered notifications",
-        )
-      ) {
-        return false;
-      }
-      // For other errors, let Cypress handle them normally
-      return true;
+  describe("Accessibility and keyboard navigation for More menu", () => {
+    beforeEach(() => {
+      cy.visit(PageURL);
+      cy.viewport(1000, 800);
+      cy.get("#more-menu-story-button").should("be.visible");
+      cy.get("#more-menu-story-button").click();
+      cy.get("#more-menu-story-container").should("not.have.class", "hidden");
     });
 
-    describe("Long menu example", () => {
-      beforeEach(() => {
-        cy.visit(PageURL);
-        // Ensure we're above mobile breakpoint
-        cy.viewport(1000, 800);
-        // Wait for the content to stabilize after initial load
-        cy.get("#more-menu-story-button").should("be.visible");
-      });
-
-      it("should show the More button with overflow items", () => {
-        // Check that the More button exists and is visible
-        cy.get("#more-menu-story-button").should("be.visible");
-
-        // Verify some items are in the main menu
-        cy.get("#more-menu-story > li").should("be.visible");
-
-        // Verify the More button has items (data attribute)
-        cy.get("#more-menu-story-button").should(
-          "have.attr",
-          "data-has-items",
-          "true",
-        );
-
-        // Verify the dropdown container is initially hidden
-        cy.get("#more-menu-story-container").should("have.class", "hidden");
-      });
-
-      it("should open the menu when clicking the More button", () => {
-        // Click the More button
-        cy.get("#more-menu-story-button").click();
-
-        // Verify the More button has aria-expanded = true
-        cy.get("#more-menu-story-button").should(
-          "have.attr",
-          "aria-expanded",
-          "true",
-        );
-
-        // Verify the dropdown container is visible
-        cy.get("#more-menu-story-container").should("not.have.class", "hidden");
-
-        // Verify the dropdown has items
-        cy.get("#more-menu-story-container ul li").should("exist");
-      });
-
-      it("should close the menu when clicking the More button again", () => {
-        // Open menu first
-        cy.get("#more-menu-story-button").click();
-        cy.get("#more-menu-story-container").should("not.have.class", "hidden");
-
-        // Click the More button again
-        cy.get("#more-menu-story-button").click();
-
-        // Verify the More button has aria-expanded = false
-        cy.get("#more-menu-story-button").should(
-          "have.attr",
-          "aria-expanded",
-          "false",
-        );
-
-        // Verify the dropdown container is hidden
-        cy.get("#more-menu-story-container").should("have.class", "hidden");
-      });
-
-      it("should respond to window resize by redistributing items", () => {
-        // Capture initial visible items state
-        cy.get('#more-menu-story > li[data-overflows="false"]').then(
-          ($visibleItems) => {
-            const initialCount = $visibleItems.length;
-
-            // Resize to a wider viewport
-            cy.viewport(1400, 800);
-
-            // Wait for the resize to finish by checking for an attribute change
-            cy.get('#more-menu-story > li[data-overflows="false"]', {
-              timeout: 5000,
-            }).should(($items) => {
-              // Check that we have more visible items than before
-              expect($items.length).to.be.at.least(initialCount);
-            });
-
-            // Now resize to a narrower viewport
-            cy.viewport(800, 800);
-
-            // Wait for the resize to finish and expect fewer visible items
-            cy.get("#more-menu-story-button", { timeout: 5000 }).should(
-              "have.attr",
-              "data-has-items",
-              "true",
-            );
-
-            cy.get('#more-menu-story > li[data-overflows="false"]').should(
-              ($items) => {
-                // We should have fewer items visible now
-                expect($items.length).to.be.at.most(initialCount);
-              },
-            );
-          },
-        );
-      });
+    it("focuses the first menu item when expanded", () => {
+      cy.get("#more-menu-story-container ul li")
+        .first()
+        .find("a")
+        .should("have.focus");
     });
 
-    describe("Shorter menu example", () => {
-      beforeEach(() => {
-        cy.visit(PageURL);
-        // Just ensure the page is loaded without assuming button visibility
-        cy.get("#more-menu-story-2").should("be.visible");
-      });
+    it("navigates menu items with arrow keys and wraps focus", () => {
+      cy.get("#more-menu-story-container ul li").as("menuItems");
+      cy.get("@menuItems").first().find("a").should("have.focus");
 
-      it("should hide 'More' button items when all fit in container", () => {
-        // Set viewport wide enough for all items to fit
-        cy.viewport(1400, 800);
+      // Arrow down to next item
+      cy.focused().type("{downArrow}");
+      cy.get("@menuItems").eq(1).find("a").should("have.focus");
 
-        // Wait for the menu to initialize and verify More button is properly configured
-        cy.get("#more-menu-story-2-button", { timeout: 5000 })
-          .should("have.attr", "data-has-items", "false")
-          .should("have.css", "display", "none");
-
-        // Verify all items are in the main menu
-        cy.get("#more-menu-story-2 > li").should(
-          "have.attr",
-          "data-overflows",
-          "false",
-        );
-      });
-
-      it("should show 'More' button items when container is too small", () => {
-        // Start with a narrow viewport where items won't fit
-        cy.viewport(800, 800);
-
-        // Wait for attribute to change
-        cy.get("#more-menu-story-2-button", { timeout: 5000 })
-          .should("have.attr", "data-has-items", "true")
-          .should("be.visible");
-
-        // Verify some items overflow
-        cy.get('#more-menu-story-2 > li[data-overflows="true"]').should(
-          "exist",
-        );
-
-        // Click More button and verify overflow items in dropdown
-        cy.get("#more-menu-story-2-button").click();
-        cy.get("#more-menu-story-2-container").should(
-          "not.have.class",
-          "hidden",
-        );
-        cy.get("#more-menu-story-2-container ul li").should("exist");
-      });
-
-      it("should transition between states when resizing", () => {
-        // Start with a wide viewport where all items fit
-        cy.viewport(1400, 800);
-
-        // Initially the More button should be hidden
-        cy.get("#more-menu-story-2-button", { timeout: 5000 })
-          .should("have.attr", "data-has-items", "false")
-          .should("have.css", "display", "none");
-
-        // Resize to a narrow viewport
-        cy.viewport(800, 800);
-
-        // The More button should appear
-        cy.get("#more-menu-story-2-button", { timeout: 5000 })
-          .should("have.attr", "data-has-items", "true")
-          .should("be.visible");
-
-        // Resize back to a wide viewport
-        cy.viewport(1400, 800);
-
-        // The More button should disappear again
-        cy.get("#more-menu-story-2-button", { timeout: 5000 })
-          .should("have.attr", "data-has-items", "false")
-          .should("have.css", "display", "none");
-
-        // Dropdown should be empty
-        cy.get("#more-menu-story-2-container ul").should("be.empty");
-      });
-    });
-
-    describe("Accessibility and keyboard navigation for More menu", () => {
-      beforeEach(() => {
-        cy.visit(PageURL);
-        cy.viewport(1000, 800);
-        cy.get("#more-menu-story-button").should("be.visible");
-        cy.get("#more-menu-story-button").click();
-        cy.get("#more-menu-story-container").should("not.have.class", "hidden");
-      });
-
-      it("focuses the first menu item when expanded", () => {
-        cy.get("#more-menu-story-container ul li")
-          .first()
-          .find("a")
-          .should("have.focus");
-      });
-
-      it("navigates menu items with arrow keys and wraps focus", () => {
-        cy.get("#more-menu-story-container ul li").as("menuItems");
-        cy.get("@menuItems").first().find("a").should("have.focus");
-
-        // Arrow down to next item
-        cy.focused().type("{downArrow}");
-        cy.get("@menuItems").eq(1).find("a").should("have.focus");
-
-        // Arrow down to last item
-        cy.get("@menuItems").then(($items) => {
-          const lastIndex = $items.length - 1;
-          cy.log("Last index:", lastIndex);
-          // cy.pause();
-          for (let i = 1; i < lastIndex; i++) {
-            cy.focused().type("{downArrow}");
-          }
-          cy.get("@menuItems").eq(lastIndex).find("a").should("have.focus");
-
-          // Arrow down again should wrap to first
+      // Arrow down to last item
+      cy.get("@menuItems").then(($items) => {
+        const lastIndex = $items.length - 1;
+        cy.log("Last index:", lastIndex);
+        // cy.pause();
+        for (let i = 1; i < lastIndex; i++) {
           cy.focused().type("{downArrow}");
-          cy.get("@menuItems").first().find("a").should("have.focus");
-        });
+        }
+        cy.get("@menuItems").eq(lastIndex).find("a").should("have.focus");
 
-        // Arrow up from first should wrap to last
-        cy.focused().type("{upArrow}");
-        cy.get("@menuItems").last().find("a").should("have.focus");
-      });
-
-      it.only("closes menu and returns focus to button on Esc", () => {
-        cy.get("#more-menu-story-container ul li").as("menuItems");
+        // Arrow down again should wrap to first
+        cy.focused().type("{downArrow}");
         cy.get("@menuItems").first().find("a").should("have.focus");
-        // cy.pause()
-        cy.focused().type("{esc}");
-        cy.focused().should("match", "#more-menu-story-button");
       });
 
-      it("More button has aria-label", () => {
-        cy.get("#more-menu-story-button")
-          .should("have.attr", "aria-label")
-          .and("not.be.empty");
-      });
+      // Arrow up from first should wrap to last
+      cy.focused().type("{upArrow}");
+      cy.get("@menuItems").last().find("a").should("have.focus");
+    });
+
+    it("closes menu and returns focus to button on Esc", () => {
+      cy.get("#more-menu-story-container ul li").as("menuItems");
+      cy.get("@menuItems").first().find("a").should("have.focus");
+      // cy.pause()
+      cy.focused().type("{esc}");
+      cy.focused().should("match", "#more-menu-story-button");
+    });
+
+    it("More button has aria-label", () => {
+      cy.get("#more-menu-story-button")
+        .should("have.attr", "aria-label")
+        .and("not.be.empty");
     });
   });
 });

--- a/tests_cypress/cypress/e2e/admin/components/more_menu.cy.js
+++ b/tests_cypress/cypress/e2e/admin/components/more_menu.cy.js
@@ -188,4 +188,260 @@ describe("Disclosure Menu components", () => {
       cy.get("#more-menu-story-2-container ul").should("be.empty");
     });
   });
+
+  let PageURL = "/_storybook?component=more-menu";
+
+  describe("Disclosure Menu components", () => {
+    // Add handler for ResizeObserver errors
+    Cypress.on("uncaught:exception", (err) => {
+      // Return false to prevent Cypress from failing the test
+      if (
+        err.message.includes(
+          "ResizeObserver loop completed with undelivered notifications",
+        )
+      ) {
+        return false;
+      }
+      // For other errors, let Cypress handle them normally
+      return true;
+    });
+
+    describe("Long menu example", () => {
+      beforeEach(() => {
+        cy.visit(PageURL);
+        // Ensure we're above mobile breakpoint
+        cy.viewport(1000, 800);
+        // Wait for the content to stabilize after initial load
+        cy.get("#more-menu-story-button").should("be.visible");
+      });
+
+      it("should show the More button with overflow items", () => {
+        // Check that the More button exists and is visible
+        cy.get("#more-menu-story-button").should("be.visible");
+
+        // Verify some items are in the main menu
+        cy.get("#more-menu-story > li").should("be.visible");
+
+        // Verify the More button has items (data attribute)
+        cy.get("#more-menu-story-button").should(
+          "have.attr",
+          "data-has-items",
+          "true",
+        );
+
+        // Verify the dropdown container is initially hidden
+        cy.get("#more-menu-story-container").should("have.class", "hidden");
+      });
+
+      it("should open the menu when clicking the More button", () => {
+        // Click the More button
+        cy.get("#more-menu-story-button").click();
+
+        // Verify the More button has aria-expanded = true
+        cy.get("#more-menu-story-button").should(
+          "have.attr",
+          "aria-expanded",
+          "true",
+        );
+
+        // Verify the dropdown container is visible
+        cy.get("#more-menu-story-container").should("not.have.class", "hidden");
+
+        // Verify the dropdown has items
+        cy.get("#more-menu-story-container ul li").should("exist");
+      });
+
+      it("should close the menu when clicking the More button again", () => {
+        // Open menu first
+        cy.get("#more-menu-story-button").click();
+        cy.get("#more-menu-story-container").should("not.have.class", "hidden");
+
+        // Click the More button again
+        cy.get("#more-menu-story-button").click();
+
+        // Verify the More button has aria-expanded = false
+        cy.get("#more-menu-story-button").should(
+          "have.attr",
+          "aria-expanded",
+          "false",
+        );
+
+        // Verify the dropdown container is hidden
+        cy.get("#more-menu-story-container").should("have.class", "hidden");
+      });
+
+      it("should respond to window resize by redistributing items", () => {
+        // Capture initial visible items state
+        cy.get('#more-menu-story > li[data-overflows="false"]').then(
+          ($visibleItems) => {
+            const initialCount = $visibleItems.length;
+
+            // Resize to a wider viewport
+            cy.viewport(1400, 800);
+
+            // Wait for the resize to finish by checking for an attribute change
+            cy.get('#more-menu-story > li[data-overflows="false"]', {
+              timeout: 5000,
+            }).should(($items) => {
+              // Check that we have more visible items than before
+              expect($items.length).to.be.at.least(initialCount);
+            });
+
+            // Now resize to a narrower viewport
+            cy.viewport(800, 800);
+
+            // Wait for the resize to finish and expect fewer visible items
+            cy.get("#more-menu-story-button", { timeout: 5000 }).should(
+              "have.attr",
+              "data-has-items",
+              "true",
+            );
+
+            cy.get('#more-menu-story > li[data-overflows="false"]').should(
+              ($items) => {
+                // We should have fewer items visible now
+                expect($items.length).to.be.at.most(initialCount);
+              },
+            );
+          },
+        );
+      });
+    });
+
+    describe("Shorter menu example", () => {
+      beforeEach(() => {
+        cy.visit(PageURL);
+        // Just ensure the page is loaded without assuming button visibility
+        cy.get("#more-menu-story-2").should("be.visible");
+      });
+
+      it("should hide 'More' button items when all fit in container", () => {
+        // Set viewport wide enough for all items to fit
+        cy.viewport(1400, 800);
+
+        // Wait for the menu to initialize and verify More button is properly configured
+        cy.get("#more-menu-story-2-button", { timeout: 5000 })
+          .should("have.attr", "data-has-items", "false")
+          .should("have.css", "display", "none");
+
+        // Verify all items are in the main menu
+        cy.get("#more-menu-story-2 > li").should(
+          "have.attr",
+          "data-overflows",
+          "false",
+        );
+      });
+
+      it("should show 'More' button items when container is too small", () => {
+        // Start with a narrow viewport where items won't fit
+        cy.viewport(800, 800);
+
+        // Wait for attribute to change
+        cy.get("#more-menu-story-2-button", { timeout: 5000 })
+          .should("have.attr", "data-has-items", "true")
+          .should("be.visible");
+
+        // Verify some items overflow
+        cy.get('#more-menu-story-2 > li[data-overflows="true"]').should(
+          "exist",
+        );
+
+        // Click More button and verify overflow items in dropdown
+        cy.get("#more-menu-story-2-button").click();
+        cy.get("#more-menu-story-2-container").should(
+          "not.have.class",
+          "hidden",
+        );
+        cy.get("#more-menu-story-2-container ul li").should("exist");
+      });
+
+      it("should transition between states when resizing", () => {
+        // Start with a wide viewport where all items fit
+        cy.viewport(1400, 800);
+
+        // Initially the More button should be hidden
+        cy.get("#more-menu-story-2-button", { timeout: 5000 })
+          .should("have.attr", "data-has-items", "false")
+          .should("have.css", "display", "none");
+
+        // Resize to a narrow viewport
+        cy.viewport(800, 800);
+
+        // The More button should appear
+        cy.get("#more-menu-story-2-button", { timeout: 5000 })
+          .should("have.attr", "data-has-items", "true")
+          .should("be.visible");
+
+        // Resize back to a wide viewport
+        cy.viewport(1400, 800);
+
+        // The More button should disappear again
+        cy.get("#more-menu-story-2-button", { timeout: 5000 })
+          .should("have.attr", "data-has-items", "false")
+          .should("have.css", "display", "none");
+
+        // Dropdown should be empty
+        cy.get("#more-menu-story-2-container ul").should("be.empty");
+      });
+    });
+
+    describe("Accessibility and keyboard navigation for More menu", () => {
+      beforeEach(() => {
+        cy.visit(PageURL);
+        cy.viewport(1000, 800);
+        cy.get("#more-menu-story-button").should("be.visible");
+        cy.get("#more-menu-story-button").click();
+        cy.get("#more-menu-story-container").should("not.have.class", "hidden");
+      });
+
+      it("focuses the first menu item when expanded", () => {
+        cy.get("#more-menu-story-container ul li")
+          .first()
+          .find("a")
+          .should("have.focus");
+      });
+
+      it("navigates menu items with arrow keys and wraps focus", () => {
+        cy.get("#more-menu-story-container ul li").as("menuItems");
+        cy.get("@menuItems").first().find("a").should("have.focus");
+
+        // Arrow down to next item
+        cy.focused().type("{downArrow}");
+        cy.get("@menuItems").eq(1).find("a").should("have.focus");
+
+        // Arrow down to last item
+        cy.get("@menuItems").then(($items) => {
+          const lastIndex = $items.length - 1;
+          cy.log("Last index:", lastIndex);
+          // cy.pause();
+          for (let i = 1; i < lastIndex; i++) {
+            cy.focused().type("{downArrow}");
+          }
+          cy.get("@menuItems").eq(lastIndex).find("a").should("have.focus");
+
+          // Arrow down again should wrap to first
+          cy.focused().type("{downArrow}");
+          cy.get("@menuItems").first().find("a").should("have.focus");
+        });
+
+        // Arrow up from first should wrap to last
+        cy.focused().type("{upArrow}");
+        cy.get("@menuItems").last().find("a").should("have.focus");
+      });
+
+      it.only("closes menu and returns focus to button on Esc", () => {
+        cy.get("#more-menu-story-container ul li").as("menuItems");
+        cy.get("@menuItems").first().find("a").should("have.focus");
+        // cy.pause()
+        cy.focused().type("{esc}");
+        cy.focused().should("match", "#more-menu-story-button");
+      });
+
+      it("More button has aria-label", () => {
+        cy.get("#more-menu-story-button")
+          .should("have.attr", "aria-label")
+          .and("not.be.empty");
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Summary | Résumé
This PR updates the `more menu`'s behaviour to align with the behaviour of the `disclosure menu`.
Fixes: https://github.com/cds-snc/notification-planning/issues/2388

- Expanding a more menu will now focus the first item in the list
- When expanded, the menu items are navigatable via the arrow keys
- When expended, focus is soft trapped inside the menu list when navigating via the arrow keys. i.e. after navigating `next` when on the last item, focus is returned to the first item in the menu list
- When expanded, pressing the `esc` key will now close the menu and return focus to the menu button itself
- Added an aria-label to the more menu button

# Test instructions | Instructions pour tester la modification
1. Navigate to `/_storybook?component=more-menu`
2. Focus on the menu button
- [ ] Screen readers announce the new `More menu items` label
3. Expand the menu with `space` or `enter`
- [ ] The first menu item in the list is focused and read by the screen reader
4. Navigate the menu using the `left` and `right` arrow keys
- [ ] Navigation works and the menu items are read by the screen reader
- [ ] Hitting the **`right arrow key`** while on the **last** item in the menu brings you back to the **first** menu item in the list
- [ ] Hitting the **`left arrow key`** while on the **first** item in the menu brings you back to the **last** menu item in the list
5. Press the `esc` key
- [ ] The menu is closed
- [ ] Focus is returned to the menu button and the `More menu items` label is read out
6. Open the menu again, then press `tab`
- [ ] The menu is closed, and focus moves to the next interactable element on the screen