### PR TITLE
feat: add W3 URLs to ignore list in a11yScan command

### DIFF
--- a/tests_cypress/cypress/support/commands.js
+++ b/tests_cypress/cypress/support/commands.js
@@ -23,7 +23,13 @@ Cypress.Commands.add('a11yScan', (url, options = { a11y: true, htmlValidate: tru
         throw new Error("a11yScan is not supported in component tests. Run this check in an e2e test instead.");
     }
     const current_hostname = getHostname('Admin');
-    const ignoreLinks = ['documentation.staging.notification.cdssandbox.xyz', 'https://blog.lastpass.com/fr/posts/security-incident-update-recommended-actions', 'https://blog.lastpass.com/2023/03/security-incident-update-recommended-actions/']
+    const ignoreLinks = [
+        'documentation.staging.notification.cdssandbox.xyz', 
+        'https://blog.lastpass.com/fr/posts/security-incident-update-recommended-actions', 
+        'https://blog.lastpass.com/2023/03/security-incident-update-recommended-actions/',
+        'https://www.w3.org',
+        'https://w3.org'
+    ]
 
     if (url) {
         cy.visit(url);

--- a/tests_cypress/cypress/support/commands.js
+++ b/tests_cypress/cypress/support/commands.js
@@ -29,7 +29,7 @@ Cypress.Commands.add('a11yScan', (url, options = { a11y: true, htmlValidate: tru
         'https://blog.lastpass.com/2023/03/security-incident-update-recommended-actions/',
         'https://www.w3.org',
         'https://w3.org'
-    ]
+    ];
 
     if (url) {
         cy.visit(url);


### PR DESCRIPTION
# Summary | Résumé
This pull request makes a minor update to the accessibility scan command in the Cypress test support file. It adds `w3.org` to the ignore list since for some reason that domain is rejecting requests from our cypress tests.

# Test instructions | Instructions pour tester la modification
- [x] Staging CI passes
   - ✅  works! https://github.com/cds-snc/notification-admin/actions/runs/26572288525/job/78282271361