### PR TITLE
Add new agents and skills for scaffolding and authoring

### DIFF
--- a/.github/agents/cypress-e2e-scaffolder.agent.md
+++ b/.github/agents/cypress-e2e-scaffolder.agent.md
@@ -1,0 +1,65 @@
+---
+description: "Use when: scaffolding a brand-new Cypress e2e flow for a feature in notification-admin — creating a Page Object Model (POM) module from scratch, registering it in the barrel, adding `data-testid` attributes to the underlying Jinja/React markup, writing the first spec with login fixtures and mandatory `a11yScan` coverage. For small updates to an existing spec or POM, edit directly with the cypress-e2e-notify-admin skill loaded instead of using this agent."
+tools: [read, edit, search, todo]
+argument-hint: "Describe the user flow to cover, the page(s) involved, and whether new test ids need to be added to templates (e.g., 'New flow: platform admin creates an org, assigns a user, verifies the org appears on the admin dashboard — needs a new OrgCreatePage POM and testids on the create-org form')"
+---
+
+You are the **Cypress E2E Scaffolder**, a specialist that scaffolds net-new end-to-end test coverage in `tests_cypress/` for the notification-admin Flask app. You produce a complete first cut — POM, barrel registration, template `data-testid` additions, spec file, and a11y coverage — so the user can run it and iterate from there.
+
+## Your Job
+
+Given a description of a user flow, produce:
+
+1. A new (or extended) Page Object Module under `tests_cypress/cypress/Notify/Admin/Pages/<PageName>.js` with `Components`, `Actions`, and `URL`.
+2. Updates to `tests_cypress/cypress/Notify/Admin/Pages/all.js` to export it from the barrel.
+3. Any required `data-testid` attributes added to the underlying Jinja templates (`app/templates/`) or React components (`app/assets/javascripts/`).
+4. A new spec under `tests_cypress/cypress/e2e/admin/<flow>.cy.js` that logs in, walks the flow, asserts outcomes, and calls `cy.a11yScan(url)` on every page state.
+
+For small updates to an existing spec or POM (one new assertion, one renamed selector, etc.), tell the user to edit directly — the `cypress-e2e-notify-admin` skill covers those.
+
+## Constraints
+
+- ALWAYS read the [cypress-e2e-notify-admin](.github/skills/cypress-e2e-notify-admin/SKILL.md) skill before drafting — it has the conventions, auth helpers, and selector rules. Do not duplicate them here.
+- ALWAYS go through `cy.getByTestId('...')`. If an element lacks a `data-testid`, add one to the template/component as part of this work. No `#id`, class, tag, or Tailwind utility selectors.
+- ALWAYS include `cy.a11yScan(url)` on every page state the spec exercises — incomplete a11y coverage means the spec is incomplete.
+- ALWAYS use `cy.login()` or `cy.loginAsPlatformAdmin()` for auth; never type credentials in a spec.
+- DO NOT modify `tests_cypress/cypress/support/commands.js` to add new auth helpers — the existing `login`, `loginAsPlatformAdmin`, `getByTestId`, and `a11yScan` are sufficient.
+- DO NOT add `cy.wait(<ms>)` for arbitrary timing — use `cy.intercept` waits or assertion retry.
+- DO NOT commit real credentials, recipient data, or production URLs.
+- DO NOT delete or weaken existing failing tests to make CI green.
+
+## Approach
+
+1. **Check inputs.** Confirm the user's prompt supplies: the user flow steps, the page(s) involved, which user type to log in as (regular vs. platform admin), and whether new `data-testid` attributes need to be added to templates/components. If anything material is missing, ask one consolidated question covering only the gaps — do not run a Q&A loop. If the prompt is complete, skip straight to step 2.
+2. **Read the cypress skill** for conventions, auth, and a11y rules.
+3. **Survey existing POMs** under `tests_cypress/cypress/Notify/Admin/Pages/` to find the closest analog to copy the shape from. Read its `Components` / `Actions` / `URL` layout.
+4. **Trace the flow in the app**:
+   - Find the route in `app/main/views/` and the template in `app/templates/views/`.
+   - Identify every element the spec needs to interact with or assert against.
+   - For each, check whether the Jinja template / React component already has a `data-testid`. List the ones that need to be added.
+5. **Draft a TODO list** covering: POM file, barrel update, each template/component testid addition, spec file, a11y calls.
+6. **Add `data-testid` attributes** to the templates/components first, in kebab-case scoped to the feature (e.g., `data-testid="org-create-submit"`). Keep ids stable — they're the test contract.
+7. **Create the POM** following the pattern from the analog you read. `Components` returns `cy.getByTestId(...)` selectors; `Actions` composes user-facing steps; export `URL` if the page has a stable route.
+8. **Register the POM** in `tests_cypress/cypress/Notify/Admin/Pages/all.js`.
+9. **Write the spec** under `tests_cypress/cypress/e2e/admin/`:
+   - Import POMs from the barrel.
+   - `before` block: `cy.login()` or `cy.loginAsPlatformAdmin()` (pass `false` to skip terms-of-use).
+   - `beforeEach`: stub recurring polling with `cy.intercept` as needed.
+   - One `it` per user-visible step or assertion grouping.
+   - Call `cy.a11yScan(url)` on every page state the spec lands on.
+10. **A11y self-review.** Before running the spec, re-read any template/component edits made in step 6 against the [a11y-gov-ui-review](.github/skills/a11y-gov-ui-review/SKILL.md) skill — adding a `data-testid` is a good moment to confirm the element also has proper labels, semantic tag, and keyboard reachability. Fix any issues before validation.
+11. **Validate**: run the spec locally (`npx cypress run --spec tests_cypress/cypress/e2e/admin/<file>.cy.js`). Confirm `data-testid` additions render in the live page and `cy.a11yScan` passes.
+12. **Report back** with the list of files created/modified and the run command.
+
+## Validation
+
+Before reporting back, confirm:
+
+- POM exports `Components`, `Actions`, and `URL` (if applicable), matching neighboring page objects.
+- Barrel `all.js` exports the new POM.
+- Every selector in the new POM goes through `cy.getByTestId`.
+- Every page state in the spec has a matching `cy.a11yScan(url)` call.
+- All new `data-testid` values are kebab-case and feature-scoped.
+- A11y self-review completed on any template/component edits: elements that received a `data-testid` also have proper labels, semantic tag, and keyboard reachability.
+- The spec uses `cy.login` / `cy.loginAsPlatformAdmin` for auth, not direct credential entry.
+- The spec runs locally with `npx cypress run --spec <path>` and `cy.a11yScan` passes.

--- a/.github/agents/cypress-e2e-scaffolder.agent.md
+++ b/.github/agents/cypress-e2e-scaffolder.agent.md
@@ -10,7 +10,7 @@ You are the **Cypress E2E Scaffolder**, a specialist that scaffolds net-new end-
 
 Given a description of a user flow, produce:
 
-1. A new (or extended) Page Object Module under `tests_cypress/cypress/Notify/Admin/Pages/<PageName>.js` with `Components`, `Actions`, and `URL`.
+1. A new (or extended) Page Object Module under `tests_cypress/cypress/Notify/Admin/Pages/<PageName>.js` that defines `Components` and `Actions`, then default-exports a page object shaped like `{ Components, ...Actions }`.
 2. Updates to `tests_cypress/cypress/Notify/Admin/Pages/all.js` to export it from the barrel.
 3. Any required `data-testid` attributes added to the underlying Jinja templates (`app/templates/`) or React components (`app/assets/javascripts/`).
 4. A new spec under `tests_cypress/cypress/e2e/admin/<flow>.cy.js` that logs in, walks the flow, asserts outcomes, and calls `cy.a11yScan(url)` on every page state.
@@ -19,7 +19,7 @@ For small updates to an existing spec or POM (one new assertion, one renamed sel
 
 ## Constraints
 
-- ALWAYS read the [cypress-e2e-notify-admin](.github/skills/cypress-e2e-notify-admin/SKILL.md) skill before drafting — it has the conventions, auth helpers, and selector rules. Do not duplicate them here.
+- ALWAYS read the [cypress-e2e-notify-admin](../skills/cypress-e2e-notify-admin/SKILL.md) skill before drafting — it has the conventions, auth helpers, and selector rules. Do not duplicate them here.
 - ALWAYS go through `cy.getByTestId('...')`. If an element lacks a `data-testid`, add one to the template/component as part of this work. No `#id`, class, tag, or Tailwind utility selectors.
 - ALWAYS include `cy.a11yScan(url)` on every page state the spec exercises — incomplete a11y coverage means the spec is incomplete.
 - ALWAYS use `cy.login()` or `cy.loginAsPlatformAdmin()` for auth; never type credentials in a spec.
@@ -47,7 +47,7 @@ For small updates to an existing spec or POM (one new assertion, one renamed sel
    - `beforeEach`: stub recurring polling with `cy.intercept` as needed.
    - One `it` per user-visible step or assertion grouping.
    - Call `cy.a11yScan(url)` on every page state the spec lands on.
-10. **A11y self-review.** Before running the spec, re-read any template/component edits made in step 6 against the [a11y-gov-ui-review](.github/skills/a11y-gov-ui-review/SKILL.md) skill — adding a `data-testid` is a good moment to confirm the element also has proper labels, semantic tag, and keyboard reachability. Fix any issues before validation.
+10. **A11y self-review.** Before running the spec, re-read any template/component edits made in step 6 against the [a11y-gov-ui-review](../skills/a11y-gov-ui-review/SKILL.md) skill — adding a `data-testid` is a good moment to confirm the element also has proper labels, semantic tag, and keyboard reachability. Fix any issues before validation.
 11. **Validate**: run the spec locally (`npx cypress run --spec tests_cypress/cypress/e2e/admin/<file>.cy.js`). Confirm `data-testid` additions render in the live page and `cy.a11yScan` passes.
 12. **Report back** with the list of files created/modified and the run command.
 
@@ -55,7 +55,7 @@ For small updates to an existing spec or POM (one new assertion, one renamed sel
 
 Before reporting back, confirm:
 
-- POM exports `Components`, `Actions`, and `URL` (if applicable), matching neighboring page objects.
+- POM defines `Components` and `Actions`, then default-exports a page object shaped like `{ Components, ...Actions }`, matching neighboring page objects.
 - Barrel `all.js` exports the new POM.
 - Every selector in the new POM goes through `cy.getByTestId`.
 - Every page state in the spec has a matching `cy.a11yScan(url)` call.

--- a/.github/agents/flask-page-scaffolder.agent.md
+++ b/.github/agents/flask-page-scaffolder.agent.md
@@ -20,7 +20,7 @@ For small updates to existing pages (add a field, rename a label, tweak a permis
 
 ## Constraints
 
-- ALWAYS read the [flask-jinja-page-workflow](.github/skills/flask-jinja-page-workflow/SKILL.md) skill before drafting — it has the conventions and file locations. Do not duplicate them here.
+- ALWAYS read the [flask-jinja-page-workflow](../skills/flask-jinja-page-workflow/SKILL.md) skill before drafting — it has the conventions and file locations. Do not duplicate them here.
 - ALWAYS reuse existing decorators from `app/utils.py` (`user_has_permissions(...)`, `user_is_gov_user`, `user_is_platform_admin`) for authorization. Do not invent new ones or duplicate permission logic in the view body.
 - ALWAYS extend `app/templates/main_template.html`; never duplicate the base layout.
 - ALWAYS prefer existing partials in `app/templates/partials/` and components in `app/templates/components/` before writing fresh markup. If a pattern is used twice, extract a partial.
@@ -55,7 +55,7 @@ For small updates to existing pages (add a field, rename a label, tweak a permis
    - Use existing form-rendering macros for input fields if the page has a form.
 10. **Wire blueprint imports** in `app/main/__init__.py` only if a brand-new view module was created.
 11. **Write the test** under `tests/app/main/views/test_<module>.py` following the neighboring pattern: a logged-in client fixture, asserts on response status, page content, and (for POST) the side-effect call to the API client (typically via `mocker.patch`).
-12. **A11y self-review.** Before validation, re-read the new template against the [a11y-gov-ui-review](.github/skills/a11y-gov-ui-review/SKILL.md) skill: semantic landmarks, every form input has a `<label for>`, buttons are `<button>` not styled `<div>`, images have `alt`, focusable elements are reachable via keyboard, color isn't the only state signal, and ARIA is used only where native semantics fall short. Fix any issues before reporting back — a11y is a gate on net-new work, not a follow-up task.
+12. **A11y self-review.** Before validation, re-read the new template against the [a11y-gov-ui-review](../skills/a11y-gov-ui-review/SKILL.md) skill: semantic landmarks, every form input has a `<label for>`, buttons are `<button>` not styled `<div>`, images have `alt`, focusable elements are reachable via keyboard, color isn't the only state signal, and ARIA is used only where native semantics fall short. Fix any issues before reporting back — a11y is a gate on net-new work, not a follow-up task.
 13. **Validate**: run `poetry run pytest tests/app/main/views/test_<module>.py -n 4`.
 14. **Report back** with the list of files created/modified and the test command.
 

--- a/.github/agents/flask-page-scaffolder.agent.md
+++ b/.github/agents/flask-page-scaffolder.agent.md
@@ -1,0 +1,74 @@
+---
+description: "Use when: scaffolding a brand-new server-rendered Flask + Jinja page in notification-admin — net-new route in app/main/views/, matching template under app/templates/views/, WTForms form in app/main/forms.py if it has user input, blueprint registration, permission decorators, and matching pytest in tests/app/. For small updates to an existing page (one new field, one template tweak), edit directly with the flask-jinja-page-workflow skill loaded instead of using this agent."
+tools: [read, edit, search, todo]
+argument-hint: "Describe the new page: route path, permission requirements, what data it reads/writes, which API client(s) it calls, and whether it's service-scoped, org-scoped, or top-level (e.g., 'Service-scoped page at /services/<service_id>/feedback that lists feedback entries from feedback_api_client and lets users with manage_service delete entries')"
+---
+
+You are the **Flask Page Scaffolder**, a specialist that scaffolds net-new server-rendered Flask + Jinja pages in the notification-admin Admin UI. You produce a complete first cut — view, template, form, decorator wiring, and test — matching the patterns in this codebase exactly.
+
+## Your Job
+
+Given a description of a new page, produce:
+
+1. A view function in the appropriate `app/main/views/<module>.py` (or a new module if no existing one fits), with correct permission decorator(s).
+2. A Jinja template under `app/templates/views/<area>/<page>.html` that extends `main_template.html` and uses existing partials/macros where possible.
+3. A WTForms form in `app/main/forms.py` if the page accepts input.
+4. Any blueprint/import wiring in `app/main/__init__.py` if a new view module is created.
+5. A matching pytest under `tests/app/main/views/test_<module>.py`.
+
+For small updates to existing pages (add a field, rename a label, tweak a permission), tell the user to edit directly — the `flask-jinja-page-workflow` skill covers those.
+
+## Constraints
+
+- ALWAYS read the [flask-jinja-page-workflow](.github/skills/flask-jinja-page-workflow/SKILL.md) skill before drafting — it has the conventions and file locations. Do not duplicate them here.
+- ALWAYS reuse existing decorators from `app/utils.py` (`user_has_permissions(...)`, `user_is_gov_user`, `user_is_platform_admin`) for authorization. Do not invent new ones or duplicate permission logic in the view body.
+- ALWAYS extend `app/templates/main_template.html`; never duplicate the base layout.
+- ALWAYS prefer existing partials in `app/templates/partials/` and components in `app/templates/components/` before writing fresh markup. If a pattern is used twice, extract a partial.
+- ALWAYS keep API/data access in the model layer (`app/models/`) or API client layer (`app/notify_client/`), not in templates or directly in view bodies when a client method exists.
+- DO NOT modify `app/notify_client/__init__.py` (base API client) or `app/extensions.py` — they are stable infrastructure.
+- DO NOT add dependencies to `pyproject.toml`.
+- DO NOT weaken or remove auth checks to make tests pass — fix the test or the permission setup.
+- DO NOT embed real user data, recipient info, or production secrets in templates or fixtures.
+
+## Approach
+
+1. **Check inputs.** Confirm the user's prompt supplies: route path, HTTP methods, permission requirements (which decorator from `app/utils.py`), scope (service/org/top-level), and which API client method(s) the page will call. If anything material is missing, ask one consolidated question covering only the gaps — do not run a Q&A loop. If the prompt is complete, skip straight to step 2.
+2. **Read the page workflow skill** for conventions and file locations.
+3. **Find the matching domain**:
+   - Search `app/main/views/` for an existing module covering the feature area (e.g., service settings → `service_settings.py`, organisations → `organisations.py`).
+   - If a suitable module exists, add to it. Creating a new view module is the *less* common case.
+   - Find the matching template directory under `app/templates/views/`.
+4. **Identify the API client** the page needs from `app/notify_client/`. If the client lacks the needed method, stop and tell the user to add it first (or delegate to `admin-api-client-builder` if appropriate) — this agent does not modify API clients.
+5. **Determine permissions**: which decorator from `app/utils.py` applies. Service-scoped pages usually need `user_has_permissions(...)` with specific permission names; platform-admin views use `user_is_platform_admin`.
+6. **Draft a TODO list** covering: view function, form (if needed), template, blueprint wiring (if new module), test.
+7. **Write the view function**:
+   - Place it in the chosen module.
+   - Apply the permission decorator(s).
+   - Handle GET (render) and POST (form submission) in the same view if it accepts input — this is the in-repo convention.
+   - Call the model/client method; keep transformation logic out of the template.
+   - Use `render_template('views/<area>/<page>.html', ...)` with named context variables.
+8. **Write the form** (if needed) in `app/main/forms.py` following the existing class pattern (subclass `StripWhitespaceForm` or the appropriate base; validators consistent with neighbors).
+9. **Write the template**:
+   - Extend `main_template.html`.
+   - Compose partials/macros from `app/templates/partials/` and `app/templates/components/`.
+   - Keep presentation-only; no API calls or heavy logic in Jinja.
+   - Use existing form-rendering macros for input fields if the page has a form.
+10. **Wire blueprint imports** in `app/main/__init__.py` only if a brand-new view module was created.
+11. **Write the test** under `tests/app/main/views/test_<module>.py` following the neighboring pattern: a logged-in client fixture, asserts on response status, page content, and (for POST) the side-effect call to the API client (typically via `mocker.patch`).
+12. **A11y self-review.** Before validation, re-read the new template against the [a11y-gov-ui-review](.github/skills/a11y-gov-ui-review/SKILL.md) skill: semantic landmarks, every form input has a `<label for>`, buttons are `<button>` not styled `<div>`, images have `alt`, focusable elements are reachable via keyboard, color isn't the only state signal, and ARIA is used only where native semantics fall short. Fix any issues before reporting back — a11y is a gate on net-new work, not a follow-up task.
+13. **Validate**: run `poetry run pytest tests/app/main/views/test_<module>.py -n 4`.
+14. **Report back** with the list of files created/modified and the test command.
+
+## Validation
+
+Before reporting back, confirm:
+
+- View has a permission decorator from `app/utils.py`; permission logic is not duplicated inside the view body.
+- Template extends `main_template.html` and uses existing partials/macros where applicable.
+- Form (if any) is in `app/main/forms.py` and follows the neighboring class shape.
+- API/data calls go through `app/notify_client/` or `app/models/`, not directly in the template.
+- New view module (if any) is imported in `app/main/__init__.py`.
+- Test exists under `tests/app/main/views/` and covers GET + POST (if applicable) plus the unauthenticated/unauthorized case.
+- A11y self-review completed: semantic landmarks, form labels, button vs. div, alt text, keyboard reachability, non-color state signals — all confirmed.
+- `poetry run pytest tests/app/main/views/test_<module>.py -n 4` passes.
+- No changes to `app/notify_client/__init__.py`, `app/extensions.py`, or `pyproject.toml`.

--- a/.github/agents/skill-author.agent.md
+++ b/.github/agents/skill-author.agent.md
@@ -18,13 +18,13 @@ You decide which shape (or both) fits, justify the choice to the user, and produ
 ## Constraints
 
 - DO NOT modify the four existing skills (`flask-jinja-page-workflow`, `cypress-e2e-notify-admin`, `a11y-gov-ui-review`, `tailwind-authoring-notify-admin`) unless the user explicitly asks.
-- DO NOT modify [AGENTS.md](AGENTS.md) unless the user asks — it is the project root contract.
+- DO NOT modify [AGENTS.md](../../AGENTS.md) unless the user asks — it is the project root contract.
 - DO NOT vendor upstream Anthropic skill-creator scripts that depend on the `claude -p` CLI or external subagent infrastructure — they will not run in this workspace.
 - DO NOT put `claude` or `anthropic` in a skill or agent name.
 - DO NOT create a `README.md` inside a skill folder; SKILL.md *is* the doc.
 - DO NOT use XML-style brackets (`<topic>`) in skill or agent content.
-- ALWAYS read the [skill-and-agent-authoring](.github/skills/skill-and-agent-authoring/SKILL.md) skill before drafting — it has the body structure, frontmatter format, and validation rules.
-- ALWAYS look at the two existing in-repo agent examples ([admin-api-client-builder.md](.github/agents/admin-api-client-builder.md), [notify-fullstack-scaffold.agent.md](.github/agents/notify-fullstack-scaffold.agent.md)) before drafting a new agent.
+- ALWAYS read the [skill-and-agent-authoring](../skills/skill-and-agent-authoring/SKILL.md) skill before drafting — it has the body structure, frontmatter format, and validation rules.
+- ALWAYS look at the two existing in-repo agent examples ([admin-api-client-builder.md](admin-api-client-builder.md), [notify-fullstack-scaffold.agent.md](notify-fullstack-scaffold.agent.md)) before drafting a new agent.
 - ALWAYS keep skill bodies under ~500 lines; split into `references/` subfiles if longer.
 - ALWAYS make descriptions slightly "pushy" (e.g., *"Use this skill whenever the user asks to ... even if they don't explicitly mention ..."*) to combat undertriggering, but never misleading.
 

--- a/.github/agents/skill-author.agent.md
+++ b/.github/agents/skill-author.agent.md
@@ -1,0 +1,87 @@
+---
+description: "Use when: creating a new VS Code Copilot skill or subagent for this repo, refactoring an existing skill/agent for better triggering, converting an ad-hoc workflow into a reusable skill or agent, or packaging conventions discovered during a task. Handles the full authoring loop: interview → draft SKILL.md or agent file → validate frontmatter and structure → propose a paired skill/agent if useful."
+tools: [read, edit, search, todo]
+argument-hint: "Describe the workflow or conventions to capture (e.g., 'a skill for writing Alembic migrations against our notify db', or 'an agent that scaffolds a new Notify report endpoint end-to-end')"
+---
+
+You are the **Skill and Agent Author**, a specialist that creates and refines VS Code Copilot skills (`.github/skills/<name>/SKILL.md`) and subagents (`.github/agents/<name>.md` or `<name>.agent.md`) for the notification-admin repo. You follow the conventions captured in the `skill-and-agent-authoring` skill — read it before drafting anything.
+
+## Your Job
+
+Given a description of a workflow, set of conventions, or repeated task the user wants to package, produce one or both of:
+
+1. A **skill** at `.github/skills/<kebab-name>/SKILL.md` — passive conventions that auto-load when their description matches user intent or file paths.
+2. An **agent** at `.github/agents/<kebab-name>.agent.md` — an invokable specialist that performs a multi-step workflow end-to-end.
+
+You decide which shape (or both) fits, justify the choice to the user, and produce the file(s) ready to commit.
+
+## Constraints
+
+- DO NOT modify the four existing skills (`flask-jinja-page-workflow`, `cypress-e2e-notify-admin`, `a11y-gov-ui-review`, `tailwind-authoring-notify-admin`) unless the user explicitly asks.
+- DO NOT modify [AGENTS.md](AGENTS.md) unless the user asks — it is the project root contract.
+- DO NOT vendor upstream Anthropic skill-creator scripts that depend on the `claude -p` CLI or external subagent infrastructure — they will not run in this workspace.
+- DO NOT put `claude` or `anthropic` in a skill or agent name.
+- DO NOT create a `README.md` inside a skill folder; SKILL.md *is* the doc.
+- DO NOT use XML-style brackets (`<topic>`) in skill or agent content.
+- ALWAYS read the [skill-and-agent-authoring](.github/skills/skill-and-agent-authoring/SKILL.md) skill before drafting — it has the body structure, frontmatter format, and validation rules.
+- ALWAYS look at the two existing in-repo agent examples ([admin-api-client-builder.md](.github/agents/admin-api-client-builder.md), [notify-fullstack-scaffold.agent.md](.github/agents/notify-fullstack-scaffold.agent.md)) before drafting a new agent.
+- ALWAYS keep skill bodies under ~500 lines; split into `references/` subfiles if longer.
+- ALWAYS make descriptions slightly "pushy" (e.g., *"Use this skill whenever the user asks to ... even if they don't explicitly mention ..."*) to combat undertriggering, but never misleading.
+
+## Approach
+
+1. **Interview the user.** Confirm:
+   - What should this enable the model (or a subagent) to do?
+   - What trigger phrases would real users say?
+   - What file paths or domains does it govern?
+   - What is explicitly *out of scope* (the "When NOT to Use" content)?
+   - Is it conventions (skill), a workflow (agent), or both?
+2. **Decide skill vs. agent vs. both.** Use the table in the `skill-and-agent-authoring` skill. State your recommendation and reasoning before drafting.
+3. **Choose a kebab-case name** that's specific to this repo (e.g., `alembic-migration-notify-db`, not `db-migrations`). Check for conflicts under `.github/skills/` and `.github/agents/`.
+4. **Read existing examples** for the shape you're producing.
+5. **Draft the file(s).** Follow the body structure from the authoring skill. Imperative voice. Explain *why* rather than relying on rigid `ALWAYS`/`NEVER` — reserve hard "must" for security/accessibility.
+6. **Re-read with fresh eyes.** Cut anything not pulling its weight. Confirm "When NOT to Use" (skills) or distinct workflows (agents) are present.
+7. **Validate** (see below).
+8. **Report back** with the path(s) created and a one-line summary of triggers.
+
+## Workflows
+
+### Workflow A: New skill
+
+1. Create `.github/skills/<name>/SKILL.md` with frontmatter and the section order from the authoring skill (When to Use → When NOT to Use → Core Files → Conventions → Procedure → Validation → Guardrails).
+2. Cross-link to AGENTS.md and existing skills rather than duplicating content.
+3. Validate.
+
+### Workflow B: New agent
+
+1. Create `.github/agents/<name>.agent.md` with frontmatter (`description`, `tools`, `argument-hint`).
+2. Body sections: Role statement → Your Job → Constraints → Approach → Workflows (if multiple) → Validation.
+3. If a matching skill exists, link to it from the agent so the agent inherits its conventions.
+4. Validate.
+
+### Workflow C: Skill + agent pair
+
+1. Draft the skill first (it encodes the conventions).
+2. Draft the agent second; reference the skill in its "Approach" step ("Read the `<name>` skill before drafting").
+3. Validate both.
+
+### Workflow D: Refactor an existing skill or agent
+
+1. Read the current file in full.
+2. Identify the failure mode (under-triggering → pushier description; over-triggering → stronger "When NOT to Use"; vague output → tighter procedure).
+3. Make the minimum edit that addresses the failure mode.
+4. Validate.
+
+## Validation
+
+Before reporting back, confirm:
+
+- File is named exactly `SKILL.md` (skill) or `<name>.md` / `<name>.agent.md` (agent).
+- Folder name matches the `name` field (skill) and is kebab-case.
+- YAML frontmatter parses; apostrophes inside single-quoted strings are escaped (`''`).
+- Description states *what* the thing does AND *when* to use it.
+- Skill has a "When NOT to Use" section.
+- Agent has explicit Constraints and a numbered Approach.
+- Body is under ~500 lines.
+- No XML brackets, no `README.md` in skill folders, no `claude`/`anthropic` in the name.
+- Run `python -c "import yaml,pathlib; yaml.safe_load(pathlib.Path('<file>').read_text().split('---',2)[1])"` to sanity-check the frontmatter.

--- a/.github/skills/a11y-gov-ui-review/SKILL.md
+++ b/.github/skills/a11y-gov-ui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: a11y-gov-ui-review
-description: 'Reviews Flask/Jinja and React UI changes for accessibility against WCAG 2.1 AA with full keyboard support. Use this skill whenever the user asks "is this accessible", "check a11y", "keyboard navigation", "screen reader", "WCAG", "add labels", "focus order", or is changing forms, modals, tables, navigation, or other interactive markup — even if accessibility isn\'t explicitly mentioned.'
+description: 'Reviews Flask/Jinja and React UI changes for accessibility against WCAG 2.1 AA with full keyboard support. Use this skill whenever the user asks "is this accessible", "check a11y", "keyboard navigation", "screen reader", "WCAG", "add labels", "focus order", or is changing forms, modals, tables, navigation, or other interactive markup — even if accessibility isn''t explicitly mentioned.'
 argument-hint: 'Describe the UI change and whether to review templates, React components, or both.'
 ---
 

--- a/.github/skills/a11y-gov-ui-review/SKILL.md
+++ b/.github/skills/a11y-gov-ui-review/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: a11y-gov-ui-review
+description: 'Reviews Flask/Jinja and React UI changes for accessibility against WCAG 2.1 AA with full keyboard support. Use this skill whenever the user asks "is this accessible", "check a11y", "keyboard navigation", "screen reader", "WCAG", "add labels", "focus order", or is changing forms, modals, tables, navigation, or other interactive markup — even if accessibility isn\'t explicitly mentioned.'
+argument-hint: 'Describe the UI change and whether to review templates, React components, or both.'
+---
+
+# Accessibility and GOV UI Review
+
+## When to Use
+- Any change to forms, navigation, modal/dialog, tables, or interactive controls
+- Jinja template updates that alter markup structure
+- React component updates that alter interaction patterns
+
+## When NOT to Use
+- Pure backend or API client changes with no rendered output
+- Build/config tweaks that don't touch templates or components
+
+## Standard
+- All UI must meet **WCAG 2.1 AA**.
+- All interactive functionality must be fully **keyboard accessible** — no mouse-only flows. Every control must be reachable via Tab, operable via Enter/Space (and arrow keys where appropriate), and have a visible focus indicator.
+
+## Focus Areas
+- Semantic structure: headings, lists, landmarks, table semantics
+- Form accessibility: labels, hints, error summaries, field-level error links
+- Keyboard behavior: tab order, focus visibility, escape/close behavior, focus trap in modals
+- Screen reader clarity: descriptive text, status updates, aria usage only when necessary
+- Language/i18n readiness for English and French UI text
+
+## Procedure
+1. Identify affected files under app/templates/, app/assets/javascripts/, and app/assets/stylesheets/.
+2. Check for semantic HTML first; avoid ARIA when native elements already solve the need.
+3. Verify controls have clear accessible names and state changes are announced where needed.
+4. Ensure error handling is perceivable and actionable (summary + inline context).
+5. Confirm color/contrast and focus styles are preserved by CSS changes.
+6. Add or update tests where practical:
+- Backend/template tests under tests/app/
+- JS tests under tests/javascripts/
+- Cypress coverage for user-critical paths under tests_cypress/
+
+## Validation Commands
+- make test
+- npm test
+
+## Guardrails
+- Do not remove visible focus outlines without an equivalent accessible style.
+- Do not rely on placeholder text as the only label.
+- Keep accessibility fixes incremental and low-risk when editing legacy UI.

--- a/.github/skills/cypress-e2e-notify-admin/SKILL.md
+++ b/.github/skills/cypress-e2e-notify-admin/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: cypress-e2e-notify-admin
+description: 'Writes Cypress end-to-end tests for notification-admin using the page-object pattern, with `data-testid` selectors and mandatory `a11yScan` coverage. Use this skill whenever the user asks to "add an e2e test", "write a cypress spec", "add a page object", "add a test id", "check accessibility in cypress", or is editing files under `tests_cypress/`, even if they don''t explicitly say "cypress".'
+argument-hint: 'Describe the flow to cover, the page(s) involved, and whether new page objects or test ids are needed.'
+---
+
+# Cypress E2E for Notification Admin
+
+## When to Use
+- Add an e2e spec for a user flow
+- Extend a page object with new selectors/actions
+- Add accessibility coverage to a page
+- Update selectors after a UI change
+
+## When NOT to Use
+- Python/Jest unit tests — use tests/app/ or tests/javascripts/ directly
+- Pure backend route logic with no user-facing flow
+
+## Important
+- **Selector rule:** every selector goes through `cy.getByTestId('...')`. If the element has no `data-testid`, add one to the template/component as part of your change. No `#id`, class, tag, or Tailwind utility selectors.
+- **A11y rule:** every spec calls `cy.a11yScan(url)` on every page state covered. A spec without `a11yScan` is incomplete.
+
+## Core Locations
+- Specs: tests_cypress/cypress/e2e/admin/
+- Page objects (POM): tests_cypress/cypress/Notify/Admin/Pages/
+- Shared barrel for page objects: tests_cypress/cypress/Notify/Admin/Pages/all.js
+- Support/commands: tests_cypress/cypress/support/
+- Config: tests_cypress/cypress.config.js
+- Repo guide: tests_cypress/README.md
+
+## Conventions
+- Use the Page Object Model. A page module exports two objects:
+  - `Components` — selector functions returning `cy.get(...)`
+  - `Actions` — higher-level user interactions composed from `Components`
+  Plus a `URL` constant when the page has a stable route.
+- **Always select by `data-testid`** using `cy.getByTestId('...')`. This decouples tests from UI structure so the markup can be refactored without breaking tests.
+  - If a needed element has no `data-testid`, add one to the Jinja template or React component as part of your change. Keep ids kebab-case and scoped to the feature.
+  - Do not use `#id`, class, tag, or Tailwind utility selectors. Limited use of `cy.contains('h1', '...')` is acceptable only for asserting visible page headings.
+- Import page objects from the barrel: `import { LoginPage, TemplatesPage } from "../../Notify/Admin/Pages/all";`
+- Use `before` to log in once per suite and `beforeEach` to stub recurring polling (e.g. `cy.intercept('GET', '**/dashboard.json', {})`).
+- **Always add accessibility coverage.** Every spec must call `cy.a11yScan(url)` (defined in [tests_cypress/cypress/support/commands.js](tests_cypress/cypress/support/commands.js)) for each page state under test. This runs axe, html validation, dead-link, and mime-type checks in one call.
+
+## Authentication and Test Users
+- A regular service user and a platform-admin user are created automatically on first login via the `createAccount` task (see [tests_cypress/cypress/support/commands.js](tests_cypress/cypress/support/commands.js)). Do not hand-roll users or fixtures for auth.
+- Use `cy.login()` for a standard service user, and `cy.loginAsPlatformAdmin()` for platform-admin flows. Pass `false` to skip the terms-of-use prompt (e.g. `cy.login(false)`).
+- Both helpers wrap `cy.session(...)`, so calling them in `before` (or in `beforeEach` when sessions differ between tests) is cheap — the session is cached for the spec.
+- After login, ids are available via `Cypress.env('REGULAR_USER_ID')` and `Cypress.env('ADMIN_USER_ID')` if a test needs them.
+- Never type credentials directly in a spec; always go through `cy.login` / `cy.loginAsPlatformAdmin`.
+
+## Procedure
+1. Identify or create the page object under tests_cypress/cypress/Notify/Admin/Pages/ and export it from `all.js`.
+2. Add selectors to `Components` using `cy.getByTestId` where possible; add `data-testid` to the underlying template/component if missing.
+3. Compose user-facing steps in `Actions` (login, fill form, submit, navigate).
+4. Write the spec under tests_cypress/cypress/e2e/admin/ following the existing `describe`/`before`/`beforeEach`/`after` pattern.
+5. Call `cy.a11yScan(url)` on every page state covered by the spec — this is mandatory, not optional.
+6. Run the spec locally before finalizing.
+
+## Validation Commands
+- Run a single spec: `npx cypress run --spec tests_cypress/cypress/e2e/admin/<file>.cy.js`
+- Open interactive runner: `npx cypress open`
+- See [tests_cypress/README.md](tests_cypress/README.md) for env vars and auth setup.
+
+## Guardrails
+- Don't couple tests to Tailwind utility classes or generated DOM structure.
+- Don't add long `cy.wait(ms)` calls; prefer assertions or `cy.intercept` waits.
+- Don't commit real credentials or recipient data; use env vars and fixtures.
+- Don't delete or weaken a failing test to make CI green — fix the underlying issue or flag it.

--- a/.github/skills/cypress-e2e-notify-admin/SKILL.md
+++ b/.github/skills/cypress-e2e-notify-admin/SKILL.md
@@ -29,19 +29,19 @@ argument-hint: 'Describe the flow to cover, the page(s) involved, and whether ne
 - Repo guide: tests_cypress/README.md
 
 ## Conventions
-- Use the Page Object Model. A page module exports two objects:
-  - `Components` — selector functions returning `cy.get(...)`
+- Use the Page Object Model. Existing page modules define:
+  - `Components` — selector functions returning Cypress chains
   - `Actions` — higher-level user interactions composed from `Components`
-  Plus a `URL` constant when the page has a stable route.
+  Then default-export a page object shaped like `{ Components, ...Actions }` so specs can call actions at the page-object top level.
 - **Always select by `data-testid`** using `cy.getByTestId('...')`. This decouples tests from UI structure so the markup can be refactored without breaking tests.
   - If a needed element has no `data-testid`, add one to the Jinja template or React component as part of your change. Keep ids kebab-case and scoped to the feature.
   - Do not use `#id`, class, tag, or Tailwind utility selectors. Limited use of `cy.contains('h1', '...')` is acceptable only for asserting visible page headings.
-- Import page objects from the barrel: `import { LoginPage, TemplatesPage } from "../../Notify/Admin/Pages/all";`
+- Import the default barrel object, then read pages from it: `import Pages from "../../Notify/Admin/Pages/all";`
 - Use `before` to log in once per suite and `beforeEach` to stub recurring polling (e.g. `cy.intercept('GET', '**/dashboard.json', {})`).
-- **Always add accessibility coverage.** Every spec must call `cy.a11yScan(url)` (defined in [tests_cypress/cypress/support/commands.js](tests_cypress/cypress/support/commands.js)) for each page state under test. This runs axe, html validation, dead-link, and mime-type checks in one call.
+- **Always add accessibility coverage.** Every spec must call `cy.a11yScan(url)` (defined in [tests_cypress/cypress/support/commands.js](../../../tests_cypress/cypress/support/commands.js)) for each page state under test. This runs axe, html validation, dead-link, and mime-type checks in one call.
 
 ## Authentication and Test Users
-- A regular service user and a platform-admin user are created automatically on first login via the `createAccount` task (see [tests_cypress/cypress/support/commands.js](tests_cypress/cypress/support/commands.js)). Do not hand-roll users or fixtures for auth.
+- A regular service user and a platform-admin user are created automatically on first login via the `createAccount` task (see [tests_cypress/cypress/support/commands.js](../../../tests_cypress/cypress/support/commands.js)). Do not hand-roll users or fixtures for auth.
 - Use `cy.login()` for a standard service user, and `cy.loginAsPlatformAdmin()` for platform-admin flows. Pass `false` to skip the terms-of-use prompt (e.g. `cy.login(false)`).
 - Both helpers wrap `cy.session(...)`, so calling them in `before` (or in `beforeEach` when sessions differ between tests) is cheap — the session is cached for the spec.
 - After login, ids are available via `Cypress.env('REGULAR_USER_ID')` and `Cypress.env('ADMIN_USER_ID')` if a test needs them.
@@ -58,7 +58,7 @@ argument-hint: 'Describe the flow to cover, the page(s) involved, and whether ne
 ## Validation Commands
 - Run a single spec: `npx cypress run --spec tests_cypress/cypress/e2e/admin/<file>.cy.js`
 - Open interactive runner: `npx cypress open`
-- See [tests_cypress/README.md](tests_cypress/README.md) for env vars and auth setup.
+- See [tests_cypress/README.md](../../../tests_cypress/README.md) for env vars and auth setup.
 
 ## Guardrails
 - Don't couple tests to Tailwind utility classes or generated DOM structure.

--- a/.github/skills/flask-jinja-page-workflow/SKILL.md
+++ b/.github/skills/flask-jinja-page-workflow/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: flask-jinja-page-workflow
+description: 'Adds or updates server-rendered Flask + Jinja pages in notification-admin — routes, views, forms, templates, partials, and matching tests. Use this skill whenever the user asks to "add a route", "new page", "new view", "wire up a form", "update this Jinja template", "add a partial", or is touching files under app/main/views/ or app/templates/, even if they don\'t explicitly mention Flask or Jinja.'
+argument-hint: 'Describe the page or flow to add/change, route path, and permission requirements.'
+---
+
+# Flask Jinja Page Workflow
+
+## When to Use
+- Add a new page or route in the Flask app
+- Modify an existing page flow in server-rendered UI
+- Wire a form submission path (GET + POST)
+- Update page-level navigation, partials, or macros
+
+## When NOT to Use
+- Pure API client / `notify_client` work with no template change
+- Frontend-only React/Vite changes — use the React/Vite guidance in AGENTS.md instead
+- Cypress test work — use the cypress-e2e-notify-admin skill
+
+## Core Files
+- Routes/views: app/main/views/
+- Blueprint import registration: app/main/__init__.py
+- Templates: app/templates/views/
+- Shared partials and macros: app/templates/partials/ and app/templates/components/
+- Common auth/permission decorators: app/utils.py
+- Page tests: tests/app/
+
+## Procedure
+1. Find the domain view module in app/main/views/ that matches the feature area.
+2. Add or update route functions and keep decorator usage consistent:
+- user_has_permissions(...)
+- user_is_gov_user
+- user_is_platform_admin
+3. Keep business/data logic in view/model/client layers, not in Jinja templates.
+4. Render or update a template under app/templates/views/ and compose shared partials/macros.
+5. If shared markup appears in multiple pages, extract to app/templates/partials/ or app/templates/components/.
+6. Add or update tests in tests/app/ near the affected feature.
+7. Run relevant validation commands.
+
+## Validation Commands
+- make test
+- poetry run pytest tests/app -n 4
+
+## Guardrails
+- Keep diffs scoped to one page flow unless asked otherwise.
+- Do not duplicate permission logic when decorators can enforce it.
+- Prefer existing template blocks/macros over one-off markup duplication.

--- a/.github/skills/flask-jinja-page-workflow/SKILL.md
+++ b/.github/skills/flask-jinja-page-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flask-jinja-page-workflow
-description: 'Adds or updates server-rendered Flask + Jinja pages in notification-admin — routes, views, forms, templates, partials, and matching tests. Use this skill whenever the user asks to "add a route", "new page", "new view", "wire up a form", "update this Jinja template", "add a partial", or is touching files under app/main/views/ or app/templates/, even if they don\'t explicitly mention Flask or Jinja.'
+description: 'Adds or updates server-rendered Flask + Jinja pages in notification-admin — routes, views, forms, templates, partials, and matching tests. Use this skill whenever the user asks to "add a route", "new page", "new view", "wire up a form", "update this Jinja template", "add a partial", or is touching files under app/main/views/ or app/templates/, even if they don''t explicitly mention Flask or Jinja.'
 argument-hint: 'Describe the page or flow to add/change, route path, and permission requirements.'
 ---
 

--- a/.github/skills/skill-and-agent-authoring/SKILL.md
+++ b/.github/skills/skill-and-agent-authoring/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: skill-and-agent-authoring
+description: 'Authors VS Code Copilot skills (`.github/skills/<name>/SKILL.md`) and subagents (`.github/agents/<name>.md` or `<name>.agent.md`) for this repo — kebab-case names, YAML frontmatter with a "pushy" what+when description, "When NOT to Use" section, < 500 line body, and validation. Use this skill whenever the user asks to "create a skill", "new skill", "add a skill", "make an agent", "new subagent", "package this workflow", or is editing files under .github/skills/ or .github/agents/, even if they don''t mention skills or agents by name.'
+---
+
+# Skill and Agent Authoring (notify-admin)
+
+Use this skill when adding or editing files under `.github/skills/` or `.github/agents/`. For doing the work end-to-end (interview → draft → validate), delegate to the `skill-author` agent instead. This skill exists so the same conventions apply when you're making a quick one-off edit and don't want to spawn a subagent.
+
+## Skill vs. Agent — pick the right shape
+
+| Want to... | Use a |
+|---|---|
+| Bake "how we do X here" conventions into every relevant edit | **Skill** |
+| Define a multi-step workflow someone can delegate to | **Agent** |
+| Capture a checklist that should auto-apply when matching files are touched | **Skill** |
+| Do scaffolding across many files without cluttering the main conversation | **Agent** |
+
+Skills are passive context bundles loaded when their description matches; agents are invokable specialists run via `runSubagent`. Many features benefit from both — a skill encodes the rules, an agent uses the skill to do work end-to-end.
+
+## File layout
+
+```
+.github/
+├── skills/
+│   └── <skill-name>/
+│       └── SKILL.md          (required, exact filename)
+└── agents/
+    └── <agent-name>.md       (or <agent-name>.agent.md)
+```
+
+- Folder/file names: kebab-case. No `claude` or `anthropic` in the name.
+- One SKILL.md per skill folder. No `README.md` inside a skill folder (duplicates content).
+- Don't use XML-style brackets like `<topic>` in skill/agent content.
+- Keep the body under ~500 lines. If it grows, split into `references/<topic>.md` files and point to them from SKILL.md.
+
+## YAML frontmatter
+
+### Skill frontmatter
+
+```yaml
+---
+name: kebab-case-skill-name
+description: 'One-sentence summary of what the skill does. Use this skill whenever the user asks to "<trigger 1>", "<trigger 2>", or is editing files under <path>/, even if they don''t mention <topic> explicitly.'
+---
+```
+
+Why this shape:
+
+- **`name`** must match the folder. Kebab-case.
+- **`description`** is the *only* signal the model uses to decide whether to load the skill, so combine **what** it does + **when** to use it in the same field. Don't hide triggers in the body.
+- Make the description a little **"pushy"** — current models tend to *under*-trigger skills. Phrases like *"Use this skill whenever..."* and *"even if they don't explicitly mention..."* combat that without being misleading.
+- Single-quote the value and escape inner apostrophes as `''` so YAML parses cleanly.
+
+### Agent frontmatter
+
+```yaml
+---
+description: "Use when: <trigger phrases or scenarios>. Handles <what it does end-to-end>."
+tools: [read, edit, search, todo]
+argument-hint: "Describe <what the user should supply> (e.g., '<concrete example>')"
+---
+```
+
+Look at [admin-api-client-builder.md](../../../.github/agents/admin-api-client-builder.md) and [notify-fullstack-scaffold.agent.md](../../../.github/agents/notify-fullstack-scaffold.agent.md) for the in-repo pattern.
+
+## Body structure (skills)
+
+A skill body usually wants these sections, in this order. Keep each tight.
+
+1. **One-line orientation** — what this skill governs.
+2. **When to Use** — concrete trigger phrases and file paths.
+3. **When NOT to Use** — adjacent topics this skill *isn't* for, so it doesn't mis-trigger. This is the highest-leverage section for accuracy.
+4. **Core Files / Locations** — exact paths the editor needs to know.
+5. **Conventions** — the rules. Prefer explaining *why* over rigid `ALWAYS`/`NEVER` in all caps — modern models follow reasoned guidance better than commands. Reserve hard "must" language for things that are genuinely non-negotiable (security, accessibility) and explain the consequence.
+6. **Procedure** — numbered steps for the common task this skill supports.
+7. **Validation** — exact commands or checks to confirm the change is correct.
+8. **Guardrails** — short list of things to avoid.
+
+## Body structure (agents)
+
+1. **Role statement** — "You are the <Name>, a specialist that ...".
+2. **Your Job** — the input/output contract.
+3. **Constraints** — `DO NOT` / `ALWAYS` rules specific to the task.
+4. **Approach** — numbered workflow.
+5. **Workflows** — if the agent handles distinct cases (e.g., "Workflow A: adding to existing client; Workflow B: creating from scratch"), enumerate them.
+6. **Validation** — what to run before reporting back.
+
+## Writing patterns
+
+- **Imperative voice**: "Add the route to `app/main/views/<module>.py`", not "The route should be added".
+- **Explain the why**: "Use `data-testid` selectors so refactoring markup doesn't break tests" is more durable than "NEVER use CSS class selectors".
+- **Reference real files** with markdown links so the model can jump to them: `[app/utils.py](app/utils.py)`.
+- **Avoid duplicating** content from [AGENTS.md](../../../AGENTS.md) — link instead.
+- **Negative space matters**: a clear "When NOT to Use" prevents the skill from misfiring on adjacent work.
+
+## Procedure: create a new skill
+
+1. **Capture intent**: clarify what the skill should enable, what trigger phrases real users say, what files it governs, and what's out of scope.
+2. Pick a kebab-case `<skill-name>` that's specific to this repo (e.g., `cypress-e2e-notify-admin`, not `cypress-tests`).
+3. Create `.github/skills/<skill-name>/SKILL.md` with the frontmatter above.
+4. Draft the body in the order listed under "Body structure (skills)".
+5. Re-read with fresh eyes — cut anything not pulling its weight, soften rigid commands into reasoned guidance.
+6. Validate (see below).
+7. If the user might also want it as a workflow, propose a matching agent under `.github/agents/`.
+
+## Procedure: create a new agent
+
+1. Capture intent: what end-to-end task should the agent own; what input does it take; what files does it touch.
+2. Create `.github/agents/<agent-name>.agent.md` (or `.md`) with the frontmatter above.
+3. Write the role statement, constraints, and a numbered approach. Reference the matching skill (if any) so the agent inherits its conventions.
+4. If the agent shares conventions with an existing skill, link to that skill rather than duplicating rules.
+5. Validate.
+
+## Validation
+
+Run these checks on any new or edited skill/agent file:
+
+- `name` (skill) and folder name are identical and kebab-case.
+- File is named exactly `SKILL.md` (skill) or `<name>.md` / `<name>.agent.md` (agent).
+- YAML frontmatter parses (no unescaped apostrophes; single-quoted values).
+- Description includes *both* what the thing does *and* when to use it.
+- Body is under ~500 lines.
+- No XML brackets in content.
+- No `README.md` inside the skill folder.
+- No `claude` or `anthropic` in the name.
+
+Optional helper (mirrors upstream skill-creator):
+
+```bash
+python -c "import yaml,sys,pathlib; p=pathlib.Path('$FILE'); t=p.read_text(); \
+  fm=t.split('---',2)[1]; m=yaml.safe_load(fm); \
+  assert m.get('name','').replace('-','').isalnum() or 'description' in m, 'bad frontmatter'; \
+  print('ok:', m.get('name') or '(agent)')"
+```
+
+## Guardrails
+
+- Don't vendor upstream tooling that depends on `claude -p` CLI or Claude Code subagents — it won't run in this workspace.
+- Don't create skills that overlap heavily with existing ones; extend the existing skill instead.
+- Don't embed secrets, real user data, or production URLs in skill content.
+- If a skill or agent encodes auth/permission rules, keep them aligned with `app/utils.py` decorators rather than inventing new patterns.

--- a/.github/skills/skill-and-agent-authoring/SKILL.md
+++ b/.github/skills/skill-and-agent-authoring/SKILL.md
@@ -90,7 +90,7 @@ A skill body usually wants these sections, in this order. Keep each tight.
 
 - **Imperative voice**: "Add the route to `app/main/views/<module>.py`", not "The route should be added".
 - **Explain the why**: "Use `data-testid` selectors so refactoring markup doesn't break tests" is more durable than "NEVER use CSS class selectors".
-- **Reference real files** with markdown links so the model can jump to them: `[app/utils.py](app/utils.py)`.
+- **Reference real files** with markdown links so the model can jump to them: `[app/utils.py](../../../app/utils.py)`.
 - **Avoid duplicating** content from [AGENTS.md](../../../AGENTS.md) — link instead.
 - **Negative space matters**: a clear "When NOT to Use" prevents the skill from misfiring on adjacent work.
 

--- a/.github/skills/tailwind-authoring-notify-admin/SKILL.md
+++ b/.github/skills/tailwind-authoring-notify-admin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tailwind-authoring-notify-admin
-description: 'Authors Tailwind/CSS changes in notification-admin — utilities-first markup, `@apply` for reused semantic classes, theme tokens, and safelist updates. Use this skill whenever the user asks to "style this", "add a class", "update CSS", "use @apply", "tailwind not picking up my class", "add to safelist", or is editing files under app/assets/stylesheets/ or tailwind.config.js, even if Tailwind isn\'t explicitly mentioned.'
+description: 'Authors Tailwind/CSS changes in notification-admin — utilities-first markup, `@apply` for reused semantic classes, theme tokens, and safelist updates. Use this skill whenever the user asks to "style this", "add a class", "update CSS", "use @apply", "tailwind not picking up my class", "add to safelist", or is editing files under app/assets/stylesheets/ or tailwind.config.js, even if Tailwind isn''t explicitly mentioned.'
 argument-hint: 'Describe the component/page styling change and whether classes are static or runtime-generated.'
 ---
 

--- a/.github/skills/tailwind-authoring-notify-admin/SKILL.md
+++ b/.github/skills/tailwind-authoring-notify-admin/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: tailwind-authoring-notify-admin
+description: 'Authors Tailwind/CSS changes in notification-admin — utilities-first markup, `@apply` for reused semantic classes, theme tokens, and safelist updates. Use this skill whenever the user asks to "style this", "add a class", "update CSS", "use @apply", "tailwind not picking up my class", "add to safelist", or is editing files under app/assets/stylesheets/ or tailwind.config.js, even if Tailwind isn\'t explicitly mentioned.'
+argument-hint: 'Describe the component/page styling change and whether classes are static or runtime-generated.'
+---
+
+# Tailwind Authoring for Notification Admin
+
+## When to Use
+- Add or modify styles for components or views
+- Introduce new utility usage in templates or React components
+- Add runtime-generated classes requiring safelist updates
+
+## When NOT to Use
+- Markup-only edits that reuse existing classes — just edit the template
+- Pure JS behavior changes with no styling impact
+
+## Core Files
+- Tailwind config and tokens: tailwind.config.js
+- Tailwind entry and import graph: app/assets/stylesheets/tailwind/style.css
+- Component styles: app/assets/stylesheets/tailwind/components/
+- View styles: app/assets/stylesheets/tailwind/views/
+
+## Utility Classes vs `@apply`
+- Default: write Tailwind utilities (`mb-4`, `flex`, `text-smaller`) directly in Jinja templates and React components. This keeps styles colocated with markup and easy to grep.
+- Reach for `@apply` in a CSS partial when one of these is true:
+  - The same utility cluster is repeated across many templates/components and deserves a named class (e.g. `.button-secondary`, `.hint`).
+  - You need pseudo-state, child selectors, or responsive overrides that are awkward to express inline.
+  - You're styling markup you don't control (third-party output, generated HTML, `prose`-like content).
+- Prefer extending an existing semantic class over inventing a new one; check `app/assets/stylesheets/tailwind/components/` first.
+- Don't wrap a single utility in `@apply` just to rename it.
+
+## Procedure
+1. Determine if the change is component-level or view-level.
+2. Decide utilities-in-markup vs `@apply` using the rules above.
+3. If editing CSS, add or update a partial in the correct directory:
+- components/ for reusable UI patterns
+- views/ for page-specific styling
+4. Import new partials from app/assets/stylesheets/tailwind/style.css.
+5. Reuse existing spacing, color, font, and breakpoint tokens from tailwind.config.js.
+6. If class names are runtime-generated and cannot be statically detected, update the safelist in tailwind.config.js.
+7. Build and verify output before finalizing.
+
+## Validation Commands
+- npm run watch
+- npm run build
+
+## Guardrails
+- Avoid hardcoded one-off values when an existing token is available.
+- Keep selector specificity low and compatible with existing utility-first approach.
+- Do not edit generated output files as source of truth.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,6 @@ If a full suite cannot be run, document what was run and why.
 - Prefer linking to source docs/config files instead of copying detailed procedures.
 - If a section grows large, move detail into a scoped instruction/skill and link it here.
 
-## Clarifications and and asking questions
+## Clarifications and asking questions
 - Use the #askUser tool for all questions and clarifications
 - Use the #askUser tool before finalizing any request

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,199 @@
+# AGENTS.md
+
+Agent instructions for this repository.
+
+## Scope
+
+- This codebase is a Flask admin app with Python backend and Vite/Tailwind frontend assets.
+- Prefer small, focused diffs. Avoid broad refactors unless explicitly requested.
+
+## Project Overview
+
+- App type: Flask server-rendered admin UI with Jinja templates plus selective React islands.
+- Backend runtime: Python 3.12 via Poetry.
+- Frontend toolchain: Vite 8, React 18, TailwindCSS 3.
+- Primary concern: service/user/template administration flows backed by Notify API clients.
+
+## First Stops
+
+- Project setup and constraints: [README.md](README.md)
+- Canonical task runner targets: [Makefile](Makefile)
+- Python tooling and lint/type config: [pyproject.toml](pyproject.toml)
+- Test defaults, markers, and env overrides: [pytest.ini](pytest.ini)
+- Runtime entrypoint and tracing toggle: [application.py](application.py)
+- App factory and blueprint wiring: [app/__init__.py](app/__init__.py)
+- Frontend HMR context and limitations: [docs/css-hmr-plan.md](docs/css-hmr-plan.md)
+
+## Canonical Commands
+
+- Install deps: `poetry install` and `npm install`
+- Run local dev (Flask debugpy + tailwind watch): `make run-dev`
+- Run tests/lint/type checks (project standard): `make test`
+- Run Python tests only: `poetry run pytest tests/app -n 4`
+- Run JS tests only: `npm test`
+- Build frontend assets: `npm run build`
+- Watch frontend assets: `npm run watch`
+- Compile translations: `make babel`
+
+Prefer these over ad-hoc command variants when validating changes.
+
+## Architecture Map
+
+- WSGI entrypoint: [application.py](application.py)
+- Main backend package: [app/](app)
+- Server-rendered views/routes: [app/main/views/](app/main/views)
+- API client wrappers: [app/notify_client/](app/notify_client)
+- Domain models/helpers: [app/models/](app/models)
+- Frontend source JS: [app/assets/javascripts/](app/assets/javascripts)
+- Frontend source CSS: [app/assets/stylesheets/](app/assets/stylesheets)
+- Python tests: [tests/app/](tests/app)
+- JS tests: [tests/javascripts/](tests/javascripts)
+- Cypress tests: [tests_cypress/](tests_cypress)
+
+## Frontend Implementation Guide
+
+### React Components
+
+- React components in this repo live under feature folders in [app/assets/javascripts/](app/assets/javascripts).
+- Keep new components within a feature directory rather than creating a cross-cutting shared folder unless existing code already uses one for that concern.
+- Pattern to follow for server-rendered pages: expose a small mount API from an entry file, then call `createRoot(...).render(...)`.
+- Keep browser-global exports minimal and only when needed for template bootstrapping.
+- Keep component logic in focused files and colocate feature helpers/hooks with the component.
+
+### Vite Usage
+
+- Modern ES module bundles are defined in [vite.config.js](vite.config.js) as explicit entrypoints.
+- Legacy IIFE bundle (`all.min.js`) is built separately via [vite.legacy.config.js](vite.legacy.config.js).
+- When adding a new standalone frontend feature that needs its own bundle:
+	- Add an input entry in [vite.config.js](vite.config.js).
+	- Ensure output naming remains compatible with static asset fingerprinting (`javascripts/[name].min.js`).
+	- Wire the script into the relevant template/view.
+- JSX in `.js` files is supported intentionally through the pre-transform plugin in [vite.config.js](vite.config.js). Do not migrate file extensions just to satisfy Vite parsing.
+
+### Tailwind and CSS
+
+- Tailwind source of truth is [app/assets/stylesheets/tailwind/style.css](app/assets/stylesheets/tailwind/style.css), which imports component/view partials.
+- Add new component styles as a dedicated file in [app/assets/stylesheets/tailwind/components/](app/assets/stylesheets/tailwind/components), then import it from [app/assets/stylesheets/tailwind/style.css](app/assets/stylesheets/tailwind/style.css).
+- Keep utility/class names compatible with configured theme tokens in [tailwind.config.js](tailwind.config.js).
+- If a class is dynamically generated at runtime and not statically discoverable, add it to the safelist in [tailwind.config.js](tailwind.config.js).
+
+### Frontend Testing Expectations
+
+- Jest config is in [tests/javascripts/jest.config.js](tests/javascripts/jest.config.js).
+- Some frontend tests rely on Babel transforms for JSX in `.js` files; keep this in mind when moving files or introducing new JSX-heavy areas.
+- For UI behavior changes, add or update:
+	- Unit tests under [tests/javascripts/](tests/javascripts)
+	- Cypress tests under [tests_cypress/](tests_cypress) when end-to-end behavior changes
+
+## Flask and Jinja Structure
+
+### Routes and Views
+
+- Main application routes are in [app/main/views/](app/main/views) and mounted via the `main` blueprint in [app/main/__init__.py](app/main/__init__.py).
+- Group new routes by domain (for example service settings, templates, dashboard) by adding to the most relevant existing view module.
+- If a domain grows substantially, add a new view module under [app/main/views/](app/main/views) and register its import in [app/main/__init__.py](app/main/__init__.py).
+- Use existing decorators and guards consistently (for example permission checks around service/org scoped routes).
+
+### Jinja Templates
+
+- Base layout and shared script/style loading are centralized in [app/templates/main_template.html](app/templates/main_template.html).
+- Page templates generally live under [app/templates/views/](app/templates/views) and shared fragments under [app/templates/partials/](app/templates/partials).
+- For new pages, prefer extending `main_template.html` and composing partials/macros rather than duplicating structure.
+- Keep route handlers and template paths aligned: a new view should render a template in the corresponding area of [app/templates/views/](app/templates/views).
+
+### Jinja Macros and Component Reuse
+
+- Prefer existing macros/components before creating new template patterns.
+- Check reusable building blocks in [app/templates/components/](app/templates/components) and shared partials in [app/templates/partials/](app/templates/partials).
+- If a pattern is used in more than one page, extract it into a macro/partial rather than duplicating markup.
+- Keep macro APIs stable and explicit (clear parameter names, minimal side effects) to reduce template regressions.
+
+### Models and API-Backed Data
+
+- Models in [app/models/](app/models) are mostly thin wrappers over API client responses (not ORM entities).
+- Prefer extending existing model methods and API clients in [app/notify_client/](app/notify_client) rather than embedding API calls directly in templates.
+- Keep transformation logic close to view/model boundaries so Jinja templates remain presentation-focused.
+
+### Decorators and Access Control
+
+- Reuse existing auth/permission decorators from [app/utils.py](app/utils.py) for route protection:
+	- `user_has_permissions(...)`
+	- `user_is_gov_user`
+	- `user_is_platform_admin`
+- Do not duplicate authorization logic inside view bodies when a decorator can enforce it consistently.
+- For service- or org-scoped routes, follow existing permission patterns in neighboring view functions in [app/main/views/](app/main/views).
+
+### Page Change Checklist
+
+- When adding or changing a page flow, update together where applicable:
+	- Route/view logic in [app/main/views/](app/main/views)
+	- Jinja template(s) in [app/templates/views/](app/templates/views)
+	- Shared partials/macros in [app/templates/partials/](app/templates/partials)
+	- Frontend entry/component code in [app/assets/javascripts/](app/assets/javascripts) if the page behavior depends on JS
+	- Tests under [tests/app/](tests/app) and [tests/javascripts/](tests/javascripts)
+
+## Conventions To Respect
+
+- Python style is enforced by Ruff and MyPy; use configured defaults in [pyproject.toml](pyproject.toml).
+- JS/CSS formatting uses Prettier on frontend directories; keep output consistent with existing style.
+- Keep route/view changes close to corresponding tests under [tests/app/main/views/](tests/app/main/views) when applicable.
+- For frontend behavior, update unit tests in [tests/javascripts/](tests/javascripts) when logic changes.
+
+## Security Considerations
+
+- Never commit secrets, API keys, tokens, or `.env` values.
+- Treat notification content, recipient data, and uploaded files as sensitive; avoid copying real data into fixtures or snapshots.
+- Keep authentication/authorization checks at route boundaries (decorators + current-user checks), not only in templates or client code.
+- For file upload or attachment features, validate type/size rules server-side and keep client checks as defense-in-depth.
+
+## Git Workflow
+
+- Keep commits narrowly scoped to one logical change.
+- Do not bundle unrelated formatting-only changes with behavior changes.
+- Before proposing merge-ready changes, run the smallest relevant command set from the Canonical Commands section and report what was executed.
+- If a change impacts both backend and frontend, validate both paths (for example `make test` and `npm run build`).
+
+## Boundaries
+
+### Always
+
+- Prefer existing patterns in neighboring files before introducing new abstractions.
+- Add or update tests for behavior changes.
+- Link to existing docs/config files instead of duplicating long instructions.
+
+### Ask First
+
+- Adding new dependencies (Python or Node).
+- Modifying CI/CD, deployment, or runtime infra configs.
+- Large structural refactors across multiple domains.
+
+### Never
+
+- Never hardcode secrets or credentials in code, tests, or docs.
+- Never edit generated/vendor/dependency artifacts by hand.
+- Never remove or weaken auth checks to satisfy tests.
+
+## Common Pitfalls
+
+- Dev debugger attach flow expects debugpy on port `5678`; use `make run-dev` to match workspace tasks.
+- Test environment overrides key vars via [pytest.ini](pytest.ini); do not assume `.env` values during tests.
+- Redis-backed paths require `REDIS_ENABLED`; local defaults can mask behavior differences.
+- CSS/asset behavior differs between local dev and built static output; validate with the command that matches the target environment.
+
+## Change Validation Guidance
+
+- Backend change: run `make test` (or targeted pytest while iterating, then `make test`).
+- Frontend change: run `npm run build` and relevant Jest/Cypress tests.
+- Translation change: run `make babel` and `make test-translations`.
+
+If a full suite cannot be run, document what was run and why.
+
+## Maintenance Rule For This File
+
+- Keep this file concise and high-signal. Target roughly 120-200 lines.
+- Prefer linking to source docs/config files instead of copying detailed procedures.
+- If a section grows large, move detail into a scoped instruction/skill and link it here.
+
+## Clarifications and and asking questions
+- Use the #askUser tool for all questions and clarifications
+- Use the #askUser tool before finalizing any request


### PR DESCRIPTION
# Summary | Résumé
This pull request introduces new VS Code Copilot agents/skills and a new accessibility review skill for the notification-admin repo. 

These additions formalize and automate best practices for:
* scaffolding new Flask/Jinja pages
* writing Cypress E2E tests
* authoring skills/agents
* reviewing UI for accessibility. 
 
 
Each agent/skill includes clear constraints, step-by-step approaches, and validation checklists to ensure high-quality, consistent contributions.