### PR TITLE
Update the default sms daily limit

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -76,7 +76,8 @@ class Config(object):
         "other": 100_000,
     }
     DEFAULT_LIVE_SERVICE_LIMIT = env.int("DEFAULT_LIVE_SERVICE_LIMIT", 10_000)
-    DEFAULT_LIVE_SMS_DAILY_LIMIT = env.int("DEFAULT_LIVE_SMS_DAILY_LIMIT", 1000)
+    # Must match DEFAULT_SMS_DAILY_LIMIT in notification-api/app/models.py
+    DEFAULT_LIVE_SMS_DAILY_LIMIT = env.int("DEFAULT_LIVE_SMS_DAILY_LIMIT", 1500)
     DEFAULT_SERVICE_LIMIT = env.int("DEFAULT_SERVICE_LIMIT", 50)
     DEFAULT_SMS_DAILY_LIMIT = env.int("DEFAULT_SMS_DAILY_LIMIT", 50)
     DOCUMENTATION_DOMAIN = os.getenv("DOCUMENTATION_DOMAIN", "documentation.notification.canada.ca")

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -468,10 +468,10 @@ def test_show_restricted_service(
 @pytest.mark.parametrize(
     "current_limit, expected_limit, current_sms_limit, expected_sms_limit",
     [
-        (42, 10_000, 33, 1000),
+        (42, 10_000, 33, 1500),
         # Maps to DEFAULT_SERVICE_LIMIT and DEFAULT_LIVE_SERVICE_LIMIT in config
-        (50, 10_000, 50, 1000),
-        (50_000, 10_000, 3000, 1000),
+        (50, 10_000, 50, 1500),
+        (50_000, 10_000, 3000, 1500),
     ],
 )
 def test_switch_service_to_live(


### PR DESCRIPTION
# Summary | Résumé

This is the value that is actually getting used to set the daily sms limit for new services. I would have liked to avoid this being set in 2 places (it is also set in the api) but it is also getting used in the go-live form on admin, so removing it would be a bit complicated. I added a comment instead. I also added a comment over here: https://github.com/cds-snc/notification-api/pull/2857
