### PR TITLE
updating role

### DIFF
--- a/.github/workflows/test-admin-delete-unused.yaml
+++ b/.github/workflows/test-admin-delete-unused.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-admin-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-admin-test-delete-unused
           role-session-name: NotifyAdminApply
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 


### PR DESCRIPTION
# Summary | Résumé


This pull request updates the AWS IAM role used in the `test-admin-delete-unused` GitHub Actions workflow. The change ensures that the workflow now assumes the correct role for testing the deletion of unused resources.

Most important change:

* Updated the `role-to-assume` in `.github/workflows/test-admin-delete-unused.yaml` from `notification-admin-apply` to `notification-admin-test-delete-unused` to ensure the workflow uses the appropriate permissions for test operations.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
