### PR TITLE
Update the free sms parts limit per fiscal year to be 100k

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -66,14 +66,14 @@ class Config(object):
     DEBUG = False
     DEBUG_KEY = os.environ.get("DEBUG_KEY", "")
     DEFAULT_FREE_SMS_FRAGMENT_LIMITS = {
-        "central": 25_000,
-        "local": 25_000,
-        "nhs_central": 250_000,
-        "nhs_local": 25_000,
-        "nhs_gp": 25_000,
-        "emergency_service": 25_000,
-        "school_or_college": 25_000,
-        "other": 25_000,
+        "central": 100_000,
+        "local": 100_000,
+        "nhs_central": 100_000,
+        "nhs_local": 100_000,
+        "nhs_gp": 100_000,
+        "emergency_service": 100_000,
+        "school_or_college": 100_000,
+        "other": 100_000,
     }
     DEFAULT_LIVE_SERVICE_LIMIT = env.int("DEFAULT_LIVE_SERVICE_LIMIT", 10_000)
     DEFAULT_LIVE_SMS_DAILY_LIMIT = env.int("DEFAULT_LIVE_SMS_DAILY_LIMIT", 1000)

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -514,7 +514,7 @@ def test_get_should_only_show_nhs_org_types_radios_if_user_has_nhs_email(
     ]
 
 
-@pytest.mark.parametrize("organisation_type, free_allowance", [("central", 25 * 1000)])
+@pytest.mark.parametrize("organisation_type, free_allowance", [("central", 100 * 1000)])
 def test_should_add_service_and_redirect_to_dashboard_along_with_proper_side_effects(
     app_,
     client_request,


### PR DESCRIPTION
# Summary | Résumé

Update the free sms parts limit per fiscal year to be 100k. This is what the free limit is set to when a new service is created (depending on the service's organisation type).

Part of https://github.com/cds-snc/notification-planning/issues/3158

# Test instructions | Instructions pour tester la modification

1. log into the review app (with your platform admin account)
2. create a new service
3. go to the service settings page
4. verify that "Free text messages per fiscal year" is 100,000 
<img width="1068" height="97" alt="Screenshot 2026-04-30 at 1 34 37 PM" src="https://github.com/user-attachments/assets/4ce7b2d8-162b-4805-9e56-a020c6e32ca8" />
