### PR TITLE
a11y fix: `div` -> `section`

### DIFF
--- a/app/templates/views/api/index.html
+++ b/app/templates/views/api/index.html
@@ -18,7 +18,7 @@
     </p>
   </div>
 
-  <div class="grid-row contain-floats mb-12 clear-both" aria-label="{{ _('API settings') }}">
+  <section class="grid-row contain-floats mb-12 clear-both" aria-label="{{ _('API settings') }}">
     <div class="md:w-1/3 float-left py-0 px-0 px-gutterHalf box-border">
       <a 
         class="api-header-links heading-small" 
@@ -55,7 +55,7 @@
         {{ _('Callbacks let you know whether GC Notify was able to deliver notifications.') }}
       </p>
     </div>
-  </div>
+  </section>
 
   <div class="mb-12 bg-gray px-10 py-2">
     <h2 class="heading-small">


### PR DESCRIPTION
# Summary | Résumé

The `aria-label` attr on a `div` on the api settings page was resulting in the following a111y error:
> Description: The `aria-label` attribute is not allowed on the generic role

To fix this I changed the `div` to a `section` element.

# Test instructions | Instructions pour tester la modification

1. log into the review app
2. visit the api settings page
3. verify that there are no a11y errors using the ARC toolkit browser extension or something similar