### PR TITLE
remove the vertical scrollbar from branding preview, remove tabindex

### DIFF
--- a/app/templates/views/email-branding/_preview.html
+++ b/app/templates/views/email-branding/_preview.html
@@ -1,5 +1,5 @@
 <div class="max-w-5xl">
-  <div class="py-0 px-0 px-gutterHalf box-border border border-gray-300 overflow-x-auto" data-testid="template-preview" id="template_preview" tabindex="0">
+  <div class="py-0 px-0 px-gutterHalf box-border border border-gray-300 overflow-x-auto overflow-y-hidden" data-testid="template-preview" id="template_preview">
     {% if '/_email' in request.base_url %}
       <link href="https://fonts.googleapis.com/css?family=Flow+Block&display=swap" rel="stylesheet" />
     {% endif %}


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/notification-planning/issues/2325

For wide branding we do sometimes want to have a horizontal scrollbar, but never a vertical scrollbar. In my testing with chrome + osx, the browser is smart enough to handle the cases correctly without setting the tabindex. If the branding preview is not scrollable, you can't focus it. If it is scrollable, you can focus it.

We were getting an unwanted vertical scrollbar so I added a css class to remove that. 

# Test instructions | Instructions pour tester la modification

1. log into the review app 
2. go to service settings and select a different GOC branding, view the preview
3. observe that clicking `tab` does not allow you to focus the branding preview
4. resize your browser window to be very narrow and observe the horizontal scrollbar on the branding preview
5. observe that clicking `tab` does allow you to focus on the branding preview