### PR TITLE
Change markdown for links on the API settings page

### DIFF
--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -18,32 +18,44 @@
     </p>
   </div>
 
-  <nav class="grid-row contain-floats mb-12 clear-both" aria-label="{{ _('API settings') }}">
+  <div class="grid-row contain-floats mb-12 clear-both" aria-label="{{ _('API settings') }}">
     <div class="md:w-1/3 float-left py-0 px-0 px-gutterHalf box-border">
-      <h2 class="heading-small">
-        <a class="api-header-links" href="{{ url_for('.api_keys', service_id=current_service.id) }}">{{ _('API keys') }}</a>
-      </h2>
-      <p>
+      <a 
+        class="api-header-links heading-small" 
+        href="{{ url_for('.api_keys', service_id=current_service.id) }}" 
+        aria-describedby="api-keys-description"
+      >
+        {{ _('API keys') }}
+      </a>
+      <p id="api-keys-description">
         {{ _('An API key lets you connect your application or system with GC Notify.') }}
       </p>
     </div>
     <div class="md:w-1/3 float-left py-0 px-0 px-gutterHalf box-border">
-      <h2 class="heading-small">
-        <a class="api-header-links" href="{{ url_for('.safelist', service_id=current_service.id) }}">{{ _('Safelist') }}</a>
-      </h2>
-      <p>
+      <a 
+        class="api-header-links heading-small" 
+        href="{{ url_for('.safelist', service_id=current_service.id) }}" 
+        aria-describedby="safelist-description"
+      >
+        {{ _('Safelist') }}
+      </a>
+      <p id="safelist-description">
         {{ _('A safelist lets you send test notifications to specific people.') }}
       </p>
     </div>
     <div class="md:w-1/3 float-left py-0 px-0 px-gutterHalf box-border">
-      <h2 class="heading-small">
-        <a class="api-header-links" href="{{ url_for(callbacks_link, service_id=current_service.id) }}">{{ _('Callbacks') }}</a>
-      </h2>
-      <p>
+      <a 
+        class="api-header-links heading-small" 
+        href="{{ url_for(callbacks_link, service_id=current_service.id) }}" 
+        aria-describedby="callbacks-description"
+      >
+        {{ _('Callbacks') }}
+      </a>
+      <p id="callbacks-description">
         {{ _('Callbacks let you know whether GC Notify was able to deliver notifications.') }}
       </p>
     </div>
-  </nav>
+  </div>
 
   <div class="mb-12 bg-gray px-10 py-2">
     <h2 class="heading-small">


### PR DESCRIPTION
# Summary | Résumé

Fixes: https://github.com/cds-snc/notification-planning/issues/2468

This PR:
- removes the `nav` element (see my comment here: https://github.com/cds-snc/notification-planning/issues/2468#issuecomment-3347718531)
- removes the `h2` elements
- adds a `aria-describedby` attributes to connect the descriptions to the links

# Test instructions | Instructions pour tester la modification

1. log into the review app
2. open a service and click "api integration"
3. read through the page with Voiceover - verify that the link descriptions are read out when you focus the links: "API Keys", "Safelist" and "Callbacks"
4. verify that there are no visual changes