### PR TITLE
Adding GC freeze when using preload_app

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -71,15 +71,17 @@ def on_starting(server):
     server.log.info("Starting Notifications Admin")
 
 
-def post_fork(server, worker):
-    # Freeze all GC-tracked objects that were loaded during preload_app into the
-    # permanent generation. This prevents the GC from touching (and thus dirtying)
-    # copy-on-write memory pages shared between workers, which would otherwise cause
-    # each worker's RSS to grow monotonically even under low traffic.
+def when_ready(server):
+    # Freeze all GC-tracked objects into the permanent generation while still in the
+    # master process, before any workers are forked. This preserves copy-on-write
+    # sharing of preloaded app memory across workers — the GC will never scan frozen
+    # objects, so their reference counts won't be touched and the OS pages stay shared.
+    # Must run in the master (here) rather than post_fork, because calling gc.freeze()
+    # in a worker would itself dirty CoW pages after the fork.
     # https://docs.python.org/3/library/gc.html#gc.freeze
     if preload_app:
         gc.freeze()
-        server.log.info(f"[worker {worker.pid}] GC frozen: {gc.get_freeze_count()} objects")
+        server.log.info(f"GC frozen in master: {gc.get_freeze_count()} objects")
 
 
 def worker_abort(worker):

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import sys
 import time
@@ -68,6 +69,17 @@ start_time = time.time()
 
 def on_starting(server):
     server.log.info("Starting Notifications Admin")
+
+
+def post_fork(server, worker):
+    # Freeze all GC-tracked objects that were loaded during preload_app into the
+    # permanent generation. This prevents the GC from touching (and thus dirtying)
+    # copy-on-write memory pages shared between workers, which would otherwise cause
+    # each worker's RSS to grow monotonically even under low traffic.
+    # https://docs.python.org/3/library/gc.html#gc.freeze
+    if preload_app:
+        gc.freeze()
+        server.log.info(f"[worker {worker.pid}] GC frozen: {gc.get_freeze_count()} objects")
 
 
 def worker_abort(worker):


### PR DESCRIPTION
# Summary | Résumé

The admin app uses a lot of memory in k8s. I have already enabled preload_app in dev and staging which greatly reduces the startup memory usage of the admin (cut by 80%) but as it serves requests, it still grows to about 1gb. This is likely because garbage collection is dirtying the shared memory causing copy-on-writes which basically takes what was once shared memory and duplicating it for each worker. This should hopefully prevent that from happening and keep the shared resources shared.

Note that preload_app is only enabled in dev and staging for now, so this will not affect production.

# Test instructions | Instructions pour tester la modification

Merge to main, let the admin sit for a while in staging and see what the memory usage is. Anything less than 1GB is an improvement.