### PR TITLE
Remove 2nd optional from step 3 of creating a new service

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -685,7 +685,7 @@ class CreateServiceStepCombinedOrganisationForm(StripWhitespaceForm):
     )
 
     child_organisation_name = StringField(
-        _l("Enter any other names for your group (Optional)"),
+        _l("Enter any other names for your group"),
         validators=[Optional(), Length(max=500)],
     )
 

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1755,7 +1755,7 @@
 "Attachment has virus","La pièce jointe contient un virus"
 "Review reports","Examiner les rapports"
 "Enter name of your group","Saisissez le nom de votre groupe"
-"Enter any other names for your group (Optional)","Saisissez tout autre nom correspondant à votre groupe (optionnel)"
+"Enter any other names for your group","Saisissez tout autre nom correspondant à votre groupe"
 "Enter name to continue","Ce champ doit être rempli."
 "We use this information to improve GC Notify.","Nous utilisons ces renseignements pour améliorer Notification GC."
 "Select your department or organisation","Sélectionnez votre ministère ou organisme"


### PR DESCRIPTION
# Summary | Résumé

We have the text `(optional)` displayed twice on Step 3 of "Create a new Service". This PR fixes that.

Before:
<img width="835" height="763" alt="Screenshot 2025-09-29 at 3 43 11 PM" src="https://github.com/user-attachments/assets/071eef08-a7e1-41ad-b2c3-3ddb6a6571d1" />

After:
<img width="626" height="637" alt="Screenshot 2025-09-29 at 3 49 22 PM" src="https://github.com/user-attachments/assets/8d28da33-64b5-4593-aa71-b47fe4b5dc39" />


# Test instructions | Instructions pour tester la modification

1. log into the review app
2. get to step 3 of "create a new service"
3. verify the word "optional" does not appear twice in the 2nd question