### PR TITLE
chore: fix markdown/content of blingual sample templates

### DIFF
--- a/app/sample_templates/bilingual_email_en_fr.yaml
+++ b/app/sample_templates/bilingual_email_en_fr.yaml
@@ -11,35 +11,31 @@ content: |
   [[fr]]
   *La version française suit*
   [[/fr]]
+
   [[en]]
   Hi ((name)),
   [[/en]]
-  [[fr]]
-  *Fin de la version anglaise*
-  [[/fr]]
+
   ---
+
   [[fr]]
   Bonjour ((name)),
-
-  *Fin de la version française*
   [[/fr]]
 example_content: |
   [[fr]]
   *La version française suit*
   [[/fr]]
+
   [[en]]
   Hi Jane Smith,
 
   This section of the message is marked as English content. Screen readers will read this section with an English voice. 
   [[/en]]
-  [[fr]]
-  *Fin de la version anglaise*
-  [[/fr]]
+
   ---
+
   [[fr]]
   Bonjour Jane Smith,
 
   Cette portion du message est balisé pour être en français. Les lecteurs d'écran lirons cette portion avec une voix française. 
-
-  *Fin de la version française*
   [[/fr]]

--- a/app/sample_templates/bilingual_email_fr_en.yaml
+++ b/app/sample_templates/bilingual_email_fr_en.yaml
@@ -11,39 +11,35 @@ content: |
   [[en]]
   *English version follows.*
   [[/en]]
+
   [[fr]]
   Bonjour ((name)),
 
   Cette portion du message est balisé pour être en français. Les lecteurs d'écran lirons cette portion avec une voix française. 
   [[/fr]]
-  [[en]]
-  *End of the French version*
-  [[/en]]
+
   ---
+
   [[en]]
   Hi ((name)),
 
   This section of the message is marked as English content. Screen readers will read this section with an English voice. 
-
-  *End of the English version*
   [[/en]]
 example_content: |
   [[en]]
   *English version follows.*
   [[/en]]
+
   [[fr]]
   Bonjour Jane Smith,
 
   Cette portion du message est balisé pour être en français. Les lecteurs d'écran lirons cette portion avec une voix française. 
   [[/fr]]
-  [[en]]
-  *End of the French version*
-  [[/en]]
+  
   ---
+  
   [[en]]
   Hi Jane Smith,
 
   This section of the message is marked as English content. Screen readers will read this section with an English voice. 
-
-  *End of the English version*
   [[/en]]


### PR DESCRIPTION
# Summary | Résumé

This pull request simplifies the bilingual email templates by removing the "end of language version" markers (e.g., "*Fin de la version anglaise*") and fixes the markdown to work properly with the RTE

## Related cards
* https://github.com/cds-snc/notification-planning/issues/3174

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
