### PR TITLE
Display only the last 10 jobs on the dashboard

### DIFF
--- a/app/main/views/dashboard.py
+++ b/app/main/views/dashboard.py
@@ -428,7 +428,7 @@ def get_dashboard_partials(service_id):
         timings["get_scheduled_jobs"] = (time.time() - start) * 1000
 
         start = time.time()
-        immediate_jobs_raw = job_api_client.get_immediate_jobs(service_id)
+        immediate_jobs_raw = job_api_client.get_immediate_jobs(service_id, page_size=10)
         timings["get_immediate_jobs"] = (time.time() - start) * 1000
 
         start = time.time()

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -48,12 +48,14 @@ class JobApiClient(NotifyAdminAPIClient):
 
         return job
 
-    def get_jobs(self, service_id, limit_days=None, statuses=None, page=1):
+    def get_jobs(self, service_id, limit_days=None, statuses=None, page=1, page_size=None):
         params = {"page": page}
         if limit_days is not None:
             params["limit_days"] = limit_days
         if statuses is not None:
             params["statuses"] = ",".join(statuses)
+        if page_size is not None:
+            params["page_size"] = page_size
 
         jobs = self.get(url="/service/{}/job".format(service_id), params=params)
         for job in jobs["data"]:
@@ -83,11 +85,12 @@ class JobApiClient(NotifyAdminAPIClient):
             page=page,
         )
 
-    def get_immediate_jobs(self, service_id, limit_days=7):
+    def get_immediate_jobs(self, service_id, limit_days=7, page_size=None):
         return self.get_jobs(
             service_id,
             limit_days=limit_days,
             statuses=self.NON_SCHEDULED_JOB_STATUSES,
+            page_size=page_size,
         )["data"]
 
     def get_scheduled_jobs(self, service_id):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2574,7 +2574,7 @@ def mock_has_no_jobs(mocker):
 
 @pytest.fixture(scope="function")
 def mock_get_jobs(mocker, api_user_active):
-    def _get_jobs(service_id, limit_days=None, statuses=None, page=1):
+    def _get_jobs(service_id, limit_days=None, statuses=None, page=1, page_size=None):
         if statuses is None:
             statuses = ["", "scheduled", "pending", "cancelled", "finished"]
 


### PR DESCRIPTION
# Summary | Résumé
This PR (along with [2861](https://github.com/cds-snc/notification-api/pull/2861)) changes the Bulk sends section of the dashboard. The table is now restricted to the last 10 bulk jobs sent instead of the default page size of 50. This significantly cuts down the render time of the dashboard when a service has sent >=50 bulk sends in the last 7 days.

<img width="1139" height="601" alt="image" src="https://github.com/user-attachments/assets/de8442dd-9c4b-4bd7-9b24-d454793bb87d" />

# Related
https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/3208

# Test instructions | Instructions pour tester la modification
1. Log into the review app
2. Navigate to the [test-simulate-prod-data-service
](https://staging.notification.cdssandbox.xyz/services/8dad0c16-6952-4424-be2a-d98b8bfc3c2d)
3. Note that the bulk sends section now only displays 10 records.