### PR TITLE
Add new guide to sitemap

### DIFF
--- a/app/main/sitemap.py
+++ b/app/main/sitemap.py
@@ -46,6 +46,11 @@ def get_sitemap():
                     {"href": gca_url_for("personalisation_guide"), "link_text": _("Sending custom content")},
                     {"href": gca_url_for("message_delivery_status"), "link_text": _("Understanding delivery and failure")},
                     {"href": gca_url_for("bounce_guidance"), "link_text": _("Updating contact information")},
+                    {
+                        "href": gca_url_for("counting_text_messages"),
+                        "link_text": _("Counting text messages"),
+                        "show": current_app.config.get("FF_USE_BILLABLE_UNITS", False),
+                    },
                 ],
             },
             {

--- a/app/main/sitemap.py
+++ b/app/main/sitemap.py
@@ -48,7 +48,7 @@ def get_sitemap():
                     {"href": gca_url_for("bounce_guidance"), "link_text": _("Updating contact information")},
                     {
                         "href": gca_url_for("counting_text_messages"),
-                        "link_text": _("Counting text messages"),
+                        "link_text": _("Counting text message parts"),
                         "show": current_app.config.get("FF_USE_BILLABLE_UNITS", False),
                     },
                 ],

--- a/app/templates/components/sitemap.html
+++ b/app/templates/components/sitemap.html
@@ -7,9 +7,11 @@
             <h2 class="w-full sm:w-2/5 heading-medium m-0" data-testid="sitemap-group">{{ group.title }}</h2>
             <ul class="w-full sm:w-3/5 flex flex-wrap items-baseline gap-y-gutterHalf">
               {% for page in group.pages|sort(attribute='link_text') %}
-                <li class="w-full md:w-1/2 pr-gutter">
-                  <a class="inline-flex text-balance" href="{{ page.href }}">{{ page.link_text | safe }}</a>
-                </li>
+                {% if page.show is not defined or page.show %}
+                  <li class="w-full md:w-1/2 pr-gutter">
+                    <a class="inline-flex text-balance" href="{{ page.href }}">{{ page.link_text | safe }}</a>
+                  </li>
+                {% endif %}
               {% endfor %}
               </ul>
             </li>

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2405,6 +2405,7 @@
 "billable units","FR billable units"
 "Text message parts","Parties de messages texte"
 "Guide: Counting text message parts","Guide&nbsp;: Compter les parties de messages texte"
+"Counting text message parts","Compter les parties de messages texte"
 "Counted as {}","Comptés comme {}"
 "text message parts to {} recipients","parties de messages texte envoyées à {} destinataires"
 "text message part to {} recipient","partie de message texte envoyée à {} destinataire"


### PR DESCRIPTION
# Summary | Résumé

Adds `counting_text_messages` to the sitemap

We can add a parameter `show` to our links for when we want to link it to Feature Flags. We can remove it when we remove all the other flags and the link will behave like the others. When `show` is not defined, the link is displayed by default. 

# Test instructions | Instructions pour tester la modification

- [x] Navigate to sitemap
- [x] Notice the new guide is listed, and in the right position, alphabetically
- [x] Test the link
- [x] Go back to the sitemap, check the FR sitemap
- [x] Check new link position. Should be alphabetical
- [x] Test the link