### PR TITLE
Fix/add service stick css

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,0 @@
-{
-  "features": {
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "1.7.1",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
-      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
-    }
-  }
-}

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -6,6 +6,7 @@
   organisations=[],
   services=[]
 ) %}
+  <div class="keyline-block"></div>
   {% if show_heading %}
     <div class="grid-row contain-floats">
       <div class="md:w-1/4 float-left py-0 px-0 px-gutterHalf box-border">
@@ -57,7 +58,7 @@
     {{ _('Your services') }}
   </h1>
 
-  <nav class="browse-list {% if current_user.has_access_to_live_and_trial_mode_services %}mt-8 block clear-both contain-floats{% endif %}" aria-label="{{ _('Your services') }}">
+  <nav class="browse-list {% if current_user.has_access_to_live_and_trial_mode_services %}mt-8 mb-0 block clear-both contain-floats{% endif %}" aria-label="{{ _('Your services') }}">
 
     {% if current_user.platform_admin %}
       <div class="grid-row contain-floats">
@@ -75,7 +76,6 @@
           </li>
         </ul>
       </div>
-      <div class="keyline-block"></div>
     {% endif %}
     {% set heading_txt = _('Live services') %}
     {% if current_user.organisations %}

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -32,6 +32,36 @@
     <li class="browse-list-item">
       <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
     </li>
+    <li class="browse-list-item">
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
+    </li>
+    <li class="browse-list-item">
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
+    </li>
+    <li class="browse-list-item">
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
+    </li>
+    <li class="browse-list-item">
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
+    </li>
+    <li class="browse-list-item">
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
+    </li>
+    <li class="browse-list-item">
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
+    </li>
+    <li class="browse-list-item">
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
+    </li>
+    <li class="browse-list-item">
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
+    </li>
+    <li class="browse-list-item">
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
+    </li>
+    <li class="browse-list-item">
+      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
+    </li>
   {% endfor %}
   {% if show_heading %}
         </ul>
@@ -41,11 +71,10 @@
     </ul>
   {% endif %}
   {% if show_add_service_button %}
-    <div class="js-stick-at-bottom-when-scrolling">
+    <div class="sticky bottom-0 pt-gutterHalf bg-white border-t-1 border-gray-300">
       <a href="{{ url_for('.add_service') }}" class="button button-secondary">{{ _('Add new service') }}</a>
     </div>
   {% endif %}
-  <div class="keyline-block"></div>
 {% endmacro %}
 
 {% block per_page_title %}
@@ -105,7 +134,7 @@
   </nav>
 
   {% if can_add_service %}
-    <div class="js-stick-at-bottom-when-scrolling">
+    <div class="sticky bottom-0 pt-gutterHalf bg-white border-t-1 border-gray-300">
       {% if current_user.has_access_to_live_and_trial_mode_services %}
         <div class="grid-row contain-floats">
           <div class="md:w-1/4 float-left py-0 px-0 px-gutterHalf box-border">

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -32,36 +32,6 @@
     <li class="browse-list-item">
       <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
     </li>
-    <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
-    </li>
-    <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
-    </li>
-    <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
-    </li>
-    <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
-    </li>
-    <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
-    </li>
-    <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
-    </li>
-    <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
-    </li>
-    <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
-    </li>
-    <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
-    </li>
-    <li class="browse-list-item">
-      <a href="{{ url_for('.service_dashboard', service_id=service.id) }}" class="browse-list-link">{{ service.name }}</a>
-    </li>
   {% endfor %}
   {% if show_heading %}
         </ul>

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -8,13 +8,13 @@
 ) %}
   <div class="keyline-block"></div>
   {% if show_heading %}
-    <div class="grid-row contain-floats">
-      <div class="md:w-1/4 float-left py-0 px-0 px-gutterHalf box-border">
+    <div class="items-baseline flex flex-col md:flex-row gap-gutter gap-y-gutterHalf">
+      <div class="md:w-1/4">
         <h2>
           {{ heading }}
         </h2>
       </div>
-      <div class="md:w-3/4 float-left py-0 px-0 px-gutterHalf box-border">
+      <div class="md:w-3/4">
         <ul>
   {% else %}
     <ul>
@@ -61,13 +61,13 @@
   <nav class="browse-list {% if current_user.has_access_to_live_and_trial_mode_services %}mt-8 mb-0 block clear-both contain-floats{% endif %}" aria-label="{{ _('Your services') }}">
 
     {% if current_user.platform_admin %}
-      <div class="grid-row contain-floats">
-        <div class="md:w-1/4 float-left py-0 px-0 px-gutterHalf box-border">
+      <div class="items-baseline flex flex-col md:flex-row gap-gutter gap-y-gutterHalf">
+        <div class="md:w-1/4">
           <h2>
             {{ _('Admin panel') }}
           </h2>
         </div>
-        <ul class="md:w-3/4 float-left py-0 px-0 px-gutterHalf box-border">
+        <ul class="md:w-3/4">
           <li class="browse-list-item">
             <a href="{{ url_for('.organisations') }}" class="browse-list-link">{{ _('All organisations') }}</a>
             <p class="browse-list-hint">
@@ -106,11 +106,11 @@
   {% if can_add_service %}
     <div class="sticky bottom-0 py-gutterHalf bg-white border-t-1 border-gray-300">
       {% if current_user.has_access_to_live_and_trial_mode_services %}
-        <div class="grid-row contain-floats">
-          <div class="md:w-1/4 float-left py-0 px-0 px-gutterHalf box-border">
+        <div class="items-baseline flex flex-col md:flex-row gap-gutter gap-y-gutterHalf">
+          <div class="hidden md:block md:w-1/4">
             &nbsp;
           </div>
-          <div class="float-left py-0 px-gutterHalf box-border">
+          <div class="md:w-3/4">
       {% endif %}
       <a href="{{ url_for('.add_service') }}" class="button button-secondary">{{ _('Add new service') }}</a>
       {% if current_user.has_access_to_live_and_trial_mode_services %}
@@ -120,7 +120,7 @@
     </div>
   {% endif %}
 
-  <div class="grid-row contain-floats py-10 px-6">
+  <div class="py-10">
     <p data-testid="guidance-join-existing-service">{{ _("To join an existing service, check your email for an invitation from the team for that service.  GC Notify staff cannot send these invitations.") }}</p>
     <details data-testid="details-join-existing-service">
       <summary class="flex gap-10 py-2">{{ _("If you do not have an invitation") }}</summary>

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -137,6 +137,9 @@
     <div class="sticky bottom-0 pt-gutterHalf bg-white border-t-1 border-gray-300">
       {% if current_user.has_access_to_live_and_trial_mode_services %}
         <div class="grid-row contain-floats">
+          <div class="md:w-1/4 float-left py-0 px-0 px-gutterHalf box-border">
+            &nbsp;
+          </div>
           <div class="float-left py-0 px-gutterHalf box-border">
       {% endif %}
       <a href="{{ url_for('.add_service') }}" class="button button-secondary">{{ _('Add new service') }}</a>

--- a/app/templates/views/choose-account.html
+++ b/app/templates/views/choose-account.html
@@ -42,7 +42,7 @@
     </ul>
   {% endif %}
   {% if show_add_service_button %}
-    <div class="sticky bottom-0 pt-gutterHalf bg-white border-t-1 border-gray-300">
+    <div class="sticky bottom-0 py-gutterHalf bg-white border-t-1 border-gray-300">
       <a href="{{ url_for('.add_service') }}" class="button button-secondary">{{ _('Add new service') }}</a>
     </div>
   {% endif %}
@@ -104,7 +104,7 @@
   </nav>
 
   {% if can_add_service %}
-    <div class="sticky bottom-0 pt-gutterHalf bg-white border-t-1 border-gray-300">
+    <div class="sticky bottom-0 py-gutterHalf bg-white border-t-1 border-gray-300">
       {% if current_user.has_access_to_live_and_trial_mode_services %}
         <div class="grid-row contain-floats">
           <div class="md:w-1/4 float-left py-0 px-0 px-gutterHalf box-border">


### PR DESCRIPTION
# Summary | Résumé

Use CSS sticky positioning instead of JavaScript on the account page. 

# Test instructions | Instructions pour tester la modification

- Check the main screen where you can add a service
- When you have multiple services (you can fake it by duplicating some li nodes)
- The button sticks at the bottom, and un-sticks only when you reach the end of the list


https://github.com/user-attachments/assets/93b234ef-cff6-4d84-a5ec-ce0a4959ec1d

