### PR TITLE
A11y/empty list tabindex

### DIFF
--- a/app/templates/components/empty-list.html
+++ b/app/templates/components/empty-list.html
@@ -1,6 +1,6 @@
 {% macro empty_list(heading, message=None, img="emptyFlower", link=None, linkText="", attributes="") %}
   <div class="flex-col items-center border-dashed border-1 border-gray-400 p-8 sm:bg-{{img}} sm:bg-right bg-empty-state min-h-emptyState" data-testid='empty-list'>
-    <div class="w-full sm:w-2/3 space-y-gutterHalf" tabindex="0">
+    <div class="w-full sm:w-2/3 space-y-gutterHalf">
       <div class="text-title text-gray-700">{{ heading }}</div>
       {% if message %}
         <p class="mb-0 text-base text-gray-800">{{ message }}</p>

--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -1,7 +1,7 @@
 {% from "components/big-number.html" import big_number %}
 
 {% macro mapping_table(caption='', field_headings=[], field_headings_visible=True, caption_visible=True, equal_length=False, font_size="table-font-xsmall", testid=None) -%}
-  <section class="scrollable-table" tabindex="0">
+  <section class="scrollable-table">
    <table class="table {{fontsize}}"{% if testid %} data-testid="{{ testid }}"{% endif %}>
     <caption class="heading-medium table-heading{{ ' visuallyhidden' if not caption_visible }}">
       {{ caption }}


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/notification-planning/issues/2302
Fixes: https://github.com/cds-snc/notification-planning/issues/2345

Remove `tabindex="0"` from the table and empty list components so that non-interactive elements will not be focusable.

# Test instructions | Instructions pour tester la modification

1. log into the review app
2. open a service dashboard with no recent messages sent
3. click "0 emails sent in the last 7 days"
4. verify that the empty list component is visible
5. tab through the page and verify that no non-interactive elements are focussable