### PR TITLE
If the table is empty, just display the `empty_message` without the `table`

### DIFF
--- a/app/templates/components/table.html
+++ b/app/templates/components/table.html
@@ -34,22 +34,21 @@
 
 {% macro list_table(items, caption='', empty_message='', field_headings=[], field_headings_visible=True, caption_visible=True, equal_length=False, testid=None) -%}
   {% set parent_caller = caller %}
-
-  {% call mapping_table(caption, field_headings, field_headings_visible, caption_visible, equal_length, testid=testid) %}
-    {% for item in items %}
-      {% call row(item.id) %}
-        {{ parent_caller(item, loop.index + 1) }}
-      {% endcall %}
-    {% endfor %}
-    {% if not items %}
-      {% call row() %}
-        <td class="table-empty-message h-10" colspan="10">
-          {{ empty_message }}
-        </td>
-      {% endcall %}
+  {% if not items %}
+    {% if empty_message is string and not empty_message.strip().startswith('<') %}
+      <p>{{empty_message}}</p>
+    {% else %}
+      {{empty_message|safe}}
     {% endif %}
-  {%- endcall %}
-
+  {% else %}
+    {% call mapping_table(caption, field_headings, field_headings_visible, caption_visible, equal_length, testid=testid) %}
+      {% for item in items %}
+        {% call row(item.id) %}
+          {{ parent_caller(item, loop.index + 1) }}
+        {% endcall %}
+      {% endfor %}
+    {%- endcall %}
+  {% endif %}
 {%- endmacro %}
 
 {% macro row(id=None, classes=None) -%}


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/notification-planning/issues/2305

This PR updates the table component so that if the table is empty, the `empty_message` is displayed without being nested in a `table` element.

# Test instructions | Instructions pour tester la modification

1. log into the review app
2. open a service dashboard that does not have any recent sending
3. open the "emails in the last 7 days" page
4. observe that you see the `empty_list` component: "You have not sent messages recently"
5. inspect it and verify that it is not in a `table` element