### PR TITLE
Fix the validation used on the "Service settings > Change service name" page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -570,6 +570,7 @@ class RenameServiceForm(StripWhitespaceForm):
         validators=[
             DataRequired(message=_l("This cannot be empty")),
             validate_service_name,
+            validate_combined_email_header_length,
         ],
     )
 
@@ -586,6 +587,7 @@ class ChangeEmailFromServiceForm(StripWhitespaceForm):
         validators=[
             DataRequired(message=_l("This cannot be empty")),
             validate_email_from,
+            validate_combined_email_header_length,
         ],
     )
 

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -260,12 +260,24 @@ def validate_combined_email_header_length(form, field):
     When a service name contains unicode characters, it gets MIME-encoded in the email header,
     which can significantly increase its length.
     """
-    # Only validate if both name and email_from are present
-    if not hasattr(form, "name") or not hasattr(form, "email_from"):
+    # At least one of name or email_from must be on the form for this
+    # validator to be meaningful.
+    if not hasattr(form, "name") and not hasattr(form, "email_from"):
         return
 
-    service_name = form.name.data if form.name.data else ""
-    email_from = form.email_from.data if form.email_from.data else ""
+    if hasattr(form, "name"):
+        service_name = form.name.data if form.name.data else ""
+    else:
+        service_name = getattr(current_service, "name", "") or ""
+
+    # If the form does not include an email_from field (e.g. when renaming an
+    # existing service), fall back to the current service's email_from so we
+    # still validate the combined header length when only the name is being
+    # edited.
+    if hasattr(form, "email_from"):
+        email_from = form.email_from.data if form.email_from.data else ""
+    else:
+        email_from = getattr(current_service, "email_from", "") or ""
 
     # If either field is empty, skip this validation (let other validators handle it)
     if not service_name or not email_from:

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -394,6 +394,30 @@ def test_should_redirect_after_change_service_name(
     assert mock_service_name_is_unique.called is True
 
 
+def test_should_reject_service_name_change_when_combined_email_header_is_too_long(
+    client_request,
+    mock_update_service,
+    mock_service_name_is_unique,
+):
+    """Renaming a service to a very long unicode name should fail validation
+    so we don't end up with an SES `from` header longer than 320 characters."""
+    long_service_name = (
+        "Message de Jimmy Royééééééééé – Gestionnaire principal responsable des urgences "
+        "et des évacuations du BIN // Message from Jimmy Royééééééééé – NPB Lead senior "
+        "manager for emergencies and évacuations"
+    )
+
+    page = client_request.post(
+        "main.service_name_change",
+        service_id=SERVICE_ONE_ID,
+        _data={"name": long_service_name},
+        _expected_status=200,
+    )
+
+    assert "Your service name and email address combined are too long" in page.text
+    assert mock_update_service.called is False
+
+
 @pytest.mark.parametrize(
     "user, expected_text, expected_link",
     [


### PR DESCRIPTION
# Summary | Résumé

Fix for https://github.com/cds-snc/notification-planning/issues/3154

We are using the correct validation for the service name on Step 2 of the "Create a new Service" flow, but the same validation was not applied when a user edits the name of an existing service from the Service Settings page. This PR fixes that.

# Test instructions | Instructions pour tester la modification

1. Log into the review app
2. Visit the Settings page for one of your existing services
3. Try to change the name of your service to the following (less than 255 chars):
```
Message de Jimmy Royééééééééé – Gestionnaire principal responsable des urgences et des évacuations du BIN // Message from Jimmy Royééééééééé – NPB Lead senior manager for emergencies and évacuations
```
4. observe that you see the following error message:
<img width="787" height="456" alt="Screenshot 2026-04-27 at 4 26 57 PM" src="https://github.com/user-attachments/assets/6ab7e7dc-0c97-4ddb-95cc-cd6762f587f9" />
