### PR TITLE
fix mounting issue

### DIFF
--- a/app/assets/javascripts/tiptap/SimpleEditor.js
+++ b/app/assets/javascripts/tiptap/SimpleEditor.js
@@ -32,6 +32,25 @@ import { EditorProvider } from "./EditorContext";
 import { AnnouncerPlugin } from "./AnnouncerPlugin";
 import { shortcuts, translations } from "./localization";
 
+// In TipTap 3, `editor.view` returns a Proxy stub (which is truthy) until the
+// underlying ProseMirror view is actually mounted. Accessing most properties on
+// that stub — e.g. `dom`, `coordsAtPos`, `posAtDOM` — THROWS:
+//   "[tiptap error]: The editor view is not available. Cannot access
+//    view['dom']. The editor may not be mounted yet."
+// Optional chaining (`editor?.view?.dom`) does NOT protect against this because
+// the `.dom` getter on the stub is what throws. Effects can run after the
+// editor instance exists but before its view is mounted (timing-dependent,
+// which is why this surfaces intermittently on some browsers), so we must guard
+// every real view access with this helper.
+const isEditorViewMounted = (editor) => {
+  if (!editor || editor.isDestroyed) return false;
+  try {
+    return !!editor.view?.dom;
+  } catch {
+    return false;
+  }
+};
+
 const SimpleEditor = ({
   inputId,
   labelId,
@@ -237,7 +256,7 @@ const SimpleEditor = ({
       // Prefer TipTap's view coordsAtPos if available — it's reliable for
       // collapsed selections and complex node structures.
       const sel = editor?.state?.selection;
-      if (editor?.view && sel) {
+      if (isEditorViewMounted(editor) && sel) {
         const pos = sel.from;
         const coords = editor.view.coordsAtPos(pos);
         if (coords) {
@@ -289,7 +308,9 @@ const SimpleEditor = ({
       // If anything goes wrong computing the rect, fall back to opening
       // the modal roughly in the editor area (center top) so it remains usable.
       try {
-        const edRect = editor?.view?.dom?.getBoundingClientRect?.();
+        const edRect = isEditorViewMounted(editor)
+          ? editor.view.dom.getBoundingClientRect?.()
+          : null;
         const left = (edRect?.left || 0) + 20;
         const top = (edRect?.top || 0) + 40;
         setModalPosition({ top, left });
@@ -306,7 +327,7 @@ const SimpleEditor = ({
   const computeModalPosition = () => {
     try {
       const selState = editor?.state?.selection;
-      if (editor?.view && selState) {
+      if (isEditorViewMounted(editor) && selState) {
         const pos = selState.from;
         const coords = editor.view.coordsAtPos(pos);
         if (coords) {
@@ -400,7 +421,7 @@ const SimpleEditor = ({
   // select-all matches mouse select-all for block toggles.
   // Hopefully tiptap will fix this upstream one day! (https://github.com/ueberdosis/tiptap/issues/6260)
   React.useEffect(() => {
-    if (!editor || !editor.view || !editor.view.dom) return;
+    if (!isEditorViewMounted(editor)) return;
     const dom = editor.view.dom;
 
     const onCaptureKeyDown = (e) => {
@@ -453,7 +474,12 @@ const SimpleEditor = ({
 
     dom.addEventListener("keydown", onCaptureKeyDown, true);
     return () => dom.removeEventListener("keydown", onCaptureKeyDown, true);
-  }, [editor]);
+    // `isMarkdownView` is a dependency because the ProseMirror view is only
+    // mounted while the RTE (EditorContent) is rendered. When starting in — or
+    // switching to — markdown mode the view is unmounted, so this effect must
+    // re-run when the mode changes to (re)attach the listener once the view is
+    // available again.
+  }, [editor, isMarkdownView]);
 
   // Update hidden input field when content changes
   React.useEffect(() => {

--- a/tests_cypress/cypress/Notify/Admin/Pages/TemplatesPage.js
+++ b/tests_cypress/cypress/Notify/Admin/Pages/TemplatesPage.js
@@ -15,6 +15,11 @@ let Components = {
     // edit template page
     TemplateName: () => cy.getByTestId('template-name'),
     TemplateContent: () => cy.getByTestId('template-content'),
+    // The email editor renders one of two content surfaces depending on the
+    // user's editor preference: the markdown textarea (`template-content`) or
+    // the rich text editor's contenteditable (`rte-editor`). SMS templates
+    // always render the `template-content` textarea.
+    RteEditor: () => cy.getByTestId('rte-editor').find('[contenteditable]').first(),
     TemplateSubject: () => cy.get('textarea[name=subject]'),
     FlashMessage: () => cy.get('.banner-default-with-tick'),
     TemplateCategoryButtonContainer: () => cy.getByTestId('tc_button_container'),
@@ -121,12 +126,27 @@ let Actions = {
     SetTemplatePriority: (priority) => {
         cy.getByTestId(priority).click();
     },
+    EnterTemplateContent: (content) => {
+        // Type into whichever content surface is rendered. When the user's
+        // editor preference is RTE (the default for new accounts), the markdown
+        // `template-content` textarea is not present and we type into the rich
+        // text editor's contenteditable instead. Wait for one of the two
+        // surfaces to mount first so we don't branch before React has rendered.
+        cy.get('[data-testid=template-content], [data-testid=rte-editor]').should('exist');
+        cy.get('body').then(($body) => {
+            if ($body.find('[data-testid=template-content]').length) {
+                Components.TemplateContent().type(content);
+            } else {
+                Components.RteEditor().type(content);
+            }
+        });
+    },
     FillTemplateForm: (name, subject, content, category = null, priority = null) => {
         Components.TemplateName().type(name);
         if (subject) {
             Components.TemplateSubject().type(subject);
         }
-        Components.TemplateContent().type(content);
+        Actions.EnterTemplateContent(content);
         if (category) {
             Actions.SelectTemplateCategory(category);
         }


### PR DESCRIPTION
## Bug:

https://cds-snc.freshdesk.com/a/tickets/29015
A client reported the tiptap editor wasnt loading

## Root cause
In TipTap 3 , editor.view is a getter that returns a Proxy stub — not undefined — until the underlying ProseMirror view is actually mounted. Accessing most properties on that stub (like dom, coordsAtPos, posAtDOM) throws:

[tiptap error]: The editor view is not available. Cannot access view['dom']. The editor may not be mounted yet.

Crucially, optional chaining like editor?.view?.dom does not protect against this, because editor?.view succeeds (returns the truthy Proxy) and it's the .dom access on the stub that throws.

The specific trigger: in SimpleEditor.js:403 the RTE (EditorContent) is only rendered in RTE mode. When a user's preferred editor is markdown (initialMode="markdown"), EditorContent is never mounted, so the view never exists. An effect then ran if (!editor || !editor.view || !editor.view.dom) return; — the editor.view.dom check itself threw instead of returning early. This is timing/config dependent, which is why it surfaced intermittently (e.g. Firefox on Windows).

## Fix
In SimpleEditor.js:

1. Added a module-level helper isEditorViewMounted(editor) that safely detects whether the real ProseMirror view is mounted (wrapping the access in try/catch so the throwing getter can't leak).
2. Replaced the unsafe guards (if (editor?.view && …), !editor.view.dom, editor?.view?.dom?.getBoundingClientRect?.()) with that helper.
3. Added isMarkdownView to the select-all effect's dependencies so the keyboard handler correctly re-attaches when the user switches from markdown back to RTE mode (when the view remounts) — otherwise it would never re-run since editor stays the same instance.