### PR TITLE
Feat/add attachment feature

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -82,6 +82,7 @@ jobs:
       with:
         repository: cds-snc/notification-api
         path: api
+        ref: task/files-api-dao #TODO: REMOVE THIS BEFORE MERGING
 
     - name: Set up Python 3.12
       uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0

--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -82,7 +82,6 @@ jobs:
       with:
         repository: cds-snc/notification-api
         path: api
-        ref: task/files-api-dao #TODO: REMOVE THIS BEFORE MERGING
 
     - name: Set up Python 3.12
       uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -71,6 +71,7 @@ from app.notify_client.billing_api_client import billing_api_client
 from app.notify_client.complaint_api_client import complaint_api_client
 from app.notify_client.email_branding_client import email_branding_client
 from app.notify_client.events_api_client import events_api_client
+from app.notify_client.file_api_client import file_api_client
 from app.notify_client.inbound_number_client import inbound_number_client
 from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.job_api_client import job_api_client
@@ -167,10 +168,12 @@ def create_app(application):
         cache,
         # API clients
         api_key_api_client,
+        file_api_client,
         billing_api_client,
         complaint_api_client,
         email_branding_client,
         events_api_client,
+        file_api_client,
         inbound_number_client,
         invite_api_client,
         job_api_client,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -168,7 +168,6 @@ def create_app(application):
         cache,
         # API clients
         api_key_api_client,
-        file_api_client,
         billing_api_client,
         complaint_api_client,
         email_branding_client,

--- a/app/assets/javascripts/attachments/AttachedFileRow.js
+++ b/app/assets/javascripts/attachments/AttachedFileRow.js
@@ -34,9 +34,7 @@ export const AttachedFileRow = ({
       {file.name}
     </a>
   ) : (
-    <span className="attachment-file-name-truncate">
-      {file.name}
-    </span>
+    <span className="attachment-file-name-truncate">{file.name}</span>
   );
 
   return (

--- a/app/assets/javascripts/attachments/AttachedFileRow.js
+++ b/app/assets/javascripts/attachments/AttachedFileRow.js
@@ -16,20 +16,7 @@ export const AttachedFileRow = ({
     file.status === ATTACHMENT_STATUSES.UPLOADING ||
     file.status === ATTACHMENT_STATUSES.PENDING_SCAN;
   const isMalware = file.status === ATTACHMENT_STATUSES.MALWARE;
-  const downloadHref = file.downloadUrl || file.download_url || file.url;
-  const canDownload = !isInProgress && !isMalware && Boolean(downloadHref);
-
-  const fileNameNode = canDownload ? (
-    <a
-      href={downloadHref}
-      download={file.name}
-      className="attachment-file-name-truncate"
-      title={file.name}
-      data-testid="attachment-download-link"
-    >
-      {file.name}
-    </a>
-  ) : (
+  const fileNameNode = (
     <span title={file.name} className="attachment-file-name-truncate">
       {file.name}
     </span>
@@ -43,12 +30,10 @@ export const AttachedFileRow = ({
       {isConfirmingRemoval ? (
         <div className="p-4" role="alert">
           <p className="heading-small mt-0 mb-3">{copy.removeConfirmTitle}</p>
-          {canDownload ? (
-            <p className="mb-3 mt-0">
-              {copy.removeConfirmBodyPrefix} '{fileNameNode}'{" "}
-              {copy.removeConfirmBodySuffix}
-            </p>
-          ) : null}
+          <p className="mb-3 mt-0">
+            {copy.removeConfirmBodyPrefix} '{fileNameNode}'{" "}
+            {copy.removeConfirmBodySuffix}
+          </p>
           <div className="flex gap-4 mt-6">
             <button
               type="button"

--- a/app/assets/javascripts/attachments/AttachedFileRow.js
+++ b/app/assets/javascripts/attachments/AttachedFileRow.js
@@ -14,8 +14,8 @@ export const AttachedFileRow = ({
 }) => {
   const isInProgress =
     file.status === ATTACHMENT_STATUSES.UPLOADING ||
-    file.status === ATTACHMENT_STATUSES.PENDING_SCAN;
-  const isMalware = file.status === ATTACHMENT_STATUSES.MALWARE;
+    file.status === ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN;
+  const isMalware = file.status === ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED;
   const fileNameNode = (
     <span title={file.name} className="attachment-file-name-truncate">
       {file.name}

--- a/app/assets/javascripts/attachments/AttachedFileRow.js
+++ b/app/assets/javascripts/attachments/AttachedFileRow.js
@@ -8,6 +8,7 @@ export const AttachedFileRow = ({
   file,
   copy = DEFAULT_COPY,
   isConfirmingRemoval,
+  downloadEndpoint,
   onRequestRemove,
   onConfirmRemove,
   onCancelRemove,
@@ -16,7 +17,22 @@ export const AttachedFileRow = ({
     file.status === ATTACHMENT_STATUSES.UPLOADING ||
     file.status === ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN;
   const isMalware = file.status === ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED;
-  const fileNameNode = (
+  const downloadHref = downloadEndpoint
+    ? `${downloadEndpoint}/${encodeURIComponent(file.id)}`
+    : null;
+  const canDownload = !isInProgress && !isMalware && Boolean(downloadHref);
+
+  const fileNameNode = canDownload ? (
+    <a
+      href={downloadHref}
+      download={file.name}
+      className="attachment-file-name-truncate"
+      title={file.name}
+      data-testid="attachment-download-link"
+    >
+      {file.name}
+    </a>
+  ) : (
     <span title={file.name} className="attachment-file-name-truncate">
       {file.name}
     </span>

--- a/app/assets/javascripts/attachments/AttachedFileRow.js
+++ b/app/assets/javascripts/attachments/AttachedFileRow.js
@@ -16,6 +16,7 @@ export const AttachedFileRow = ({
   const isInProgress =
     file.status === ATTACHMENT_STATUSES.UPLOADING ||
     file.status === ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN;
+  const isUploaded = file.status === ATTACHMENT_STATUSES.UPLOADED;
   const isMalware = file.status === ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED;
   const downloadHref = downloadEndpoint
     ? `${downloadEndpoint}/${encodeURIComponent(file.id)}`
@@ -33,7 +34,7 @@ export const AttachedFileRow = ({
       {file.name}
     </a>
   ) : (
-    <span title={file.name} className="attachment-file-name-truncate">
+    <span className="attachment-file-name-truncate">
       {file.name}
     </span>
   );
@@ -46,10 +47,12 @@ export const AttachedFileRow = ({
       {isConfirmingRemoval ? (
         <div className="p-4" role="alert">
           <p className="heading-small mt-0 mb-3">{copy.removeConfirmTitle}</p>
-          <p className="mb-3 mt-0">
-            {copy.removeConfirmBodyPrefix} '{fileNameNode}'{" "}
-            {copy.removeConfirmBodySuffix}
-          </p>
+          {isUploaded ? (
+            <p className="mb-3 mt-0">
+              {copy.removeConfirmBodyPrefix} '{fileNameNode}'{" "}
+              {copy.removeConfirmBodySuffix}
+            </p>
+          ) : null}
           <div className="flex gap-4 mt-6">
             <button
               type="button"

--- a/app/assets/javascripts/attachments/AttachmentsWidget.js
+++ b/app/assets/javascripts/attachments/AttachmentsWidget.js
@@ -48,24 +48,22 @@ export const AttachmentsWidget = ({
       return [];
     }
 
-    const payload = await response.json();
-    if (Array.isArray(payload)) {
-      return payload;
-    }
-
-    return payload.data || payload.files || [];
+    return response.json();
   };
 
   const deleteFile = async (file) => {
-    const response = await fetch(`${removeEndpoint}/${encodeURIComponent(file.id)}`, {
-      method: "POST",
-      credentials: "same-origin",
-      headers: csrfToken
-        ? {
-            "X-CSRFToken": csrfToken,
-          }
-        : undefined,
-    });
+    const response = await fetch(
+      `${removeEndpoint}/${encodeURIComponent(file.id)}`,
+      {
+        method: "POST",
+        credentials: "same-origin",
+        headers: csrfToken
+          ? {
+              "X-CSRFToken": csrfToken,
+            }
+          : undefined,
+      },
+    );
 
     if (!response.ok) {
       throw new Error(`Failed to remove attachment (${response.status})`);
@@ -102,7 +100,9 @@ export const AttachmentsWidget = ({
               isConfirmingRemoval={removeCandidateId === file.id}
               onRequestRemove={setRemoveCandidateId}
               onConfirmRemove={async (fileId) => {
-                const fileToRemove = files.find((currentFile) => currentFile.id === fileId);
+                const fileToRemove = files.find(
+                  (currentFile) => currentFile.id === fileId,
+                );
                 if (!fileToRemove) {
                   setRemoveCandidateId(null);
                   return;

--- a/app/assets/javascripts/attachments/AttachmentsWidget.js
+++ b/app/assets/javascripts/attachments/AttachmentsWidget.js
@@ -10,7 +10,9 @@ import { getAttachmentTranslations } from "./localization";
 
 export const AttachmentsWidget = ({
   initialFiles = [],
-  onAttachFiles,
+  attachEndpoint,
+  removeEndpoint,
+  csrfToken,
   lang = "en",
   classificationUrl,
 }) => {
@@ -20,6 +22,62 @@ export const AttachmentsWidget = ({
   const copy = useMemo(() => getAttachmentTranslations(lang), [lang]);
 
   const { files, attachFiles, removeFile } = useAttachments(initialFiles, copy);
+
+  const uploadFiles = async (selectedFiles) => {
+    const formData = new FormData();
+    selectedFiles.forEach((file) => {
+      formData.append("files", file, file.name);
+    });
+
+    const response = await fetch(attachEndpoint, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: csrfToken
+        ? {
+            "X-CSRFToken": csrfToken,
+          }
+        : undefined,
+      body: formData,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to upload attachments (${response.status})`);
+    }
+
+    if (!response.headers.get("content-type")?.includes("application/json")) {
+      return [];
+    }
+
+    const payload = await response.json();
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+
+    return payload.data || payload.files || [];
+  };
+
+  const deleteFile = async (file) => {
+    const response = await fetch(removeEndpoint, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/json",
+        ...(csrfToken
+          ? {
+              "X-CSRFToken": csrfToken,
+            }
+          : {}),
+      },
+      body: JSON.stringify({
+        fileId: file.id,
+        name: file.name,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to remove attachment (${response.status})`);
+    }
+  };
 
   const statusSummary = useMemo(
     () => summarizeStatuses(files, copy),
@@ -34,7 +92,7 @@ export const AttachmentsWidget = ({
       return;
     }
 
-    await attachFiles(result.acceptedFiles, onAttachFiles);
+    await attachFiles(result.acceptedFiles, uploadFiles);
     setAttachModalOpen(false);
   };
 
@@ -50,9 +108,21 @@ export const AttachmentsWidget = ({
               file={file}
               isConfirmingRemoval={removeCandidateId === file.id}
               onRequestRemove={setRemoveCandidateId}
-              onConfirmRemove={(fileId) => {
-                removeFile(fileId);
-                setRemoveCandidateId(null);
+              onConfirmRemove={async (fileId) => {
+                const fileToRemove = files.find((currentFile) => currentFile.id === fileId);
+                if (!fileToRemove) {
+                  setRemoveCandidateId(null);
+                  return;
+                }
+
+                try {
+                  await deleteFile(fileToRemove);
+                  removeFile(fileId);
+                } catch (error) {
+                  console.error(error);
+                } finally {
+                  setRemoveCandidateId(null);
+                }
               }}
               onCancelRemove={() => setRemoveCandidateId(null)}
               copy={copy}

--- a/app/assets/javascripts/attachments/AttachmentsWidget.js
+++ b/app/assets/javascripts/attachments/AttachmentsWidget.js
@@ -117,8 +117,14 @@ export const AttachmentsWidget = ({
       return;
     }
 
-    await attachFiles(result.acceptedFiles, uploadFiles);
-    setAttachModalOpen(false);
+    try {
+      await attachFiles(result.acceptedFiles, uploadFiles);
+      setAttachModalOpen(false);
+    } catch (error) {
+      setValidationIssues([
+        error.message || "Failed to attach files. Please try again.",
+      ]);
+    }
   };
 
   return (

--- a/app/assets/javascripts/attachments/AttachmentsWidget.js
+++ b/app/assets/javascripts/attachments/AttachmentsWidget.js
@@ -57,21 +57,14 @@ export const AttachmentsWidget = ({
   };
 
   const deleteFile = async (file) => {
-    const response = await fetch(removeEndpoint, {
+    const response = await fetch(`${removeEndpoint}/${encodeURIComponent(file.id)}`, {
       method: "POST",
       credentials: "same-origin",
-      headers: {
-        "Content-Type": "application/json",
-        ...(csrfToken
-          ? {
-              "X-CSRFToken": csrfToken,
-            }
-          : {}),
-      },
-      body: JSON.stringify({
-        fileId: file.id,
-        name: file.name,
-      }),
+      headers: csrfToken
+        ? {
+            "X-CSRFToken": csrfToken,
+          }
+        : undefined,
     });
 
     if (!response.ok) {

--- a/app/assets/javascripts/attachments/AttachmentsWidget.js
+++ b/app/assets/javascripts/attachments/AttachmentsWidget.js
@@ -12,6 +12,7 @@ export const AttachmentsWidget = ({
   initialFiles = [],
   attachEndpoint,
   removeEndpoint,
+  statusEndpoint,
   csrfToken,
   lang = "en",
   classificationUrl,
@@ -21,7 +22,39 @@ export const AttachmentsWidget = ({
   const [removeCandidateId, setRemoveCandidateId] = useState(null);
   const copy = useMemo(() => getAttachmentTranslations(lang), [lang]);
 
-  const { files, attachFiles, removeFile } = useAttachments(initialFiles, copy);
+  const fetchFileStatus = useMemo(() => {
+    if (!statusEndpoint) {
+      return null;
+    }
+
+    return async (fileId) => {
+      const response = await fetch(
+        `${statusEndpoint}/${encodeURIComponent(fileId)}`,
+        {
+          method: "GET",
+          credentials: "same-origin",
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch attachment status (${response.status})`,
+        );
+      }
+
+      if (!response.headers.get("content-type")?.includes("application/json")) {
+        return null;
+      }
+
+      return response.json();
+    };
+  }, [statusEndpoint]);
+
+  const { files, attachFiles, removeFile } = useAttachments(
+    initialFiles,
+    copy,
+    fetchFileStatus,
+  );
 
   const uploadFiles = async (selectedFiles) => {
     const formData = new FormData();

--- a/app/assets/javascripts/attachments/AttachmentsWidget.js
+++ b/app/assets/javascripts/attachments/AttachmentsWidget.js
@@ -13,6 +13,7 @@ export const AttachmentsWidget = ({
   attachEndpoint,
   removeEndpoint,
   statusEndpoint,
+  downloadEndpoint,
   csrfToken,
   lang = "en",
   classificationUrl,
@@ -151,6 +152,7 @@ export const AttachmentsWidget = ({
                 }
               }}
               onCancelRemove={() => setRemoveCandidateId(null)}
+              downloadEndpoint={downloadEndpoint}
               copy={copy}
             />
           ))}

--- a/app/assets/javascripts/attachments/attachments.js
+++ b/app/assets/javascripts/attachments/attachments.js
@@ -9,13 +9,6 @@ export const load = function (element, props = {}) {
     resolvedProps.lang = window.APP_LANG || "en";
   }
 
-  if (typeof resolvedProps.onAttachFilesHandler === "string") {
-    const handler = window[resolvedProps.onAttachFilesHandler];
-    if (typeof handler === "function") {
-      resolvedProps.onAttachFiles = handler;
-    }
-  }
-
   const root = createRoot(element);
   root.render(<AttachmentsWidget {...resolvedProps} />);
 };

--- a/app/assets/javascripts/attachments/useAttachments.js
+++ b/app/assets/javascripts/attachments/useAttachments.js
@@ -308,7 +308,7 @@ export const useAttachments = (
 
       setFiles((currentFiles) => [...currentFiles, ...uploadedFiles]);
     } catch (error) {
-      return;
+      throw new Error("Failed to attach files. Please try again.");
     }
   };
 

--- a/app/assets/javascripts/attachments/useAttachments.js
+++ b/app/assets/javascripts/attachments/useAttachments.js
@@ -27,8 +27,9 @@ export const ATTACHMENT_STATUSES = {
   UPLOADED: "uploaded",
   VIRUS_SCAN_FAILED: "virus_scan_failed",
   DELETED: "deleted",
-  UPLOAD_FAILED: "upload-failed",
 };
+
+const VALID_ATTACHMENT_STATUSES = new Set(Object.values(ATTACHMENT_STATUSES));
 
 const FILE_STATUS_POLL_INTERVAL_MS = 2000;
 
@@ -100,36 +101,12 @@ const nextId = () => {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 };
 
-const normalizeStatus = (status) => {
-  if (status === "pending_virus_scan") {
-    return ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN;
-  }
-
-  if (status === "virus_scan_failed") {
-    return ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED;
-  }
-
-  if (status === "uploaded") {
-    return ATTACHMENT_STATUSES.UPLOADED;
-  }
-
-  if (
-    status === ATTACHMENT_STATUSES.UPLOADING ||
-    status === ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN ||
-    status === ATTACHMENT_STATUSES.UPLOADED ||
-    status === ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED ||
-    status === ATTACHMENT_STATUSES.DELETED ||
-    status === ATTACHMENT_STATUSES.UPLOAD_FAILED
-  ) {
-    return status;
-  }
-
-  return ATTACHMENT_STATUSES.UPLOADED;
-};
+const parseApiStatus = (status, fallbackStatus) =>
+  VALID_ATTACHMENT_STATUSES.has(status) ? status : fallbackStatus;
 
 const normalizeFile = (file) => ({
   ...file,
-  status: normalizeStatus(file.status),
+  status: parseApiStatus(file.status, ATTACHMENT_STATUSES.DELETED),
 });
 
 export const summarizeStatuses = (files, copy = DEFAULT_COPY) => {
@@ -224,7 +201,10 @@ export const useAttachments = (
         try {
           const response = await fetchFileStatus(file.id);
           const responseData = response?.data || response;
-          const nextStatus = normalizeStatus(responseData?.status);
+          const nextStatus = parseApiStatus(
+            responseData?.status,
+            ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
+          );
 
           if (nextStatus === ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN) {
             const timeoutId = setTimeout(poll, FILE_STATUS_POLL_INTERVAL_MS);
@@ -239,8 +219,8 @@ export const useAttachments = (
                 ? {
                     ...currentFile,
                     id:
-                      responseData?.document_id ||
                       responseData?.id ||
+                      responseData?.document_id ||
                       currentFile.id,
                     status: nextStatus,
                     sourceFile: undefined,
@@ -317,18 +297,24 @@ export const useAttachments = (
         callbackResult = await onAttachFiles(selectedFiles);
       }
 
+      const callbackItems = Array.isArray(callbackResult) ? callbackResult : [];
+
       const resultById = new Map();
-      if (Array.isArray(callbackResult)) {
-        callbackResult.forEach((item, index) => {
+      if (callbackItems.length) {
+        callbackItems.forEach((item, index) => {
           const preparedFile = prepared[index];
           if (!preparedFile) {
             return;
           }
 
-          const status = normalizeStatus(item?.status);
+          const itemData = item?.data || item;
+          const status = parseApiStatus(
+            itemData?.status,
+            ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
+          );
 
           resultById.set(preparedFile.id, {
-            id: item.document_id,
+            id: itemData?.id || itemData?.document_id,
             status,
           });
         });
@@ -341,7 +327,7 @@ export const useAttachments = (
 
         resultById.set(preparedFile.id, {
           id: preparedFile.id,
-          status: ATTACHMENT_STATUSES.UPLOADED,
+          status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
         });
       });
 
@@ -354,7 +340,7 @@ export const useAttachments = (
 
             const resolvedResult = resultById.get(currentFile.id) || {
               id: currentFile.id,
-              status: ATTACHMENT_STATUSES.UPLOADED,
+              status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
             };
 
             return {
@@ -373,7 +359,7 @@ export const useAttachments = (
             preparedIds.has(currentFile.id)
               ? {
                   ...currentFile,
-                  status: ATTACHMENT_STATUSES.UPLOAD_FAILED,
+                  status: ATTACHMENT_STATUSES.DELETED,
                   sourceFile: undefined,
                 }
               : currentFile,

--- a/app/assets/javascripts/attachments/useAttachments.js
+++ b/app/assets/javascripts/attachments/useAttachments.js
@@ -290,7 +290,8 @@ export const useAttachments = (
 
           return {
             id: fileId,
-            name: sourceFile?.name || itemData?.name || `attachment-${nextId()}`,
+            name:
+              sourceFile?.name || itemData?.name || `attachment-${nextId()}`,
             size: sourceFile?.size || itemData?.file_size || 0,
             status: parseApiStatus(
               itemData?.status,

--- a/app/assets/javascripts/attachments/useAttachments.js
+++ b/app/assets/javascripts/attachments/useAttachments.js
@@ -155,7 +155,6 @@ export const summarizeStatuses = (files, copy = DEFAULT_COPY) => {
 export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
   const [files, setFiles] = useState(initialFiles);
   const timeoutIdsRef = useRef([]);
-  const objectUrlsRef = useRef(new Set());
   const isMountedRef = useRef(true);
 
   useEffect(() => {
@@ -163,35 +162,8 @@ export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
       isMountedRef.current = false;
       timeoutIdsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
       timeoutIdsRef.current = [];
-      objectUrlsRef.current.forEach((url) => {
-        if (typeof URL !== "undefined" && URL.revokeObjectURL) {
-          URL.revokeObjectURL(url);
-        }
-      });
-      objectUrlsRef.current.clear();
     };
   }, []);
-
-  const resolveDownloadInfo = (resultItem, sourceFile) => {
-    const providedDownloadUrl =
-      resultItem?.downloadUrl || resultItem?.download_url || resultItem?.url;
-
-    if (providedDownloadUrl) {
-      return { downloadUrl: providedDownloadUrl, isObjectUrl: false };
-    }
-
-    if (
-      sourceFile &&
-      typeof URL !== "undefined" &&
-      typeof URL.createObjectURL === "function"
-    ) {
-      const objectUrl = URL.createObjectURL(sourceFile);
-      objectUrlsRef.current.add(objectUrl);
-      return { downloadUrl: objectUrl, isObjectUrl: true };
-    }
-
-    return { downloadUrl: undefined, isObjectUrl: false };
-  };
 
   const schedule = (callback, delay) => {
     const timeoutId = setTimeout(() => {
@@ -261,14 +233,10 @@ export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
           }
 
           const status = normalizeStatus(item?.status);
-          const downloadInfo =
-            status === ATTACHMENT_STATUSES.ATTACHED
-              ? resolveDownloadInfo(item, preparedFile.sourceFile)
-              : { downloadUrl: undefined, isObjectUrl: false };
 
           resultById.set(preparedFile.id, {
+            id: item.id,
             status,
-            ...downloadInfo,
           });
         });
       }
@@ -278,10 +246,9 @@ export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
           return;
         }
 
-        const downloadInfo = resolveDownloadInfo(null, preparedFile.sourceFile);
         resultById.set(preparedFile.id, {
+          id: preparedFile.id,
           status: ATTACHMENT_STATUSES.ATTACHED,
-          ...downloadInfo,
         });
       });
 
@@ -293,17 +260,14 @@ export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
             }
 
             const resolvedResult = resultById.get(currentFile.id) || {
+              id: currentFile.id,
               status: ATTACHMENT_STATUSES.ATTACHED,
-              downloadUrl: undefined,
-              isObjectUrl: false,
             };
 
             return {
               ...currentFile,
+              id: resolvedResult.id || currentFile.id,
               status: resolvedResult.status,
-              downloadUrl:
-                resolvedResult.downloadUrl || currentFile.downloadUrl,
-              isObjectUrl: resolvedResult.isObjectUrl,
               sourceFile: undefined,
             };
           }),
@@ -328,18 +292,6 @@ export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
 
   const removeFile = (fileId) => {
     setFiles((currentFiles) => {
-      const fileToRemove = currentFiles.find((file) => file.id === fileId);
-
-      if (
-        fileToRemove?.isObjectUrl &&
-        fileToRemove.downloadUrl &&
-        typeof URL !== "undefined" &&
-        URL.revokeObjectURL
-      ) {
-        URL.revokeObjectURL(fileToRemove.downloadUrl);
-        objectUrlsRef.current.delete(fileToRemove.downloadUrl);
-      }
-
       return currentFiles.filter((file) => file.id !== fileId);
     });
   };

--- a/app/assets/javascripts/attachments/useAttachments.js
+++ b/app/assets/javascripts/attachments/useAttachments.js
@@ -218,10 +218,6 @@ export const useAttachments = (
               currentFile.id === file.id
                 ? {
                     ...currentFile,
-                    id:
-                      responseData?.id ||
-                      responseData?.document_id ||
-                      currentFile.id,
                     status: nextStatus,
                     sourceFile: undefined,
                   }
@@ -264,31 +260,9 @@ export const useAttachments = (
   );
 
   const attachFiles = async (selectedFiles, onAttachFiles) => {
-    const prepared = selectedFiles.map((file) => ({
-      id: nextId(),
-      name: file.name,
-      size: file.size,
-      status: ATTACHMENT_STATUSES.UPLOADING,
-      sourceFile: file,
-    }));
-
-    if (!prepared.length) {
+    if (!selectedFiles.length) {
       return;
     }
-
-    setFiles((currentFiles) => [...currentFiles, ...prepared]);
-
-    const preparedIds = new Set(prepared.map((file) => file.id));
-
-    schedule(() => {
-      setFiles((currentFiles) =>
-        currentFiles.map((currentFile) =>
-          preparedIds.has(currentFile.id)
-            ? { ...currentFile, status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN }
-            : currentFile,
-        ),
-      );
-    }, 500);
 
     try {
       let callbackResult = null;
@@ -299,73 +273,41 @@ export const useAttachments = (
 
       const callbackItems = Array.isArray(callbackResult) ? callbackResult : [];
 
-      const resultById = new Map();
-      if (callbackItems.length) {
-        callbackItems.forEach((item, index) => {
-          const preparedFile = prepared[index];
-          if (!preparedFile) {
-            return;
-          }
-
-          const itemData = item?.data || item;
-          const status = parseApiStatus(
-            itemData?.status,
-            ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
-          );
-
-          resultById.set(preparedFile.id, {
-            id: itemData?.id || itemData?.document_id,
-            status,
-          });
-        });
+      if (!callbackItems.length) {
+        return;
       }
 
-      prepared.forEach((preparedFile) => {
-        if (resultById.has(preparedFile.id)) {
-          return;
-        }
+      const uploadedFiles = callbackItems
+        .map((item, index) => {
+          const itemData = item?.data || item;
+          const fileId = itemData?.id;
 
-        resultById.set(preparedFile.id, {
-          id: preparedFile.id,
-          status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
-        });
-      });
+          if (!fileId) {
+            return null;
+          }
 
-      schedule(() => {
-        setFiles((currentFiles) =>
-          currentFiles.map((currentFile) => {
-            if (!preparedIds.has(currentFile.id)) {
-              return currentFile;
-            }
+          const sourceFile = selectedFiles[index];
 
-            const resolvedResult = resultById.get(currentFile.id) || {
-              id: currentFile.id,
-              status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
-            };
+          return {
+            id: fileId,
+            name: sourceFile?.name || itemData?.name || `attachment-${nextId()}`,
+            size: sourceFile?.size || itemData?.file_size || 0,
+            status: parseApiStatus(
+              itemData?.status,
+              ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
+            ),
+            sourceFile: undefined,
+          };
+        })
+        .filter(Boolean);
 
-            return {
-              ...currentFile,
-              id: resolvedResult.id || currentFile.id,
-              status: resolvedResult.status,
-              sourceFile: undefined,
-            };
-          }),
-        );
-      }, 1800);
+      if (!uploadedFiles.length) {
+        return;
+      }
+
+      setFiles((currentFiles) => [...currentFiles, ...uploadedFiles]);
     } catch (error) {
-      schedule(() => {
-        setFiles((currentFiles) =>
-          currentFiles.map((currentFile) =>
-            preparedIds.has(currentFile.id)
-              ? {
-                  ...currentFile,
-                  status: ATTACHMENT_STATUSES.DELETED,
-                  sourceFile: undefined,
-                }
-              : currentFile,
-          ),
-        );
-      }, 1800);
+      return;
     }
   };
 

--- a/app/assets/javascripts/attachments/useAttachments.js
+++ b/app/assets/javascripts/attachments/useAttachments.js
@@ -23,11 +23,14 @@ export const ACCEPT_ATTRIBUTE = ACCEPTED_EXTENSIONS.join(",");
 
 export const ATTACHMENT_STATUSES = {
   UPLOADING: "uploading",
-  PENDING_SCAN: "pending-scan",
-  ATTACHED: "attached",
-  MALWARE: "malware",
+  PENDING_VIRUS_SCAN: "pending_virus_scan",
+  UPLOADED: "uploaded",
+  VIRUS_SCAN_FAILED: "virus_scan_failed",
+  DELETED: "deleted",
   UPLOAD_FAILED: "upload-failed",
 };
+
+const FILE_STATUS_POLL_INTERVAL_MS = 2000;
 
 const ALLOWED_EXTENSIONS = new Set(ACCEPTED_EXTENSIONS);
 
@@ -98,18 +101,36 @@ const nextId = () => {
 };
 
 const normalizeStatus = (status) => {
+  if (status === "pending_virus_scan") {
+    return ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN;
+  }
+
+  if (status === "virus_scan_failed") {
+    return ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED;
+  }
+
+  if (status === "uploaded") {
+    return ATTACHMENT_STATUSES.UPLOADED;
+  }
+
   if (
     status === ATTACHMENT_STATUSES.UPLOADING ||
-    status === ATTACHMENT_STATUSES.PENDING_SCAN ||
-    status === ATTACHMENT_STATUSES.ATTACHED ||
-    status === ATTACHMENT_STATUSES.MALWARE ||
+    status === ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN ||
+    status === ATTACHMENT_STATUSES.UPLOADED ||
+    status === ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED ||
+    status === ATTACHMENT_STATUSES.DELETED ||
     status === ATTACHMENT_STATUSES.UPLOAD_FAILED
   ) {
     return status;
   }
 
-  return ATTACHMENT_STATUSES.ATTACHED;
+  return ATTACHMENT_STATUSES.UPLOADED;
 };
+
+const normalizeFile = (file) => ({
+  ...file,
+  status: normalizeStatus(file.status),
+});
 
 export const summarizeStatuses = (files, copy = DEFAULT_COPY) => {
   const counts = {
@@ -120,11 +141,11 @@ export const summarizeStatuses = (files, copy = DEFAULT_COPY) => {
   };
 
   for (const file of files) {
-    if (file.status === ATTACHMENT_STATUSES.PENDING_SCAN) {
+    if (file.status === ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN) {
       counts.scanning += 1;
     } else if (file.status === ATTACHMENT_STATUSES.UPLOADING) {
       counts.uploading += 1;
-    } else if (file.status === ATTACHMENT_STATUSES.ATTACHED) {
+    } else if (file.status === ATTACHMENT_STATUSES.UPLOADED) {
       counts.attached += 1;
     } else {
       counts.failed += 1;
@@ -152,9 +173,14 @@ export const summarizeStatuses = (files, copy = DEFAULT_COPY) => {
   return chunks.length ? chunks.join(", ") : copy.noFilesAttached;
 };
 
-export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
-  const [files, setFiles] = useState(initialFiles);
+export const useAttachments = (
+  initialFiles = [],
+  copy = DEFAULT_COPY,
+  fetchFileStatus = null,
+) => {
+  const [files, setFiles] = useState(() => initialFiles.map(normalizeFile));
   const timeoutIdsRef = useRef([]);
+  const pollTimeoutIdsRef = useRef(new Map());
   const isMountedRef = useRef(true);
 
   useEffect(() => {
@@ -162,8 +188,75 @@ export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
       isMountedRef.current = false;
       timeoutIdsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
       timeoutIdsRef.current = [];
+      pollTimeoutIdsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
+      pollTimeoutIdsRef.current.clear();
     };
   }, []);
+
+  useEffect(() => {
+    if (typeof fetchFileStatus !== "function") {
+      return;
+    }
+
+    const pendingFiles = files.filter(
+      (file) => file.status === ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
+    );
+
+    const pendingIds = new Set(pendingFiles.map((file) => file.id));
+
+    pollTimeoutIdsRef.current.forEach((timeoutId, fileId) => {
+      if (!pendingIds.has(fileId)) {
+        clearTimeout(timeoutId);
+        pollTimeoutIdsRef.current.delete(fileId);
+      }
+    });
+
+    pendingFiles.forEach((file) => {
+      if (pollTimeoutIdsRef.current.has(file.id)) {
+        return;
+      }
+
+      const poll = async () => {
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        try {
+          const response = await fetchFileStatus(file.id);
+          const responseData = response?.data || response;
+          const nextStatus = normalizeStatus(responseData?.status);
+
+          if (nextStatus === ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN) {
+            const timeoutId = setTimeout(poll, FILE_STATUS_POLL_INTERVAL_MS);
+            pollTimeoutIdsRef.current.set(file.id, timeoutId);
+            return;
+          }
+
+          pollTimeoutIdsRef.current.delete(file.id);
+          setFiles((currentFiles) =>
+            currentFiles.map((currentFile) =>
+              currentFile.id === file.id
+                ? {
+                    ...currentFile,
+                    id:
+                      responseData?.document_id ||
+                      responseData?.id ||
+                      currentFile.id,
+                    status: nextStatus,
+                    sourceFile: undefined,
+                  }
+                : currentFile,
+            ),
+          );
+        } catch (error) {
+          const timeoutId = setTimeout(poll, FILE_STATUS_POLL_INTERVAL_MS);
+          pollTimeoutIdsRef.current.set(file.id, timeoutId);
+        }
+      };
+
+      poll();
+    });
+  }, [files, fetchFileStatus]);
 
   const schedule = (callback, delay) => {
     const timeoutId = setTimeout(() => {
@@ -185,7 +278,7 @@ export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
       files.filter(
         (file) =>
           file.status === ATTACHMENT_STATUSES.UPLOADING ||
-          file.status === ATTACHMENT_STATUSES.PENDING_SCAN,
+          file.status === ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
       ).length,
     [files],
   );
@@ -211,7 +304,7 @@ export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
       setFiles((currentFiles) =>
         currentFiles.map((currentFile) =>
           preparedIds.has(currentFile.id)
-            ? { ...currentFile, status: ATTACHMENT_STATUSES.PENDING_SCAN }
+            ? { ...currentFile, status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN }
             : currentFile,
         ),
       );
@@ -248,7 +341,7 @@ export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
 
         resultById.set(preparedFile.id, {
           id: preparedFile.id,
-          status: ATTACHMENT_STATUSES.ATTACHED,
+          status: ATTACHMENT_STATUSES.UPLOADED,
         });
       });
 
@@ -261,7 +354,7 @@ export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
 
             const resolvedResult = resultById.get(currentFile.id) || {
               id: currentFile.id,
-              status: ATTACHMENT_STATUSES.ATTACHED,
+              status: ATTACHMENT_STATUSES.UPLOADED,
             };
 
             return {

--- a/app/assets/javascripts/attachments/useAttachments.js
+++ b/app/assets/javascripts/attachments/useAttachments.js
@@ -235,7 +235,7 @@ export const useAttachments = (initialFiles = [], copy = DEFAULT_COPY) => {
           const status = normalizeStatus(item?.status);
 
           resultById.set(preparedFile.id, {
-            id: item.id,
+            id: item.document_id,
             status,
           });
         });

--- a/app/config.py
+++ b/app/config.py
@@ -92,7 +92,7 @@ class Config(object):
     FF_CARETAKER = env.bool("FF_CARETAKER", False)
     FF_USE_BILLABLE_UNITS = env.bool("FF_USE_BILLABLE_UNITS", False)
     FF_ADD_TEMPLATE_PERM = env.bool("FF_ADD_TEMPLATE_PERM", False)
-    FF_FILE_ATTACHMENTS = env.bool("FF_FIL_ATTACHMENTS", False)
+    FF_FILE_ATTACHMENTS = env.bool("FF_FILE_ATTACHMENTS", False)
 
     FREE_YEARLY_EMAIL_LIMIT = env.int("FREE_YEARLY_EMAIL_LIMIT", 20_000_000)
     FREE_YEARLY_SMS_LIMIT = env.int("FREE_YEARLY_SMS_LIMIT", 100_000)
@@ -261,6 +261,7 @@ class ProductionFF(Config):
     NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
     GC_ORGANISATIONS_BUCKET_NAME = "dev-gc-organisations"
     FF_USE_BILLABLE_UNITS = False
+    FF_FILE_ATTACHMENTS = True
 
 
 class Production(Config):
@@ -270,7 +271,6 @@ class Production(Config):
     NOTIFY_LOG_LEVEL = "INFO"
     SYSTEM_STATUS_URL = "https://status.notification.canada.ca"
     NO_BRANDING_ID = "760c802a-7762-4f71-b19e-f93c66c92f1a"
-    FF_FILE_ATTACHMENTS = False
 
 
 class Staging(Production):
@@ -279,7 +279,6 @@ class Staging(Production):
     NOTIFY_LOG_LEVEL = "INFO"
     SYSTEM_STATUS_URL = "https://status.staging.notification.cdssandbox.xyz"
     NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
-    FF_FILE_ATTACHMENTS = True
 
 
 class Scratch(Production):

--- a/app/config.py
+++ b/app/config.py
@@ -92,6 +92,7 @@ class Config(object):
     FF_CARETAKER = env.bool("FF_CARETAKER", False)
     FF_USE_BILLABLE_UNITS = env.bool("FF_USE_BILLABLE_UNITS", False)
     FF_ADD_TEMPLATE_PERM = env.bool("FF_ADD_TEMPLATE_PERM", False)
+    FF_FILE_ATTACHMENTS = env.bool("FF_FIL_ATTACHMENTS", False)
 
     FREE_YEARLY_EMAIL_LIMIT = env.int("FREE_YEARLY_EMAIL_LIMIT", 20_000_000)
     FREE_YEARLY_SMS_LIMIT = env.int("FREE_YEARLY_SMS_LIMIT", 100_000)
@@ -201,6 +202,7 @@ class Development(Config):
     VITE_HMR_ENABLED = env.bool("VITE_HMR_ENABLED", True)
     DEBUG_KEY = "debug"
     FF_ADD_TEMPLATE_PERM = True
+    FF_FILE_ATTACHMENTS = True
     MOU_BUCKET_NAME = "notify.tools-mou"
     ONE_CLICK_UNSUB_ALL_SERVICES = True
     REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
@@ -268,6 +270,7 @@ class Production(Config):
     NOTIFY_LOG_LEVEL = "INFO"
     SYSTEM_STATUS_URL = "https://status.notification.canada.ca"
     NO_BRANDING_ID = "760c802a-7762-4f71-b19e-f93c66c92f1a"
+    FF_FILE_ATTACHMENTS = False
 
 
 class Staging(Production):
@@ -276,6 +279,7 @@ class Staging(Production):
     NOTIFY_LOG_LEVEL = "INFO"
     SYSTEM_STATUS_URL = "https://status.staging.notification.cdssandbox.xyz"
     NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
+    FF_FILE_ATTACHMENTS = True
 
 
 class Scratch(Production):

--- a/app/main/views/storybook.py
+++ b/app/main/views/storybook.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
 
-from flask import render_template, request
+from flask import jsonify, render_template, request
 from flask_wtf import FlaskForm as Form
 from wtforms import BooleanField, RadioField, StringField
 from wtforms.validators import DataRequired
@@ -143,3 +143,13 @@ def storybook():
         full_form=full_form,
         complex_markdown=complex_markdown,
     )
+
+
+@main.route("/_storybook/attachments/attach", methods=["POST"])
+def storybook_attachments_attach():
+    return jsonify({"data": []})
+
+
+@main.route("/_storybook/attachments/remove", methods=["POST"])
+def storybook_attachments_remove():
+    return ("", 204)

--- a/app/main/views/storybook.py
+++ b/app/main/views/storybook.py
@@ -147,8 +147,7 @@ def storybook():
 
 @main.route("/_storybook/attachments/attach", methods=["POST"])
 def storybook_attachments_attach():
-    return jsonify({"data": []})
-
+    return jsonify([])
 
 @main.route("/_storybook/attachments/remove", methods=["POST"])
 @main.route("/_storybook/attachments/remove/<file_id>", methods=["POST"])

--- a/app/main/views/storybook.py
+++ b/app/main/views/storybook.py
@@ -151,5 +151,6 @@ def storybook_attachments_attach():
 
 
 @main.route("/_storybook/attachments/remove", methods=["POST"])
-def storybook_attachments_remove():
+@main.route("/_storybook/attachments/remove/<file_id>", methods=["POST"])
+def storybook_attachments_remove(file_id=None):
     return ("", 204)

--- a/app/main/views/storybook.py
+++ b/app/main/views/storybook.py
@@ -149,6 +149,7 @@ def storybook():
 def storybook_attachments_attach():
     return jsonify([])
 
+
 @main.route("/_storybook/attachments/remove", methods=["POST"])
 @main.route("/_storybook/attachments/remove/<file_id>", methods=["POST"])
 def storybook_attachments_remove(file_id=None):

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -5,6 +5,7 @@ from string import ascii_uppercase
 
 from dateutil.parser import parse
 from flask import (
+    Response,
     abort,
     current_app,
     flash,
@@ -278,6 +279,30 @@ def remove_files(service_id, template_id, file_id=None):
 def template_attachment_status(service_id, template_id, file_id=None):
     file_id = file_id or request.args.get("file_id")
     return jsonify(file_api_client.get_file_status(template_id, file_id))
+
+
+@main.route(
+    "/services/<service_id>/templates/<uuid:template_id>/attachments/download",
+    methods=["GET"],
+)
+@main.route(
+    "/services/<service_id>/templates/<uuid:template_id>/attachments/download/<file_id>",
+    methods=["GET"],
+)
+@user_has_permissions()
+def download_template_attachment(service_id, template_id, file_id=None):
+    file_id = file_id or request.args.get("file_id")
+    if not file_id:
+        abort(400)
+
+    file_payload = file_api_client.get_file_contents(template_id, file_id)
+    file_name = file_payload["filename"]
+
+    return Response(
+        file_payload["content"],
+        mimetype=file_payload["mime_type"],
+        headers={"Content-Disposition": f'attachment; filename="{file_name}"'},
+    )
 
 
 @main.route("/services/<service_id>/templates/<uuid:template_id>/preview", methods=["GET", "POST"])

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -228,13 +228,16 @@ def view_template(service_id, template_id):
     )
 
 
-# TODO: hook these up to the API client when its available
+# Template attachment endpoints (gated by FF_FILE_ATTACHMENTS)
 @main.route(
     "/services/<service_id>/templates/<uuid:template_id>/attachments",
     methods=["POST"],
 )
 @user_has_permissions("manage_templates")
 def attach_files(service_id, template_id):
+    if not current_app.config.get("FF_FILE_ATTACHMENTS") or not current_service.has_permission("upload_document"):
+        abort(404)
+
     uploaded_files = request.files.getlist("files")
     created_files = []
 
@@ -267,6 +270,12 @@ def attach_files(service_id, template_id):
 )
 @user_has_permissions("manage_templates")
 def remove_files(service_id, template_id, file_id=None):
+    if not current_app.config.get("FF_FILE_ATTACHMENTS"):
+        abort(404)
+
+    if not file_id:
+        abort(400)
+
     file_api_client.delete_file(template_id, file_id)
     return ("", 204)
 
@@ -281,7 +290,13 @@ def remove_files(service_id, template_id, file_id=None):
 )
 @user_has_permissions("manage_templates")
 def template_attachment_status(service_id, template_id, file_id=None):
+    if not current_app.config.get("FF_FILE_ATTACHMENTS"):
+        abort(404)
+
     file_id = file_id or request.args.get("file_id")
+    if not file_id:
+        abort(400)
+
     return jsonify(file_api_client.get_file_status(template_id, file_id))
 
 
@@ -295,13 +310,17 @@ def template_attachment_status(service_id, template_id, file_id=None):
 )
 @user_has_permissions("manage_templates")
 def download_template_attachment(service_id, template_id, file_id=None):
+    if not current_app.config.get("FF_FILE_ATTACHMENTS"):
+        abort(404)
+
+    current_service.get_template_with_user_permission_or_403(template_id, current_user)
+
     file_id = file_id or request.args.get("file_id")
     if not file_id:
         abort(400)
 
     file_payload = file_api_client.get_file_contents(template_id, file_id)
     file_name = file_payload["filename"]
-
     return Response(
         file_payload["content"],
         mimetype=file_payload["mime_type"],

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -199,6 +199,10 @@ def view_template(service_id, template_id):
     delete_preview_data(service_id, template_id)
     template = current_service.get_template(template_id)
     template_folder = current_service.get_template_folder(template["folder"])
+    template_attachments = []
+
+    if template["template_type"] == "email":
+        template_attachments = current_service.get_template_attachments(template_id)
 
     user_has_template_permission = current_user.has_template_folder_permission(template_folder)
 
@@ -211,9 +215,33 @@ def view_template(service_id, template_id):
         "views/templates/template.html",
         template=preview_template,
         template_postage=template["postage"],
+        template_attachments=template_attachments,
         user_has_template_permission=user_has_template_permission,
         **get_limit_stats(template["template_type"], preview_template),
     )
+
+
+# TODO: hook these up to the API client when its available
+@main.route(
+    "/services/<service_id>/templates/<uuid:template_id>/attachments",
+    methods=["POST"],
+)
+@user_has_permissions()
+def attach_files(service_id, template_id):
+    return jsonify({"data": []})
+
+
+@main.route(
+    "/services/<service_id>/templates/<uuid:template_id>/attachments/remove",
+    methods=["POST"],
+)
+@main.route(
+    "/services/<service_id>/templates/<uuid:template_id>/attachments/remove/<file_id>",
+    methods=["POST"],
+)
+@user_has_permissions()
+def remove_files(service_id, template_id, file_id=None):
+    return ("", 204)
 
 
 @main.route("/services/<service_id>/templates/<uuid:template_id>/preview", methods=["GET", "POST"])

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from datetime import datetime, timedelta
 from string import ascii_uppercase
@@ -60,6 +61,7 @@ from app.models.template_list import (
     TemplateList,
     TemplateLists,
 )
+from app.notify_client.file_api_client import file_api_client
 from app.notify_client.notification_counts_client import notification_counts_client
 from app.sample_template_utils import create_temporary_sample_template, get_sample_templates, get_sample_templates_by_type
 from app.template_previews import TemplatePreview, get_page_count_for_letter
@@ -228,7 +230,26 @@ def view_template(service_id, template_id):
 )
 @user_has_permissions()
 def attach_files(service_id, template_id):
-    return jsonify({"data": []})
+    uploaded_files = request.files.getlist("files")
+    created_files = []
+
+    for uploaded_file in uploaded_files:
+        file_contents = uploaded_file.read()
+        file_size = len(file_contents)
+        file_data = base64.b64encode(file_contents).decode("ascii")
+
+        created_files.append(
+            file_api_client.create_file(
+                template_id,
+                "template_attach",
+                uploaded_file.filename,
+                uploaded_file.mimetype or "application/octet-stream",
+                file_size,
+                file_data,
+            )
+        )
+
+    return jsonify(created_files)
 
 
 @main.route(
@@ -241,6 +262,7 @@ def attach_files(service_id, template_id):
 )
 @user_has_permissions()
 def remove_files(service_id, template_id, file_id=None):
+    file_api_client.delete_file(template_id, file_id)
     return ("", 204)
 
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -204,7 +204,11 @@ def view_template(service_id, template_id):
     template_folder = current_service.get_template_folder(template["folder"])
     template_attachments = []
 
-    if template["template_type"] == "email":
+    if (
+        current_app.config.get("FF_FILE_ATTACHMENTS")
+        and template["template_type"] == "email"
+        and current_service.has_permission("upload_document")
+    ):
         template_attachments = current_service.get_template_attachments(template_id)
 
     user_has_template_permission = current_user.has_template_folder_permission(template_folder)
@@ -229,7 +233,7 @@ def view_template(service_id, template_id):
     "/services/<service_id>/templates/<uuid:template_id>/attachments",
     methods=["POST"],
 )
-@user_has_permissions()
+@user_has_permissions("manage_templates")
 def attach_files(service_id, template_id):
     uploaded_files = request.files.getlist("files")
     created_files = []
@@ -261,7 +265,7 @@ def attach_files(service_id, template_id):
     "/services/<service_id>/templates/<uuid:template_id>/attachments/remove/<file_id>",
     methods=["POST"],
 )
-@user_has_permissions()
+@user_has_permissions("manage_templates")
 def remove_files(service_id, template_id, file_id=None):
     file_api_client.delete_file(template_id, file_id)
     return ("", 204)
@@ -275,7 +279,7 @@ def remove_files(service_id, template_id, file_id=None):
     "/services/<service_id>/templates/<uuid:template_id>/attachments/status/<file_id>",
     methods=["GET"],
 )
-@user_has_permissions()
+@user_has_permissions("manage_templates")
 def template_attachment_status(service_id, template_id, file_id=None):
     file_id = file_id or request.args.get("file_id")
     return jsonify(file_api_client.get_file_status(template_id, file_id))
@@ -289,7 +293,7 @@ def template_attachment_status(service_id, template_id, file_id=None):
     "/services/<service_id>/templates/<uuid:template_id>/attachments/download/<file_id>",
     methods=["GET"],
 )
-@user_has_permissions()
+@user_has_permissions("manage_templates")
 def download_template_attachment(service_id, template_id, file_id=None):
     file_id = file_id or request.args.get("file_id")
     if not file_id:

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -266,6 +266,20 @@ def remove_files(service_id, template_id, file_id=None):
     return ("", 204)
 
 
+@main.route(
+    "/services/<service_id>/templates/<uuid:template_id>/attachments/status",
+    methods=["GET"],
+)
+@main.route(
+    "/services/<service_id>/templates/<uuid:template_id>/attachments/status/<file_id>",
+    methods=["GET"],
+)
+@user_has_permissions()
+def template_attachment_status(service_id, template_id, file_id=None):
+    file_id = file_id or request.args.get("file_id")
+    return jsonify(file_api_client.get_file_status(template_id, file_id))
+
+
 @main.route("/services/<service_id>/templates/<uuid:template_id>/preview", methods=["GET", "POST"])
 @main.route(
     "/services/<service_id>/templates/sample/<uuid:sample_template_id>/preview",

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -229,14 +229,18 @@ def view_template(service_id, template_id):
 
 
 # Template attachment endpoints (gated by FF_FILE_ATTACHMENTS)
+def _abort_if_attachments_disabled_for_service():
+    if not current_app.config.get("FF_FILE_ATTACHMENTS") or not current_service.has_permission("upload_document"):
+        abort(404)
+
+
 @main.route(
     "/services/<service_id>/templates/<uuid:template_id>/attachments",
     methods=["POST"],
 )
 @user_has_permissions("manage_templates")
 def attach_files(service_id, template_id):
-    if not current_app.config.get("FF_FILE_ATTACHMENTS") or not current_service.has_permission("upload_document"):
-        abort(404)
+    _abort_if_attachments_disabled_for_service()
 
     uploaded_files = request.files.getlist("files")
     created_files = []
@@ -270,8 +274,7 @@ def attach_files(service_id, template_id):
 )
 @user_has_permissions("manage_templates")
 def remove_files(service_id, template_id, file_id=None):
-    if not current_app.config.get("FF_FILE_ATTACHMENTS"):
-        abort(404)
+    _abort_if_attachments_disabled_for_service()
 
     if not file_id:
         abort(400)
@@ -290,8 +293,7 @@ def remove_files(service_id, template_id, file_id=None):
 )
 @user_has_permissions("manage_templates")
 def template_attachment_status(service_id, template_id, file_id=None):
-    if not current_app.config.get("FF_FILE_ATTACHMENTS"):
-        abort(404)
+    _abort_if_attachments_disabled_for_service()
 
     file_id = file_id or request.args.get("file_id")
     if not file_id:
@@ -310,8 +312,7 @@ def template_attachment_status(service_id, template_id, file_id=None):
 )
 @user_has_permissions("manage_templates")
 def download_template_attachment(service_id, template_id, file_id=None):
-    if not current_app.config.get("FF_FILE_ATTACHMENTS"):
-        abort(404)
+    _abort_if_attachments_disabled_for_service()
 
     current_service.get_template_with_user_permission_or_403(template_id, current_user)
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -190,6 +190,10 @@ class Service(JSONModel):
     def get_template(self, template_id, version=None):
         return service_api_client.get_service_template(self.id, str(template_id), version)["data"]
 
+    # TODO: complete this method when the backend API is available
+    def get_template_attachments(self, template_id):
+        return []
+
     def get_template_folder_with_user_permission_or_403(self, folder_id, user):
         template_folder = self.get_template_folder(folder_id)
 

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -12,6 +12,7 @@ from app.models.user import InvitedUsers, User, Users
 from app.notify_client.api_key_api_client import api_key_api_client
 from app.notify_client.billing_api_client import billing_api_client
 from app.notify_client.email_branding_client import email_branding_client
+from app.notify_client.file_api_client import file_api_client
 from app.notify_client.inbound_number_client import inbound_number_client
 from app.notify_client.invite_api_client import invite_api_client
 from app.notify_client.job_api_client import job_api_client
@@ -190,9 +191,8 @@ class Service(JSONModel):
     def get_template(self, template_id, version=None):
         return service_api_client.get_service_template(self.id, str(template_id), version)["data"]
 
-    # TODO: complete this method when the backend API is available
     def get_template_attachments(self, template_id):
-        return []
+        return file_api_client.get_files_by_template_id(str(template_id))
 
     def get_template_folder_with_user_permission_or_403(self, folder_id, user):
         template_folder = self.get_template_folder(folder_id)

--- a/app/notify_client/file_api_client.py
+++ b/app/notify_client/file_api_client.py
@@ -1,3 +1,5 @@
+from flask_login import current_user
+
 from app.notify_client import NotifyAdminAPIClient
 
 
@@ -10,6 +12,7 @@ class FileApiClient(NotifyAdminAPIClient):
             "mime_type": mime_type,
             "file_size": file_size,
             "file_data": file_data,
+            "created_by": current_user.id,
         }
         return self.post(f"/templates/{template_id}/files", data)
 

--- a/app/notify_client/file_api_client.py
+++ b/app/notify_client/file_api_client.py
@@ -1,0 +1,29 @@
+from app.notify_client import NotifyAdminAPIClient
+
+
+class FileApiClient(NotifyAdminAPIClient):
+    def create_file(self, template_id, type_, name, mime_type, file_size, file_data):
+        data = {
+            "template_id": str(template_id),
+            "type": type_,
+            "name": name,
+            "mime_type": mime_type,
+            "file_size": file_size,
+            "file_data": file_data,
+        }
+        return self.post(f"/templates/{template_id}/files", data)
+
+    def get_files_by_template_id(self, template_id):
+        return self.get(f"/templates/{template_id}/files")
+
+    def get_file_status(self, template_id, file_id):
+        return self.get(f"/templates/{template_id}/files/{file_id}/status")
+
+    def delete_file(self, template_id, file_id):
+        return self.delete(f"/templates/{template_id}/files/{file_id}", {})
+
+    def update_file_status(self, template_id, file_id, status):
+        return self.post(f"/templates/{template_id}/files/{file_id}/status", {"status": status})
+
+
+file_api_client = FileApiClient()

--- a/app/notify_client/file_api_client.py
+++ b/app/notify_client/file_api_client.py
@@ -19,6 +19,17 @@ class FileApiClient(NotifyAdminAPIClient):
     def get_file_status(self, template_id, file_id):
         return self.get(f"/templates/{template_id}/files/{file_id}/status")
 
+    def get_file_contents(self, template_id, file_id):
+        # TODO: Call the API download endpoint when backend support is available.
+        # For now, return a predictable example file payload for the UI flow.
+        return {
+            "filename": f"example-{file_id}.txt",
+            "mime_type": "text/plain",
+            "content": (
+                f"Example file contents for template {template_id}, file {file_id}.\n" "Backend download integration is pending."
+            ).encode("utf-8"),
+        }
+
     def delete_file(self, template_id, file_id):
         return self.delete(f"/templates/{template_id}/files/{file_id}", {})
 

--- a/app/templates/components/attachments.html
+++ b/app/templates/components/attachments.html
@@ -1,23 +1,20 @@
-{% macro attachments_widget(mount_id, props={}, lang=None) %}
+{% macro attachments_widget(mount_id, initialFiles=None, classificationUrl=None, attachEndpoint=None, removeEndpoint=None, lang=None) %}
   <div id="{{ mount_id }}"></div>
   <script nonce="{{ request_nonce }}">
     (function () {
-      var element = document.getElementById("{{ mount_id }}");
+      var element = document.getElementById({{ mount_id | tojson }});
       if (!element) {
         return;
       }
 
-      var props = Object.assign(
-        {
-          lang: {{ (lang or current_lang) | tojson }}
-        },
-        {{ props | tojson }}
-      );
-      function boot() {
-        if (window.Attachments) {
-          window.Attachments.load(element, props);
-        }
-      }
+      var props = {
+        initialFiles: {{ (initialFiles or []) | tojson }},
+        classificationUrl: {{ (classificationUrl or '#') | tojson }},
+        attachEndpoint: {{ attachEndpoint | tojson }},
+        removeEndpoint: {{ removeEndpoint | tojson }},
+        csrfToken: {{ csrf_token() | tojson }},
+        lang: {{ (lang or current_lang) | tojson }},
+      };
 
       if (!window.attachmentsLoadPromise) {
         window.attachmentsLoadPromise = new Promise(function (resolve, reject) {
@@ -54,7 +51,11 @@
         });
       }
 
-      window.attachmentsLoadPromise.then(boot).catch(function () {});
+      window.attachmentsLoadPromise.then(function () {
+        if (window.Attachments) {
+          window.Attachments.load(element, props);
+        }
+      }).catch(function () {});
     })();
   </script>
 {% endmacro %}

--- a/app/templates/components/attachments.html
+++ b/app/templates/components/attachments.html
@@ -1,4 +1,4 @@
-{% macro attachments_widget(mount_id, initialFiles=None, classificationUrl=None, attachEndpoint=None, removeEndpoint=None, lang=None) %}
+{% macro attachments_widget(mount_id, initialFiles=None, classificationUrl=None, attachEndpoint=None, removeEndpoint=None, statusEndpoint=None, lang=None) %}
   <div id="{{ mount_id }}"></div>
   <script nonce="{{ request_nonce }}">
     (function () {
@@ -12,6 +12,7 @@
         classificationUrl: {{ (classificationUrl or '#') | tojson }},
         attachEndpoint: {{ attachEndpoint | tojson }},
         removeEndpoint: {{ removeEndpoint | tojson }},
+        statusEndpoint: {{ statusEndpoint | tojson }},
         csrfToken: {{ csrf_token() | tojson }},
         lang: {{ (lang or current_lang) | tojson }},
       };

--- a/app/templates/components/attachments.html
+++ b/app/templates/components/attachments.html
@@ -1,4 +1,4 @@
-{% macro attachments_widget(mount_id, initialFiles=None, classificationUrl=None, attachEndpoint=None, removeEndpoint=None, statusEndpoint=None, lang=None) %}
+{% macro attachments_widget(mount_id, initialFiles=None, classificationUrl=None, attachEndpoint=None, removeEndpoint=None, statusEndpoint=None, downloadEndpoint=None, lang=None) %}
   <div id="{{ mount_id }}"></div>
   <script nonce="{{ request_nonce }}">
     (function () {
@@ -13,6 +13,7 @@
         attachEndpoint: {{ attachEndpoint | tojson }},
         removeEndpoint: {{ removeEndpoint | tojson }},
         statusEndpoint: {{ statusEndpoint | tojson }},
+        downloadEndpoint: {{ downloadEndpoint | tojson }},
         csrfToken: {{ csrf_token() | tojson }},
         lang: {{ (lang or current_lang) | tojson }},
       };

--- a/app/templates/views/storybook/attachments.html
+++ b/app/templates/views/storybook/attachments.html
@@ -37,7 +37,7 @@
             "id": "storybook-progress-2",
             "name": "Sometimes_you_need_a_very_very_very_very_long_file_name_final_v1_final_final_3_hello.pdf",
             "size": 170000,
-            "status": "attached",
+            "status": "uploaded",
             "downloadUrl": "/storybook/downloads/Sometimes_you_need_a_very_very_very_very_long_file_name_final_v1_final_final_3_hello.pdf"
           }
         ],
@@ -66,7 +66,7 @@
             "id": "storybook-malware-2",
             "name": "safe_permit.pdf",
             "size": 260000,
-            "status": "attached",
+            "status": "uploaded",
             "downloadUrl": "/storybook/downloads/safe_permit.pdf"
           }
         ],
@@ -90,7 +90,7 @@
             "id": "storybook-interactive-1",
             "name": "already_attached_notice.pdf",
             "size": 220000,
-            "status": "attached",
+            "status": "uploaded",
             "downloadUrl": "/storybook/downloads/already_attached_notice.pdf"
           }
         ],

--- a/app/templates/views/storybook/attachments.html
+++ b/app/templates/views/storybook/attachments.html
@@ -15,6 +15,8 @@
         url_for("main.terms"),
         url_for("main.storybook_attachments_attach"),
         url_for("main.storybook_attachments_remove"),
+        none,
+        none,
         lang=current_lang
       )
     }}
@@ -31,19 +33,20 @@
             "id": "storybook-progress-1",
             "name": "Filename.pdf",
             "size": 320000,
-            "status": "pending-scan"
+            "status": "pending_virus_scan"
           },
           {
             "id": "storybook-progress-2",
             "name": "Sometimes_you_need_a_very_very_very_very_long_file_name_final_v1_final_final_3_hello.pdf",
             "size": 170000,
-            "status": "uploaded",
-            "downloadUrl": "/storybook/downloads/Sometimes_you_need_a_very_very_very_very_long_file_name_final_v1_final_final_3_hello.pdf"
+            "status": "uploaded"
           }
         ],
         url_for("main.terms"),
         url_for("main.storybook_attachments_attach"),
         url_for("main.storybook_attachments_remove"),
+        none,
+        none,
         lang=current_lang
       )
     }}
@@ -60,19 +63,20 @@
             "id": "storybook-malware-1",
             "name": "document_with_malware.pdf",
             "size": 470000,
-            "status": "malware"
+            "status": "virus_scan_failed"
           },
           {
             "id": "storybook-malware-2",
             "name": "safe_permit.pdf",
             "size": 260000,
-            "status": "uploaded",
-            "downloadUrl": "/storybook/downloads/safe_permit.pdf"
+            "status": "uploaded"
           }
         ],
         url_for("main.terms"),
         url_for("main.storybook_attachments_attach"),
         url_for("main.storybook_attachments_remove"),
+        none,
+        none,
         lang=current_lang
       )
     }}
@@ -90,13 +94,14 @@
             "id": "storybook-interactive-1",
             "name": "already_attached_notice.pdf",
             "size": 220000,
-            "status": "uploaded",
-            "downloadUrl": "/storybook/downloads/already_attached_notice.pdf"
+            "status": "uploaded"
           }
         ],
         url_for("main.terms"),
         url_for("main.storybook_attachments_attach"),
         url_for("main.storybook_attachments_remove"),
+        none,
+        none,
         lang=current_lang
       )
     }}

--- a/app/templates/views/storybook/attachments.html
+++ b/app/templates/views/storybook/attachments.html
@@ -4,28 +4,6 @@
 <p class="mb-6">React component demo for adding and removing template attachments.</p>
 
 <script nonce="{{ request_nonce }}">
-  window.storybookAttachmentsNoop = async function () {
-    return [];
-  };
-
-  window.storybookAttachmentsSimulatedResults = async function (selectedFiles) {
-    return selectedFiles.map(function (file) {
-      var name = file.name.toLowerCase();
-
-      if (name.includes("malware") || name.includes("virus")) {
-        return { status: "malware" };
-      }
-
-      if (name.includes("fail") || name.includes("error")) {
-        return { status: "upload-failed" };
-      }
-
-      return {
-        status: "attached",
-        downloadUrl: "/storybook/downloads/" + encodeURIComponent(file.name)
-      };
-    });
-  };
 </script>
 
 <div class="space-y-10">
@@ -33,11 +11,10 @@
     <h3 class="heading-small mb-4">No files attached</h3>
     {{ attachments_widget(
         "storybook-attachments-empty",
-        {
-          "initialFiles": [],
-          "onAttachFilesHandler": "storybookAttachmentsNoop",
-          "classificationUrl": url_for("main.terms")
-        },
+        [],
+        url_for("main.terms"),
+        url_for("main.storybook_attachments_attach"),
+        url_for("main.storybook_attachments_remove"),
         lang=current_lang
       )
     }}
@@ -49,25 +26,24 @@
     <h3 class="heading-small mb-4">Mixed in-progress and attached</h3>
     {{ attachments_widget(
         "storybook-attachments-in-progress",
-        {
-          "initialFiles": [
-            {
-              "id": "storybook-progress-1",
-              "name": "Filename.pdf",
-              "size": 320000,
-              "status": "pending-scan"
-            },
-            {
-              "id": "storybook-progress-2",
-              "name": "Sometimes_you_need_a_very_very_very_very_long_file_name_final_v1_final_final_3_hello.pdf",
-              "size": 170000,
-              "status": "attached",
-              "downloadUrl": "/storybook/downloads/Sometimes_you_need_a_very_very_very_very_long_file_name_final_v1_final_final_3_hello.pdf"
-            }
-          ],
-          "onAttachFilesHandler": "storybookAttachmentsNoop",
-          "classificationUrl": url_for("main.terms")
-        },
+        [
+          {
+            "id": "storybook-progress-1",
+            "name": "Filename.pdf",
+            "size": 320000,
+            "status": "pending-scan"
+          },
+          {
+            "id": "storybook-progress-2",
+            "name": "Sometimes_you_need_a_very_very_very_very_long_file_name_final_v1_final_final_3_hello.pdf",
+            "size": 170000,
+            "status": "attached",
+            "downloadUrl": "/storybook/downloads/Sometimes_you_need_a_very_very_very_very_long_file_name_final_v1_final_final_3_hello.pdf"
+          }
+        ],
+        url_for("main.terms"),
+        url_for("main.storybook_attachments_attach"),
+        url_for("main.storybook_attachments_remove"),
         lang=current_lang
       )
     }}
@@ -79,25 +55,24 @@
     <h3 class="heading-small mb-4">Unsafe file state</h3>
     {{ attachments_widget(
         "storybook-attachments-malware",
-        {
-          "initialFiles": [
-            {
-              "id": "storybook-malware-1",
-              "name": "document_with_malware.pdf",
-              "size": 470000,
-              "status": "malware"
-            },
-            {
-              "id": "storybook-malware-2",
-              "name": "safe_permit.pdf",
-              "size": 260000,
-              "status": "attached",
-              "downloadUrl": "/storybook/downloads/safe_permit.pdf"
-            }
-          ],
-          "onAttachFilesHandler": "storybookAttachmentsNoop",
-          "classificationUrl": url_for("main.terms")
-        },
+        [
+          {
+            "id": "storybook-malware-1",
+            "name": "document_with_malware.pdf",
+            "size": 470000,
+            "status": "malware"
+          },
+          {
+            "id": "storybook-malware-2",
+            "name": "safe_permit.pdf",
+            "size": 260000,
+            "status": "attached",
+            "downloadUrl": "/storybook/downloads/safe_permit.pdf"
+          }
+        ],
+        url_for("main.terms"),
+        url_for("main.storybook_attachments_attach"),
+        url_for("main.storybook_attachments_remove"),
         lang=current_lang
       )
     }}
@@ -110,19 +85,18 @@
     <p class="hint mb-4">Attach files with names containing malware/virus or fail/error to simulate non-attached outcomes.</p>
     {{ attachments_widget(
         "storybook-attachments-interactive",
-        {
-          "initialFiles": [
-            {
-              "id": "storybook-interactive-1",
-              "name": "already_attached_notice.pdf",
-              "size": 220000,
-              "status": "attached",
-              "downloadUrl": "/storybook/downloads/already_attached_notice.pdf"
-            }
-          ],
-          "onAttachFilesHandler": "storybookAttachmentsSimulatedResults",
-          "classificationUrl": url_for("main.terms")
-        },
+        [
+          {
+            "id": "storybook-interactive-1",
+            "name": "already_attached_notice.pdf",
+            "size": 220000,
+            "status": "attached",
+            "downloadUrl": "/storybook/downloads/already_attached_notice.pdf"
+          }
+        ],
+        url_for("main.terms"),
+        url_for("main.storybook_attachments_attach"),
+        url_for("main.storybook_attachments_remove"),
         lang=current_lang
       )
     }}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -1,4 +1,5 @@
 {% extends "admin_template.html" %}
+{% from "components/attachments.html" import attachments_widget with context %}
 {% from "components/banner.html" import banner_wrapper %}
 {% from "components/folder-path.html" import folder_path, page_title_folder_path %}
 {% from "components/page-footer.html" import page_footer %}
@@ -44,7 +45,7 @@
   </div>
 
   {% include 'views/templates/_template.html' %}
-
+ 
   <div class="flex mb-16 -mt-8{% if template.template_type != 'email' %} flex-col{% endif %}">
       <div class="{% if template.template_type == 'email' %}w-1/2{% else %}mb-6{% endif %}">
         {% if current_user.has_permissions('manage_templates') and not template._template.archived %}
@@ -89,6 +90,18 @@
         {% endif %}
       </div>
   </div>
+
+  {% if config['FF_FILE_ATTACHMENTS'] and template.template_type == 'email' %}
+    <div class="mb-16">
+      {{ attachments_widget(
+        "template-attachments",
+        template_attachments,
+        url_for('main.terms'),
+        url_for('main.attach_files', service_id=current_service.id, template_id=template.id),
+        url_for('main.remove_files', service_id=current_service.id, template_id=template.id)
+      ) }}
+    </div>
+  {% endif %}
 
   <div class="mb-16">
     {{ api_key(template.id, name="Template ID", thing='template ID') }}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -91,7 +91,7 @@
       </div>
   </div>
 
-  {% if config['FF_FILE_ATTACHMENTS'] and template.template_type == 'email' and current_service.has_permission("upload_document") %}
+  {% if config['FF_FILE_ATTACHMENTS'] and template.template_type == 'email' and current_service.has_permission("upload_document") and current_user.has_permissions('manage_templates') %}
     <div class="mb-16">
       {{ attachments_widget(
         "template-attachments",

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -99,7 +99,8 @@
         url_for('main.terms'),
         url_for('main.attach_files', service_id=current_service.id, template_id=template.id),
         url_for('main.remove_files', service_id=current_service.id, template_id=template.id),
-        url_for('main.template_attachment_status', service_id=current_service.id, template_id=template.id)
+        url_for('main.template_attachment_status', service_id=current_service.id, template_id=template.id),
+        url_for('main.download_template_attachment', service_id=current_service.id, template_id=template.id)
       ) }}
     </div>
   {% endif %}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -91,14 +91,15 @@
       </div>
   </div>
 
-  {% if config['FF_FILE_ATTACHMENTS'] and template.template_type == 'email' %}
+  {% if config['FF_FILE_ATTACHMENTS'] and template.template_type == 'email' and current_service.has_permission("upload_document") %}
     <div class="mb-16">
       {{ attachments_widget(
         "template-attachments",
         template_attachments,
         url_for('main.terms'),
         url_for('main.attach_files', service_id=current_service.id, template_id=template.id),
-        url_for('main.remove_files', service_id=current_service.id, template_id=template.id)
+        url_for('main.remove_files', service_id=current_service.id, template_id=template.id),
+        url_for('main.template_attachment_status', service_id=current_service.id, template_id=template.id)
       ) }}
     </div>
   {% endif %}

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -823,9 +823,12 @@ def test_template_attachment_status_route_returns_file_status(
     mock_get_template_folders,
     mock_get_limit_stats,
     fake_uuid,
+    service_one,
+    app_,
     mocker,
 ):
     current_user.verified_phonenumber = True
+    service_one["permissions"].append("upload_document")
     mocker.patch(
         "app.service_api_client.get_service_template",
         return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
@@ -835,14 +838,15 @@ def test_template_attachment_status_route_returns_file_status(
         return_value={"status": "pending_virus_scan", "document_id": "file-1"},
     )
 
-    response = client_request.get(
-        ".template_attachment_status",
-        service_id=SERVICE_ONE_ID,
-        template_id=fake_uuid,
-        file_id="file-1",
-        _test_page_title=False,
-        _return_response=True,
-    )
+    with set_config(app_, "FF_FILE_ATTACHMENTS", True):  # TODO: REMOVE WHEN FF_FILE_ATTACHMENTS IS REMOVED
+        response = client_request.get(
+            ".template_attachment_status",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            file_id="file-1",
+            _test_page_title=False,
+            _return_response=True,
+        )
 
     assert response.get_json() == {"status": "pending_virus_scan", "document_id": "file-1"}
     mock_get_file_status.assert_called_once_with(UUID(fake_uuid), "file-1")
@@ -853,9 +857,12 @@ def test_template_attachment_download_route_returns_file(
     mock_get_template_folders,
     mock_get_limit_stats,
     fake_uuid,
+    service_one,
+    app_,
     mocker,
 ):
     current_user.verified_phonenumber = True
+    service_one["permissions"].append("upload_document")
     mocker.patch(
         "app.service_api_client.get_service_template",
         return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
@@ -869,20 +876,58 @@ def test_template_attachment_download_route_returns_file(
         },
     )
 
-    response = client_request.get(
-        ".download_template_attachment",
-        service_id=SERVICE_ONE_ID,
-        template_id=fake_uuid,
-        file_id="file-1",
-        _test_page_title=False,
-        _return_response=True,
-    )
+    with set_config(app_, "FF_FILE_ATTACHMENTS", True):  # TODO: REMOVE WHEN FF_FILE_ATTACHMENTS IS REMOVED
+        response = client_request.get(
+            ".download_template_attachment",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            file_id="file-1",
+            _test_page_title=False,
+            _return_response=True,
+        )
 
     assert response.status_code == 200
     assert response.mimetype == "text/plain"
     assert response.data == b"example content"
     assert response.headers["Content-Disposition"] == 'attachment; filename="example-file-1.txt"'
     mock_get_file_contents.assert_called_once_with(UUID(fake_uuid), "file-1")
+
+
+@pytest.mark.parametrize(
+    "route_name, method, route_params",
+    [
+        (".attach_files", "post", {}),
+        (".remove_files", "post", {"file_id": "file-1"}),
+        (".template_attachment_status", "get", {"file_id": "file-1"}),
+        (".download_template_attachment", "get", {"file_id": "file-1"}),
+    ],
+)
+def test_template_attachment_routes_return_404_without_upload_document_permission(
+    client_request,
+    mock_get_template_folders,
+    mock_get_limit_stats,
+    fake_uuid,
+    app_,
+    route_name,
+    method,
+    route_params,
+):
+    current_user.verified_phonenumber = True
+
+    with set_config(app_, "FF_FILE_ATTACHMENTS", True):  # TODO: REMOVE WHEN FF_FILE_ATTACHMENTS IS REMOVED
+        request_func = getattr(client_request, method)
+        response = request_func(
+            route_name,
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            _expected_status=404,
+            _test_page_title=False,
+            _return_response=True,
+            **route_params,
+        )
+
+    if method == "get":
+        assert response.status_code == 404
 
 
 def test_should_show_logos_on_template_page(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -790,6 +790,7 @@ def test_should_show_attachments_widget_on_email_template_page(
     assert url_for("main.attach_files", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
     assert url_for("main.remove_files", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
     assert url_for("main.template_attachment_status", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
+    assert url_for("main.download_template_attachment", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
 
 
 def test_should_not_show_attachments_widget_without_send_files_permission(
@@ -845,6 +846,43 @@ def test_template_attachment_status_route_returns_file_status(
 
     assert response.get_json() == {"status": "pending_virus_scan", "document_id": "file-1"}
     mock_get_file_status.assert_called_once_with(UUID(fake_uuid), "file-1")
+
+
+def test_template_attachment_download_route_returns_file(
+    client_request,
+    mock_get_template_folders,
+    mock_get_limit_stats,
+    fake_uuid,
+    mocker,
+):
+    current_user.verified_phonenumber = True
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
+    )
+    mock_get_file_contents = mocker.patch(
+        "app.main.views.templates.file_api_client.get_file_contents",
+        return_value={
+            "filename": "example-file-1.txt",
+            "mime_type": "text/plain",
+            "content": b"example content",
+        },
+    )
+
+    response = client_request.get(
+        ".download_template_attachment",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        file_id="file-1",
+        _test_page_title=False,
+        _return_response=True,
+    )
+
+    assert response.status_code == 200
+    assert response.mimetype == "text/plain"
+    assert response.data == b"example content"
+    assert response.headers["Content-Disposition"] == 'attachment; filename="example-file-1.txt"'
+    mock_get_file_contents.assert_called_once_with(UUID(fake_uuid), "file-1")
 
 
 def test_should_show_logos_on_template_page(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -759,6 +759,32 @@ def test_should_show_template_id_on_template_page(
     assert page.select(".api-key-key")[0].text == fake_uuid
 
 
+def test_should_show_attachments_widget_on_email_template_page(
+    client_request,
+    mock_get_template_folders,
+    mock_get_limit_stats,
+    fake_uuid,
+    mocker,
+):
+    current_user.verified_phonenumber = True
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
+    )
+
+    page = client_request.get(
+        ".view_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _test_page_title=False,
+    )
+
+    assert page.select_one("#template-attachments") is not None
+    assert "viewTemplateAttachmentsNoop" not in str(page)
+    assert url_for("main.attach_files", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
+    assert url_for("main.remove_files", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
+
+
 def test_should_show_logos_on_template_page(
     client_request,
     fake_uuid,

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from functools import partial
 from unittest.mock import ANY, MagicMock, Mock, patch
+from uuid import UUID
 
 import pytest
 from flask import url_for
@@ -51,6 +52,7 @@ from tests.conftest import (
     fake_uuid,
     mock_get_service_template_with_process_type,
     normalize_spaces,
+    set_config,
 )
 
 DEFAULT_PROCESS_TYPE = TemplateProcessTypes.BULK.value
@@ -764,6 +766,38 @@ def test_should_show_attachments_widget_on_email_template_page(
     mock_get_template_folders,
     mock_get_limit_stats,
     fake_uuid,
+    app_,
+    service_one,
+    mocker,
+):
+    current_user.verified_phonenumber = True
+    service_one["permissions"].append("upload_document")
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
+    )
+
+    with set_config(app_, "FF_FILE_ATTACHMENTS", True):  # TODO: REMOVE WHEN FF_FILE_ATTACHMENTS IS REMOVED
+        page = client_request.get(
+            ".view_template",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            _test_page_title=False,
+        )
+
+    assert page.select_one("#template-attachments") is not None
+    assert "viewTemplateAttachmentsNoop" not in str(page)
+    assert url_for("main.attach_files", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
+    assert url_for("main.remove_files", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
+    assert url_for("main.template_attachment_status", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
+
+
+def test_should_not_show_attachments_widget_without_send_files_permission(
+    client_request,
+    mock_get_template_folders,
+    mock_get_limit_stats,
+    fake_uuid,
+    app_,
     mocker,
 ):
     current_user.verified_phonenumber = True
@@ -772,17 +806,45 @@ def test_should_show_attachments_widget_on_email_template_page(
         return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
     )
 
-    page = client_request.get(
-        ".view_template",
-        service_id=SERVICE_ONE_ID,
-        template_id=fake_uuid,
-        _test_page_title=False,
+    with set_config(app_, "FF_FILE_ATTACHMENTS", True):  # TODO: REMOVE WHEN FF_FILE_ATTACHMENTS IS REMOVED
+        page = client_request.get(
+            ".view_template",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            _test_page_title=False,
+        )
+
+    assert page.select_one("#template-attachments") is None
+
+
+def test_template_attachment_status_route_returns_file_status(
+    client_request,
+    mock_get_template_folders,
+    mock_get_limit_stats,
+    fake_uuid,
+    mocker,
+):
+    current_user.verified_phonenumber = True
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
+    )
+    mock_get_file_status = mocker.patch(
+        "app.main.views.templates.file_api_client.get_file_status",
+        return_value={"status": "pending_virus_scan", "document_id": "file-1"},
     )
 
-    assert page.select_one("#template-attachments") is not None
-    assert "viewTemplateAttachmentsNoop" not in str(page)
-    assert url_for("main.attach_files", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
-    assert url_for("main.remove_files", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
+    response = client_request.get(
+        ".template_attachment_status",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        file_id="file-1",
+        _test_page_title=False,
+        _return_response=True,
+    )
+
+    assert response.get_json() == {"status": "pending_virus_scan", "document_id": "file-1"}
+    mock_get_file_status.assert_called_once_with(UUID(fake_uuid), "file-1")
 
 
 def test_should_show_logos_on_template_page(

--- a/tests/app/models/test_user.py
+++ b/tests/app/models/test_user.py
@@ -1,4 +1,5 @@
 import pytest
+from flask import session
 
 from app.models.user import AnonymousUser, User
 
@@ -66,11 +67,11 @@ def test_activate_user_already_active(app_, api_user_active, mock_activate_user)
         (False, None, False),
     ],
 )
-def test_platform_admin_flag_set_in_session(client, mocker, is_platform_admin, value_in_session, expected_result):
-    session_dict = {}
-    if value_in_session is not None:
-        session_dict["disable_platform_admin_view"] = value_in_session
+def test_platform_admin_flag_set_in_session(app_, is_platform_admin, value_in_session, expected_result):
+    with app_.test_request_context("/"):
+        if value_in_session is None:
+            session.pop("disable_platform_admin_view", None)
+        else:
+            session["disable_platform_admin_view"] = value_in_session
 
-    mocker.patch.dict("app.models.user.session", values=session_dict, clear=True)
-
-    assert User({"platform_admin": is_platform_admin}).platform_admin == expected_result
+        assert User({"platform_admin": is_platform_admin}).platform_admin == expected_result

--- a/tests/app/notify_client/test_file_api_client.py
+++ b/tests/app/notify_client/test_file_api_client.py
@@ -1,0 +1,62 @@
+from app.notify_client.file_api_client import FileApiClient, file_api_client
+
+
+class TestFileApiClient:
+    def test_get_files_by_template_id(self, mocker):
+        client = FileApiClient()
+        mock_get = mocker.patch.object(client, "get", return_value=[])
+
+        ret = client.get_files_by_template_id("template-id")
+
+        assert ret == []
+        mock_get.assert_called_once_with("/templates/template-id/files")
+
+    def test_create_file(self, mocker):
+        client = FileApiClient()
+        mock_post = mocker.patch.object(client, "post", return_value={"id": "file-id"})
+
+        ret = client.create_file(
+            "template-id",
+            "upload_document",
+            "report.pdf",
+            "application/pdf",
+            1234,
+            "Zm9v",
+        )
+
+        assert ret == {"id": "file-id"}
+        mock_post.assert_called_once_with(
+            "/templates/template-id/files",
+            {
+                "template_id": "template-id",
+                "type": "upload_document",
+                "name": "report.pdf",
+                "mime_type": "application/pdf",
+                "file_size": 1234,
+                "file_data": "Zm9v",
+            },
+        )
+
+    def test_delete_file(self, mocker):
+        client = FileApiClient()
+        mock_delete = mocker.patch.object(client, "delete", return_value=None)
+
+        client.delete_file("template-id", "file-id")
+
+        mock_delete.assert_called_once_with("/templates/template-id/files/file-id", {})
+
+    def test_update_file_status(self, mocker):
+        client = FileApiClient()
+        mock_post = mocker.patch.object(client, "post", return_value={"status": "uploaded"})
+
+        ret = client.update_file_status("template-id", "file-id", "uploaded")
+
+        assert ret == {"status": "uploaded"}
+        mock_post.assert_called_once_with(
+            "/templates/template-id/files/file-id/status",
+            {"status": "uploaded"},
+        )
+
+
+def test_singleton_client_exposes_methods():
+    assert file_api_client is not None

--- a/tests/app/notify_client/test_file_api_client.py
+++ b/tests/app/notify_client/test_file_api_client.py
@@ -13,6 +13,7 @@ class TestFileApiClient:
 
     def test_create_file(self, mocker):
         client = FileApiClient()
+        mocker.patch("app.notify_client.file_api_client.current_user", new=mocker.Mock(id="test-user-id"))
         mock_post = mocker.patch.object(client, "post", return_value={"id": "file-id"})
 
         ret = client.create_file(
@@ -34,6 +35,7 @@ class TestFileApiClient:
                 "mime_type": "application/pdf",
                 "file_size": 1234,
                 "file_data": "Zm9v",
+                "created_by": "test-user-id",
             },
         )
 

--- a/tests/app/notify_client/test_file_api_client.py
+++ b/tests/app/notify_client/test_file_api_client.py
@@ -57,6 +57,16 @@ class TestFileApiClient:
             {"status": "uploaded"},
         )
 
+    def test_get_file_contents_returns_stub_example_file(self):
+        client = FileApiClient()
+
+        ret = client.get_file_contents("template-id", "file-id")
+
+        assert ret["filename"] == "example-file-id.txt"
+        assert ret["mime_type"] == "text/plain"
+        assert b"template-id" in ret["content"]
+        assert b"file-id" in ret["content"]
+
 
 def test_singleton_client_exposes_methods():
     assert file_api_client is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4595,6 +4595,11 @@ def mock_get_template_folders(mocker):
     return mocker.patch("app.template_folder_api_client.get_template_folders", return_value=[])
 
 
+@pytest.fixture(autouse=True)
+def mock_get_template_attachments(mocker):
+    return mocker.patch("app.models.service.file_api_client.get_files_by_template_id", return_value=[])
+
+
 @pytest.fixture
 def mock_move_to_template_folder(mocker):
     return mocker.patch("app.template_folder_api_client.move_to_folder")

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -635,4 +635,28 @@ describe("attachments - useAttachments", () => {
 
     harness.cleanup();
   });
+
+  test("throws a retry error when upload callback fails", async () => {
+    const harness = setupHookHarness();
+    let thrownError = null;
+
+    await act(async () => {
+      try {
+        await harness.getState().attachFiles(
+          [{ name: "failed-upload.pdf", size: 2048 }],
+          async () => {
+            throw new Error("network error");
+          },
+        );
+      } catch (error) {
+        thrownError = error;
+      }
+    });
+
+    expect(thrownError).toBeTruthy();
+    expect(thrownError.message).toBe("Failed to attach files. Please try again.");
+    expect(harness.getState().files).toHaveLength(0);
+
+    harness.cleanup();
+  });
 });

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -585,9 +585,7 @@ describe("attachments - useAttachments", () => {
       jest.advanceTimersByTime(1800);
     });
 
-    const [file] = harness.getState().files;
-    expect(file.id).toBeDefined();
-    expect(file.status).toBe(ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN);
+    expect(harness.getState().files).toHaveLength(0);
 
     harness.cleanup();
   });
@@ -615,6 +613,25 @@ describe("attachments - useAttachments", () => {
     const [file] = harness.getState().files;
     expect(file.id).toBe("file-unknown-status-1");
     expect(file.status).toBe(ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN);
+
+    harness.cleanup();
+  });
+
+  test("does not render file when upload response has no id", async () => {
+    const harness = setupHookHarness();
+
+    await act(async () => {
+      await harness.getState().attachFiles(
+        [{ name: "missing-id.pdf", size: 2048 }],
+        async () => [
+          {
+            status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
+          },
+        ],
+      );
+    });
+
+    expect(harness.getState().files).toHaveLength(0);
 
     harness.cleanup();
   });

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -106,8 +106,8 @@ describe("attachments - summarizeStatuses", () => {
   test("returns grouped summary text", () => {
     const files = [
       { status: ATTACHMENT_STATUSES.UPLOADING },
-      { status: ATTACHMENT_STATUSES.PENDING_SCAN },
-      { status: ATTACHMENT_STATUSES.ATTACHED },
+      { status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN },
+      { status: ATTACHMENT_STATUSES.UPLOADED },
       { status: ATTACHMENT_STATUSES.UPLOAD_FAILED },
     ];
 
@@ -116,8 +116,8 @@ describe("attachments - summarizeStatuses", () => {
 
   test("summarizes attached-only files with proper pluralization", () => {
     const files = [
-      { status: ATTACHMENT_STATUSES.ATTACHED },
-      { status: ATTACHMENT_STATUSES.ATTACHED },
+      { status: ATTACHMENT_STATUSES.UPLOADED },
+      { status: ATTACHMENT_STATUSES.UPLOADED },
     ];
 
     expect(summarizeStatuses(files)).toBe("2 files attached");
@@ -127,7 +127,7 @@ describe("attachments - summarizeStatuses", () => {
     const files = [
       { status: ATTACHMENT_STATUSES.UPLOADING },
       { status: ATTACHMENT_STATUSES.UPLOADING },
-      { status: ATTACHMENT_STATUSES.PENDING_SCAN },
+      { status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN },
     ];
 
     expect(summarizeStatuses(files)).toBe("2 files uploading, 1 file scanning");
@@ -135,7 +135,7 @@ describe("attachments - summarizeStatuses", () => {
 
   test("groups malware and upload-failed into issues bucket", () => {
     const files = [
-      { status: ATTACHMENT_STATUSES.MALWARE },
+      { status: ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED },
       { status: ATTACHMENT_STATUSES.UPLOAD_FAILED },
     ];
 
@@ -151,7 +151,7 @@ describe("attachments - render contracts", () => {
           file: {
             id: "file-a",
             name: "duplicate-name.pdf",
-            status: ATTACHMENT_STATUSES.ATTACHED,
+            status: ATTACHMENT_STATUSES.UPLOADED,
           },
           isConfirmingRemoval: false,
           onRequestRemove: () => {},
@@ -162,7 +162,7 @@ describe("attachments - render contracts", () => {
           file: {
             id: "file-b",
             name: "duplicate-name.pdf",
-            status: ATTACHMENT_STATUSES.PENDING_SCAN,
+            status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
           },
           isConfirmingRemoval: false,
           onRequestRemove: () => {},
@@ -187,7 +187,7 @@ describe("attachments - render contracts", () => {
         file: {
           id: "file-1",
           name: "Filename.pdf",
-          status: ATTACHMENT_STATUSES.ATTACHED,
+          status: ATTACHMENT_STATUSES.UPLOADED,
         },
         isConfirmingRemoval: false,
         onRequestRemove: () => {},
@@ -207,7 +207,7 @@ describe("attachments - render contracts", () => {
         file: {
           id: "malware-1",
           name: "document_with_malware.pdf",
-          status: ATTACHMENT_STATUSES.MALWARE,
+          status: ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED,
         },
         isConfirmingRemoval: false,
         onRequestRemove: () => {},
@@ -226,7 +226,7 @@ describe("attachments - render contracts", () => {
         file: {
           id: "file-2",
           name: "Sometimes_you_need_a_very_very_very_very_long_file_name_final_v1_final_final_3_hello.pdf",
-          status: ATTACHMENT_STATUSES.ATTACHED,
+          status: ATTACHMENT_STATUSES.UPLOADED,
         },
         isConfirmingRemoval: false,
         onRequestRemove: () => {},
@@ -244,7 +244,7 @@ describe("attachments - render contracts", () => {
         file: {
           id: "file-download-2",
           name: "remove-me.pdf",
-          status: ATTACHMENT_STATUSES.ATTACHED,
+          status: ATTACHMENT_STATUSES.UPLOADED,
         },
         isConfirmingRemoval: true,
         onRequestRemove: () => {},
@@ -263,7 +263,7 @@ describe("attachments - render contracts", () => {
         file: {
           id: "file-malware-remove-1",
           name: "document_with_malware.pdf",
-          status: ATTACHMENT_STATUSES.MALWARE,
+          status: ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED,
         },
         isConfirmingRemoval: true,
         onRequestRemove: () => {},
@@ -323,11 +323,11 @@ describe("attachments - render contracts", () => {
 describe("attachments - useAttachments", () => {
   const originalActEnvironment = global.IS_REACT_ACT_ENVIRONMENT;
 
-  const setupHookHarness = (initialFiles = []) => {
+  const setupHookHarness = (initialFiles = [], fetchFileStatus = null) => {
     let latest = null;
 
     const HookHarness = ({ files }) => {
-      latest = useAttachments(files);
+      latest = useAttachments(files, undefined, fetchFileStatus);
       return null;
     };
 
@@ -373,7 +373,7 @@ describe("attachments - useAttachments", () => {
     await act(async () => {
       await harness.getState().attachFiles(
         [{ name: "document-id.pdf", size: 2468 }],
-        async () => [{ status: ATTACHMENT_STATUSES.ATTACHED, document_id: "file-456" }],
+        async () => [{ status: ATTACHMENT_STATUSES.UPLOADED, document_id: "file-456" }],
       );
     });
 
@@ -383,8 +383,62 @@ describe("attachments - useAttachments", () => {
     });
 
     const [file] = harness.getState().files;
-    expect(file.status).toBe(ATTACHMENT_STATUSES.ATTACHED);
+    expect(file.status).toBe(ATTACHMENT_STATUSES.UPLOADED);
     expect(file.id).toBe("file-456");
+
+    harness.cleanup();
+  });
+
+  test("normalizes pending_virus_scan initial files to scanning", async () => {
+    const harness = setupHookHarness([
+      {
+        id: "file-999",
+        name: "persisted.pdf",
+          status: "pending_virus_scan",
+      },
+    ]);
+
+    const { files, pendingCount } = harness.getState();
+
+    expect(files).toHaveLength(1);
+    expect(files[0].status).toBe(ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN);
+    expect(pendingCount).toBe(1);
+
+    harness.cleanup();
+  });
+
+  test("polls pending_scan files until the backend finishes scanning", async () => {
+    const fetchFileStatus = jest
+      .fn()
+      .mockResolvedValueOnce({ status: "pending_virus_scan" })
+      .mockResolvedValueOnce({ status: "uploaded" });
+
+    const harness = setupHookHarness(
+      [
+        {
+          id: "file-777",
+          name: "pending.pdf",
+          status: "pending_virus_scan",
+        },
+      ],
+      fetchFileStatus,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchFileStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+
+    const [file] = harness.getState().files;
+    expect(fetchFileStatus).toHaveBeenCalledTimes(2);
+    expect(file.status).toBe(ATTACHMENT_STATUSES.UPLOADED);
+    expect(file.id).toBe("file-777");
 
     harness.cleanup();
   });

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -367,28 +367,6 @@ describe("attachments - useAttachments", () => {
     jest.useRealTimers();
   });
 
-  test("preserves callback id on attached files", async () => {
-    const harness = setupHookHarness();
-
-    await act(async () => {
-      await harness.getState().attachFiles(
-        [{ name: "document-id.pdf", size: 2468 }],
-        async () => [{ status: ATTACHMENT_STATUSES.ATTACHED, id: "file-123" }],
-      );
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(500);
-      jest.advanceTimersByTime(1800);
-    });
-
-    const [file] = harness.getState().files;
-    expect(file.status).toBe(ATTACHMENT_STATUSES.ATTACHED);
-    expect(file.id).toBe("file-123");
-
-    harness.cleanup();
-  });
-
   test("preserves document_id on attached files", async () => {
     const harness = setupHookHarness();
 

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -238,34 +238,13 @@ describe("attachments - render contracts", () => {
     expect(html).toContain('class="attachment-file-name-truncate"');
   });
 
-  test("attached file renders clickable download link", () => {
-    const html = renderToStaticMarkup(
-      React.createElement(AttachedFileRow, {
-        file: {
-          id: "file-download-1",
-          name: "downloadable.pdf",
-          status: ATTACHMENT_STATUSES.ATTACHED,
-          downloadUrl: "/storybook/downloads/downloadable.pdf",
-        },
-        isConfirmingRemoval: false,
-        onRequestRemove: () => {},
-        onConfirmRemove: () => {},
-        onCancelRemove: () => {},
-      }),
-    );
-
-    expect(html).toContain('data-testid="attachment-download-link"');
-    expect(html).toContain('href="/storybook/downloads/downloadable.pdf"');
-  });
-
-  test("remove confirmation keeps filename downloadable when available", () => {
+  test("remove confirmation shows filename text", () => {
     const html = renderToStaticMarkup(
       React.createElement(AttachedFileRow, {
         file: {
           id: "file-download-2",
           name: "remove-me.pdf",
           status: ATTACHMENT_STATUSES.ATTACHED,
-          downloadUrl: "/storybook/downloads/remove-me.pdf",
         },
         isConfirmingRemoval: true,
         onRequestRemove: () => {},
@@ -274,12 +253,11 @@ describe("attachments - render contracts", () => {
       }),
     );
 
-    expect(html).toContain("Download a copy of");
-    expect(html).toContain('data-testid="attachment-download-link"');
-    expect(html).toContain('href="/storybook/downloads/remove-me.pdf"');
+    expect(html).toContain("remove-me.pdf");
+    expect(html).not.toContain('data-testid="attachment-download-link"');
   });
 
-  test("malware remove confirmation omits download prompt", () => {
+  test("malware remove confirmation shows plain prompt text", () => {
     const html = renderToStaticMarkup(
       React.createElement(AttachedFileRow, {
         file: {
@@ -294,18 +272,17 @@ describe("attachments - render contracts", () => {
       }),
     );
 
-    expect(html).not.toContain("Download a copy of");
+    expect(html).toContain("Download a copy of");
     expect(html).not.toContain('data-testid="attachment-download-link"');
   });
 
-  test("uploading remove confirmation omits download prompt", () => {
+  test("uploading remove confirmation shows plain prompt text", () => {
     const html = renderToStaticMarkup(
       React.createElement(AttachedFileRow, {
         file: {
           id: "file-uploading-remove-1",
           name: "still-uploading.pdf",
           status: ATTACHMENT_STATUSES.UPLOADING,
-          downloadUrl: "/storybook/downloads/still-uploading.pdf",
         },
         isConfirmingRemoval: true,
         onRequestRemove: () => {},
@@ -314,7 +291,7 @@ describe("attachments - render contracts", () => {
       }),
     );
 
-    expect(html).not.toContain("Download a copy of");
+    expect(html).toContain("Download a copy of");
     expect(html).not.toContain('data-testid="attachment-download-link"');
   });
 
@@ -344,7 +321,6 @@ describe("attachments - render contracts", () => {
 });
 
 describe("attachments - useAttachments", () => {
-  const originalUrl = global.URL;
   const originalActEnvironment = global.IS_REACT_ACT_ENVIRONMENT;
 
   const setupHookHarness = (initialFiles = []) => {
@@ -384,25 +360,20 @@ describe("attachments - useAttachments", () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
-    global.URL = {
-      createObjectURL: jest.fn(() => "blob:generated-object-url"),
-      revokeObjectURL: jest.fn(),
-    };
   });
 
   afterEach(() => {
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
-    global.URL = originalUrl;
   });
 
-  test("maps callback download_url to file downloadUrl", async () => {
+  test("preserves callback id on attached files", async () => {
     const harness = setupHookHarness();
 
     await act(async () => {
       await harness.getState().attachFiles(
-        [{ name: "server-link.pdf", size: 1234 }],
-        async () => [{ status: ATTACHMENT_STATUSES.ATTACHED, download_url: "/download/server-link.pdf" }],
+        [{ name: "document-id.pdf", size: 2468 }],
+        async () => [{ status: ATTACHMENT_STATUSES.ATTACHED, id: "file-123" }],
       );
     });
 
@@ -413,55 +384,7 @@ describe("attachments - useAttachments", () => {
 
     const [file] = harness.getState().files;
     expect(file.status).toBe(ATTACHMENT_STATUSES.ATTACHED);
-    expect(file.downloadUrl).toBe("/download/server-link.pdf");
-    expect(global.URL.createObjectURL).not.toHaveBeenCalled();
-
-    harness.cleanup();
-  });
-
-  test("uses object URL fallback for attached file when callback omits URL", async () => {
-    const harness = setupHookHarness();
-
-    await act(async () => {
-      await harness.getState().attachFiles(
-        [{ name: "fallback.pdf", size: 4321 }],
-        async () => [{ status: ATTACHMENT_STATUSES.ATTACHED }],
-      );
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(500);
-      jest.advanceTimersByTime(1800);
-    });
-
-    const [file] = harness.getState().files;
-    expect(file.status).toBe(ATTACHMENT_STATUSES.ATTACHED);
-    expect(file.downloadUrl).toBe("blob:generated-object-url");
-    expect(file.isObjectUrl).toBe(true);
-    expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);
-
-    harness.cleanup();
-  });
-
-  test("does not keep a download URL for malware status", async () => {
-    const harness = setupHookHarness();
-
-    await act(async () => {
-      await harness.getState().attachFiles(
-        [{ name: "unsafe.pdf", size: 567 }],
-        async () => [{ status: ATTACHMENT_STATUSES.MALWARE, download_url: "/download/unsafe.pdf" }],
-      );
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(500);
-      jest.advanceTimersByTime(1800);
-    });
-
-    const [file] = harness.getState().files;
-    expect(file.status).toBe(ATTACHMENT_STATUSES.MALWARE);
-    expect(file.downloadUrl).toBeUndefined();
-    expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+    expect(file.id).toBe("file-123");
 
     harness.cleanup();
   });

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -144,6 +144,49 @@ describe("attachments - summarizeStatuses", () => {
 });
 
 describe("attachments - render contracts", () => {
+  test("uploaded file renders download link when download endpoint is configured", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(AttachedFileRow, {
+        file: {
+          id: "file-download-1",
+          name: "report.pdf",
+          status: ATTACHMENT_STATUSES.UPLOADED,
+        },
+        downloadEndpoint: "/services/service-1/templates/template-1/attachments/download",
+        isConfirmingRemoval: false,
+        onRequestRemove: () => {},
+        onConfirmRemove: () => {},
+        onCancelRemove: () => {},
+      }),
+    );
+
+    expect(html).toContain('data-testid="attachment-download-link"');
+    expect(html).toContain('href="/services/service-1/templates/template-1/attachments/download/file-download-1"');
+  });
+
+  test.each([
+    [ATTACHMENT_STATUSES.UPLOADING],
+    [ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN],
+    [ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED],
+  ])("%s status does not render a download link", (status) => {
+    const html = renderToStaticMarkup(
+      React.createElement(AttachedFileRow, {
+        file: {
+          id: "file-no-download-1",
+          name: "no-download.pdf",
+          status,
+        },
+        downloadEndpoint: "/services/service-1/templates/template-1/attachments/download",
+        isConfirmingRemoval: false,
+        onRequestRemove: () => {},
+        onConfirmRemove: () => {},
+        onCancelRemove: () => {},
+      }),
+    );
+
+    expect(html).not.toContain('data-testid="attachment-download-link"');
+  });
+
   test("renders duplicate filenames as separate rows when ids differ", () => {
     const html = renderToStaticMarkup(
       React.createElement(React.Fragment, null,

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -534,6 +534,82 @@ describe("attachments - useAttachments", () => {
     harness.cleanup();
   });
 
+  test("stops polling after status becomes uploaded", async () => {
+    const fetchFileStatus = jest
+      .fn()
+      .mockResolvedValueOnce({ status: "pending_virus_scan" })
+      .mockResolvedValueOnce({ status: "uploaded" });
+
+    const harness = setupHookHarness(
+      [
+        {
+          id: "file-stop-uploaded",
+          name: "pending.pdf",
+          status: "pending_virus_scan",
+        },
+      ],
+      fetchFileStatus,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+
+    expect(fetchFileStatus).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      jest.advanceTimersByTime(10000);
+      await Promise.resolve();
+    });
+
+    expect(fetchFileStatus).toHaveBeenCalledTimes(2);
+
+    harness.cleanup();
+  });
+
+  test("stops polling after status becomes virus_scan_failed", async () => {
+    const fetchFileStatus = jest
+      .fn()
+      .mockResolvedValueOnce({ status: "pending_virus_scan" })
+      .mockResolvedValueOnce({ status: "virus_scan_failed" });
+
+    const harness = setupHookHarness(
+      [
+        {
+          id: "file-stop-malware",
+          name: "pending.pdf",
+          status: "pending_virus_scan",
+        },
+      ],
+      fetchFileStatus,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+
+    expect(fetchFileStatus).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      jest.advanceTimersByTime(10000);
+      await Promise.resolve();
+    });
+
+    expect(fetchFileStatus).toHaveBeenCalledTimes(2);
+
+    harness.cleanup();
+  });
+
   test("keeps file in pending_virus_scan when upload callback returns wrapped data response", async () => {
     const harness = setupHookHarness();
 

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -108,7 +108,7 @@ describe("attachments - summarizeStatuses", () => {
       { status: ATTACHMENT_STATUSES.UPLOADING },
       { status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN },
       { status: ATTACHMENT_STATUSES.UPLOADED },
-      { status: ATTACHMENT_STATUSES.UPLOAD_FAILED },
+      { status: ATTACHMENT_STATUSES.DELETED },
     ];
 
     expect(summarizeStatuses(files)).toBe("1 file uploading, 1 file scanning, 1 file attached, 1 file not attached");
@@ -133,10 +133,10 @@ describe("attachments - summarizeStatuses", () => {
     expect(summarizeStatuses(files)).toBe("2 files uploading, 1 file scanning");
   });
 
-  test("groups malware and upload-failed into issues bucket", () => {
+  test("groups malware and deleted into issues bucket", () => {
     const files = [
       { status: ATTACHMENT_STATUSES.VIRUS_SCAN_FAILED },
-      { status: ATTACHMENT_STATUSES.UPLOAD_FAILED },
+      { status: ATTACHMENT_STATUSES.DELETED },
     ];
 
     expect(summarizeStatuses(files)).toBe("2 files not attached");
@@ -297,10 +297,11 @@ describe("attachments - render contracts", () => {
     );
 
     expect(html).toContain("remove-me.pdf");
+    expect(html).toContain("Download a copy of");
     expect(html).not.toContain('data-testid="attachment-download-link"');
   });
 
-  test("malware remove confirmation shows plain prompt text", () => {
+  test("malware remove confirmation does not show download prompt text", () => {
     const html = renderToStaticMarkup(
       React.createElement(AttachedFileRow, {
         file: {
@@ -315,11 +316,11 @@ describe("attachments - render contracts", () => {
       }),
     );
 
-    expect(html).toContain("Download a copy of");
+    expect(html).not.toContain("Download a copy of");
     expect(html).not.toContain('data-testid="attachment-download-link"');
   });
 
-  test("uploading remove confirmation shows plain prompt text", () => {
+  test("uploading remove confirmation does not show download prompt text", () => {
     const html = renderToStaticMarkup(
       React.createElement(AttachedFileRow, {
         file: {
@@ -334,7 +335,26 @@ describe("attachments - render contracts", () => {
       }),
     );
 
-    expect(html).toContain("Download a copy of");
+    expect(html).not.toContain("Download a copy of");
+    expect(html).not.toContain('data-testid="attachment-download-link"');
+  });
+
+  test("pending scan remove confirmation does not show download prompt text", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(AttachedFileRow, {
+        file: {
+          id: "file-pending-remove-1",
+          name: "pending-scan.pdf",
+          status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
+        },
+        isConfirmingRemoval: true,
+        onRequestRemove: () => {},
+        onConfirmRemove: () => {},
+        onCancelRemove: () => {},
+      }),
+    );
+
+    expect(html).not.toContain("Download a copy of");
     expect(html).not.toContain('data-testid="attachment-download-link"');
   });
 
@@ -410,13 +430,13 @@ describe("attachments - useAttachments", () => {
     jest.useRealTimers();
   });
 
-  test("preserves document_id on attached files", async () => {
+  test("uses id from upload response", async () => {
     const harness = setupHookHarness();
 
     await act(async () => {
       await harness.getState().attachFiles(
         [{ name: "document-id.pdf", size: 2468 }],
-        async () => [{ status: ATTACHMENT_STATUSES.UPLOADED, document_id: "file-456" }],
+        async () => [{ status: ATTACHMENT_STATUSES.UPLOADED, id: "file-456" }],
       );
     });
 
@@ -428,6 +448,34 @@ describe("attachments - useAttachments", () => {
     const [file] = harness.getState().files;
     expect(file.status).toBe(ATTACHMENT_STATUSES.UPLOADED);
     expect(file.id).toBe("file-456");
+
+    harness.cleanup();
+  });
+
+  test("prefers id over document_id when both are present", async () => {
+    const harness = setupHookHarness();
+
+    await act(async () => {
+      await harness.getState().attachFiles(
+        [{ name: "both-ids.pdf", size: 2468 }],
+        async () => [
+          {
+            status: ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
+            id: "file-id-preferred",
+            document_id: "document-id-secondary",
+          },
+        ],
+      );
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(1800);
+    });
+
+    const [file] = harness.getState().files;
+    expect(file.id).toBe("file-id-preferred");
+    expect(file.status).toBe(ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN);
 
     harness.cleanup();
   });
@@ -482,6 +530,91 @@ describe("attachments - useAttachments", () => {
     expect(fetchFileStatus).toHaveBeenCalledTimes(2);
     expect(file.status).toBe(ATTACHMENT_STATUSES.UPLOADED);
     expect(file.id).toBe("file-777");
+
+    harness.cleanup();
+  });
+
+  test("keeps file in pending_virus_scan when upload callback returns wrapped data response", async () => {
+    const harness = setupHookHarness();
+
+    await act(async () => {
+      await harness.getState().attachFiles(
+        [{ name: "wrapped-pending.pdf", size: 2048 }],
+        async () => [
+          {
+            data: {
+              id: "file-wrapped-1",
+              status: "pending_virus_scan",
+            },
+          },
+        ],
+      );
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(1800);
+    });
+
+    const [file] = harness.getState().files;
+    expect(file.id).toBe("file-wrapped-1");
+    expect(file.status).toBe(ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN);
+
+    harness.cleanup();
+  });
+
+  test("keeps file in pending_virus_scan when upload callback returns non-array payload", async () => {
+    const harness = setupHookHarness();
+
+    await act(async () => {
+      await harness.getState().attachFiles(
+        [{ name: "wrapped-list.pdf", size: 1024 }],
+        async () => ({
+          data: [
+            {
+              id: "file-wrapped-list-1",
+              status: "pending_virus_scan",
+            },
+          ],
+        }),
+      );
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(1800);
+    });
+
+    const [file] = harness.getState().files;
+    expect(file.id).toBeDefined();
+    expect(file.status).toBe(ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN);
+
+    harness.cleanup();
+  });
+
+  test("keeps file in pending_virus_scan when upload callback returns unknown status", async () => {
+    const harness = setupHookHarness();
+
+    await act(async () => {
+      await harness.getState().attachFiles(
+        [{ name: "unknown-status.pdf", size: 2048 }],
+        async () => [
+          {
+            id: "file-unknown-status-1",
+            status: "created",
+          },
+        ],
+      );
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(1800);
+    });
+
+    const [file] = harness.getState().files;
+    expect(file.id).toBe("file-unknown-status-1");
+    expect(file.status).toBe(ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN);
 
     harness.cleanup();
   });

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -388,4 +388,26 @@ describe("attachments - useAttachments", () => {
 
     harness.cleanup();
   });
+
+  test("preserves document_id on attached files", async () => {
+    const harness = setupHookHarness();
+
+    await act(async () => {
+      await harness.getState().attachFiles(
+        [{ name: "document-id.pdf", size: 2468 }],
+        async () => [{ status: ATTACHMENT_STATUSES.ATTACHED, document_id: "file-456" }],
+      );
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(1800);
+    });
+
+    const [file] = harness.getState().files;
+    expect(file.status).toBe(ATTACHMENT_STATUSES.ATTACHED);
+    expect(file.id).toBe("file-456");
+
+    harness.cleanup();
+  });
 });

--- a/tests_cypress/cypress.config.js
+++ b/tests_cypress/cypress.config.js
@@ -188,6 +188,13 @@ module.exports = defineConfig({
       framework: "react",
       bundler: "vite",
       viteConfig: {
+        optimizeDeps: {
+          esbuildOptions: {
+            loader: {
+              ".js": "jsx",
+            },
+          },
+        },
         plugins: [jsxInJsFiles()],
       },
     },

--- a/tests_cypress/cypress/Notify/Admin/Pages/ServiceSettingsPage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/ServiceSettingsPage.js
@@ -17,6 +17,13 @@ let Components = {
 
     // Common
     MessageBanner: () => cy.get("div[role='status']"),
+
+    // TODO: add `data-testids` to settings page
+    // File attachments setting
+    FileAttachmentsEnabledOption: () =>
+        cy.get('input[name="enabled"][value="True"]'),
+    FileAttachmentsDisabledOption: () =>
+        cy.get('input[name="enabled"][value="False"]'),
 };
 
 let Actions = {
@@ -39,6 +46,21 @@ let Actions = {
     },
     Submit: () => {
         return Components.SubmitButton().click();
+    },
+
+    // File attachments setting
+    VisitFileAttachmentsSettingPage: (serviceId) => {
+        cy.visit(`/services/${serviceId}/service-settings/switch-upload-document`);
+    },
+    SetAllowFileAttachments: (enabled) => {
+        if (enabled) {
+            Components.FileAttachmentsEnabledOption().check({ force: true });
+        } else {
+            Components.FileAttachmentsDisabledOption().check({ force: true });
+        }
+    },
+    SaveFileAttachmentsSetting: () => {
+        cy.contains("button", "Save").click();
     },
 };
 

--- a/tests_cypress/cypress/Notify/Admin/Pages/TemplatesPage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/TemplatesPage.js
@@ -27,6 +27,18 @@ let Components = {
     SelectedTemplateCategoryCollapsed: () => Components.TemplateCategoryButtonContainer().find('p'),
     TCExpandBytton: () => cy.getByTestId('tc_expand_button'),
     TemplatePriority: () => cy.getByTestId('process_type'),
+    AttachmentsWidget: () => cy.getByTestId('attachments-widget'),
+    AttachmentsOpenModalButton: () => cy.getByTestId('attachments-open-modal'),
+    AttachmentsPanel: () => cy.getByTestId('attachments-panel'),
+    AttachmentsFileInput: () => cy.getByTestId('attachments-file-input'),
+    AttachmentsSubmitButton: () => cy.getByTestId('attachments-submit'),
+    AttachmentsList: (options = {}) => cy.getByTestId('attachments-list', options),
+    AttachmentsRemoveButtonForFile: (filename) => Components.AttachmentsList()
+        .contains(filename)
+        .parents('[data-testid="attached-file-row"]')
+        .first()
+        .find('[data-testid="attachments-remove"]'),
+    AttachmentsRemoveConfirmButton: () => cy.getByTestId('attachments-remove-confirm'),
     DeleteTemplateButton: () => cy.contains('a', 'Delete this template'), 
     TextDirectionCheckbox: () => cy.getByTestId('template-rtl'),
     AddRecipientsButton: () => cy.getByTestId('add-recipients'),
@@ -83,6 +95,28 @@ let Actions = {
     },
     SelectTemplateCategory: (category) => {
         Components.TemplateCategories().contains('label', category).click();
+    },
+    OpenAttachmentsModal: () => {
+        Components.AttachmentsOpenModalButton().click();
+        Components.AttachmentsPanel().should('be.visible');
+    },
+    AttachFile: (fileName, fixtureName = "cds2.png", mimeType = "image/png") => {
+        cy.fixture(fixtureName, "base64").then((fileContent) => {
+            Components.AttachmentsFileInput().selectFile(
+                {
+                    contents: Cypress.Buffer.from(fileContent, "base64"),
+                    fileName: fileName,
+                    mimeType: mimeType,
+                },
+                { force: true },
+            );
+        });
+
+        Components.AttachmentsSubmitButton().click();
+    },
+    RemoveAttachedFile: (fileName) => {
+        Components.AttachmentsRemoveButtonForFile(fileName).click();
+        Components.AttachmentsRemoveConfirmButton().should('be.visible').click();
     },
     SetTemplatePriority: (priority) => {
         cy.getByTestId(priority).click();

--- a/tests_cypress/cypress/e2e/admin/template/attachments.cy.js
+++ b/tests_cypress/cypress/e2e/admin/template/attachments.cy.js
@@ -8,6 +8,7 @@ const ServiceSettingsPage = Pages.ServiceSettingsPage;
 const CYPRESS_SERVICE_ID = getServiceID("CYPRESS");
 const EMAIL_TEMPLATE_ID = getTemplateID("SMOKE_TEST_EMAIL");
 const TEMPLATE_VIEW_PATH = `/services/${CYPRESS_SERVICE_ID}/templates/${EMAIL_TEMPLATE_ID}`;
+const TEST_ATTACHMENT_FILE_NAME = "smoke-test-attachment-e2e.png";
 
 const scanCurrentState = () => {
   cy.a11yScan(false, {
@@ -26,16 +27,38 @@ const setAllowFileAttachments = (enabled) => {
   ServiceSettingsPage.Components.MessageBanner().contains("Setting updated");
 };
 
+const removeAttachmentIfPresent = (fileName) => {
+  cy.visit(TEMPLATE_VIEW_PATH);
+
+  cy.get("body").then(($body) => {
+    if (!$body.find("[data-testid='attachments-list']").length) {
+      return;
+    }
+
+    Page.Components.AttachmentsList().then(($list) => {
+      if (!$list.text().includes(fileName)) {
+        return;
+      }
+
+      cy.intercept("POST", "**/attachments/remove/**").as("cleanupRemoveAttachment");
+      Page.RemoveAttachedFile(fileName);
+      cy.wait("@cleanupRemoveAttachment").its("response.statusCode").should("eq", 204);
+    });
+  });
+};
+
 describe("Template attachments", () => {
   beforeEach(() => {
     cy.loginAsPlatformAdmin();
     setAllowFileAttachments(true);
+    removeAttachmentIfPresent(TEST_ATTACHMENT_FILE_NAME);
     cy.visit(`/services/${CYPRESS_SERVICE_ID}/templates`);
   });
 
   afterEach(() => {
     // Keep baseline permission enabled for any dependent tests.
     setAllowFileAttachments(true);
+    removeAttachmentIfPresent(TEST_ATTACHMENT_FILE_NAME);
   });
 
   it("shows and hides attachments widget based on Send files by email setting", () => {
@@ -50,8 +73,8 @@ describe("Template attachments", () => {
     Page.Components.AttachmentsWidget().should("be.visible");
   });
 
-  it("attaches and removes a file on an existing template", () => {
-    const attachmentFileName = `smoke-test-attachment-${Date.now()}.png`;
+  it.only("attaches and removes a file on an existing template", () => {
+    const attachmentFileName = TEST_ATTACHMENT_FILE_NAME;
 
     Page.SelectTemplateById(CYPRESS_SERVICE_ID, EMAIL_TEMPLATE_ID);
     Page.Components.AttachmentsWidget().should("be.visible");

--- a/tests_cypress/cypress/e2e/admin/template/attachments.cy.js
+++ b/tests_cypress/cypress/e2e/admin/template/attachments.cy.js
@@ -4,8 +4,10 @@ import Pages from "../../../Notify/Admin/Pages/all";
 import { getServiceID, getTemplateID } from "../../../support/utils";
 
 const Page = Pages.TemplatesPage;
+const ServiceSettingsPage = Pages.ServiceSettingsPage;
 const CYPRESS_SERVICE_ID = getServiceID("CYPRESS");
 const EMAIL_TEMPLATE_ID = getTemplateID("SMOKE_TEST_EMAIL");
+const TEMPLATE_VIEW_PATH = `/services/${CYPRESS_SERVICE_ID}/templates/${EMAIL_TEMPLATE_ID}`;
 
 const scanCurrentState = () => {
   cy.a11yScan(false, {
@@ -17,10 +19,35 @@ const scanCurrentState = () => {
   });
 };
 
+const setAllowFileAttachments = (enabled) => {
+  ServiceSettingsPage.VisitFileAttachmentsSettingPage(CYPRESS_SERVICE_ID);
+  ServiceSettingsPage.SetAllowFileAttachments(enabled);
+  ServiceSettingsPage.SaveFileAttachmentsSetting();
+  ServiceSettingsPage.Components.MessageBanner().contains("Setting updated");
+};
+
 describe("Template attachments", () => {
   beforeEach(() => {
     cy.loginAsPlatformAdmin();
+    setAllowFileAttachments(true);
     cy.visit(`/services/${CYPRESS_SERVICE_ID}/templates`);
+  });
+
+  afterEach(() => {
+    // Keep baseline permission enabled for any dependent tests.
+    setAllowFileAttachments(true);
+  });
+
+  it("shows and hides attachments widget based on Send files by email setting", () => {
+    setAllowFileAttachments(false);
+
+    cy.visit(TEMPLATE_VIEW_PATH);
+    Page.Components.AttachmentsWidget().should("not.exist");
+
+    setAllowFileAttachments(true);
+
+    cy.visit(TEMPLATE_VIEW_PATH);
+    Page.Components.AttachmentsWidget().should("be.visible");
   });
 
   it("attaches and removes a file on an existing template", () => {
@@ -38,9 +65,6 @@ describe("Template attachments", () => {
     Page.Components.AttachmentsList({ timeout: 10000 })
       .contains(attachmentFileName)
       .should("exist");
-    cy.getByTestId("attachment-row-spinner", { timeout: 10000 }).should(
-      "not.exist",
-    );
     scanCurrentState();
 
     cy.intercept("POST", "**/attachments/remove/**").as("removeAttachment");

--- a/tests_cypress/cypress/e2e/admin/template/attachments.cy.js
+++ b/tests_cypress/cypress/e2e/admin/template/attachments.cy.js
@@ -40,9 +40,13 @@ const removeAttachmentIfPresent = (fileName) => {
         return;
       }
 
-      cy.intercept("POST", "**/attachments/remove/**").as("cleanupRemoveAttachment");
+      cy.intercept("POST", "**/attachments/remove/**").as(
+        "cleanupRemoveAttachment",
+      );
       Page.RemoveAttachedFile(fileName);
-      cy.wait("@cleanupRemoveAttachment").its("response.statusCode").should("eq", 204);
+      cy.wait("@cleanupRemoveAttachment")
+        .its("response.statusCode")
+        .should("eq", 204);
     });
   });
 };

--- a/tests_cypress/cypress/e2e/admin/template/attachments.cy.js
+++ b/tests_cypress/cypress/e2e/admin/template/attachments.cy.js
@@ -1,0 +1,54 @@
+/// <reference types="cypress" />
+
+import Pages from "../../../Notify/Admin/Pages/all";
+import { getServiceID, getTemplateID } from "../../../support/utils";
+
+const Page = Pages.TemplatesPage;
+const CYPRESS_SERVICE_ID = getServiceID("CYPRESS");
+const EMAIL_TEMPLATE_ID = getTemplateID("SMOKE_TEST_EMAIL");
+
+const scanCurrentState = () => {
+  cy.a11yScan(false, {
+    a11y: true,
+    htmlValidate: false,
+    deadLinks: false,
+    mimeTypes: false,
+    axeConfig: false,
+  });
+};
+
+describe("Template attachments", () => {
+  beforeEach(() => {
+    cy.loginAsPlatformAdmin();
+    cy.visit(`/services/${CYPRESS_SERVICE_ID}/templates`);
+  });
+
+  it("attaches and removes a file on an existing template", () => {
+    const attachmentFileName = `smoke-test-attachment-${Date.now()}.png`;
+
+    Page.SelectTemplateById(CYPRESS_SERVICE_ID, EMAIL_TEMPLATE_ID);
+    Page.Components.AttachmentsWidget().should("be.visible");
+    scanCurrentState();
+
+    Page.OpenAttachmentsModal();
+    scanCurrentState();
+
+    Page.AttachFile(attachmentFileName);
+
+    Page.Components.AttachmentsList({ timeout: 10000 })
+      .contains(attachmentFileName)
+      .should("exist");
+    cy.getByTestId("attachment-row-spinner", { timeout: 10000 }).should(
+      "not.exist",
+    );
+    scanCurrentState();
+
+    cy.intercept("POST", "**/attachments/remove/**").as("removeAttachment");
+    Page.RemoveAttachedFile(attachmentFileName);
+    cy.wait("@removeAttachment").its("response.statusCode").should("eq", 204);
+
+    Page.Components.AttachmentsList().should("not.exist");
+
+    scanCurrentState();
+  });
+});


### PR DESCRIPTION
# Summary | Résumé
This pull request integrates the new files api into admin and hooks it up to the file attachment component. A new feature flag, `FF_FILE_ATTACHMENTS`, is introduced to gate the behaviour. 4 main things are done in this PR:

1. Backend integration: added the `file_api_client` integration class and wired it by adding new routes to `templates.py`
   - Files: [templates.py](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-ab6836e1de1ae35fdbf46e68b40e71ca658c734751950019b2c08aba9c4084a1), [file_api_client.py](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-874d741183f2c66fe28122ed7fde0c0584a6628b4cca03b195cadfaadb6ee89b), [service.py](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-d174b115f53d712c37e9a1c5586e9e0738d3a8bea9e906fdc64bb32bc2f09097), [__init__.py](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-9cec7b11237bc29d77a439e81c9b7acfac003d8e8855731eb6bc130b5a8ce602)

2. Component refactor: update attachment component to make it simpler to pass in the necessary routes (`attachEndpoint`,  `removeEndpoint`, `statusEndpoint`, `downloadEndpoint`), updated storybook to suit.
   - Component files: [AttachedFileRow.js](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-5705002889f9feced2cb8ab66e4bd750e76ac2567882927612271c7d73ebf6eb), [attachments.js](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-e9e7a54e0903f71b1f7be27d8fd6a8d93045d626aced555c66ade105bcf7cd6d), [AttachmentsWidget.js](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-4689b069b8c22f8dec4abb8c023eb06da10135aa4753fac39703bf7b4d1eb471), [useAttachments.js](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-5970c8433c99559c14fd76fb66fe6181b06b9987c01c06f2048d844c4fbd8d18), [components/attachments.html](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-0b7cf8fea7772306fcaec19e203355cc4d2ebb86691719c95135d3af987c2d6e)
   - Storybook files: [storybook.py‎](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-dc4e07f502c14e1c64fe8a445324418d264ef05fbee7b58bbf7bc0ed21f0c93e), [storybook/attachments.html‎](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-596ee8cea32802b3061d1d80a7f2bf7bf030978a9815dbd921b349fb460e9bac)

3. Component integration: added the component to the template page:
   - Files: [template.html](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-2af1946a77b42882ae8ba016b452f35f851d020cbc0c4c37cb1a50bd09cbb032)

4. Test suites: added unit tests and integration tests
   - Unit tests: [test_templates.py](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-9a3a99773cfb7ebcdd7ed7a5e49503ca67d08fca8e7a09b6ac7f1a616ef313f2), [test_file_api_client.py](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-e795b3e2165dfa464622a5c8c037f054f40c252263a45773e125c39fdc4b0d17), [attachments.test.js‎](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-793c65abe10a072788f555e3fa11a7af705c349472fd6e32d657a9db18f700dd), [conftest.py‎](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128)
   - Integration tests: [attachments.cy.js](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-3e21114015202cb4ac87133c610ff31343cfb47713d981dbfcfc97252129aab6), [TemplatesPage.js](https://github.com/cds-snc/notification-admin/pull/2702/changes#diff-dc2df81bdbd014ba5557d4f4d90191bf4384172ecc08675440ad61dd3a85919a)



# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
