### PR TITLE
Add label for "key name"

### DIFF
--- a/app/templates/views/api/keys.html
+++ b/app/templates/views/api/keys.html
@@ -54,7 +54,7 @@
     ) %}
       {% call field() %}
         <div class="file-list">
-          {{ item.name }}
+          <span class="hint">{{ "{}:".format(_("Key name"))}}</span> {{ item.name }}
           {% if (
               'total_sends' in item and
               'email_sends' in item and

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2336,3 +2336,4 @@
 "Warning: nearing daily limit","Avertissement&nbsp;: approche de la limite quotidienne"
 "Within annual limits","Dans les limites annuelles"
 "More menu items","Plus d’éléments du menu"
+"Key name","Nom de la clé"


### PR DESCRIPTION
# Summary | Résumé
This PR fixes: https://github.com/cds-snc/notification-planning/issues/2470

# Test instructions | Instructions pour tester la modification
1. Log in and select a service
2. Navigate to `API integration` -> `API keys`
3. Note the visual label for `Key name`
