### PR TITLE
Add log statements related to ui attachments

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -1110,6 +1110,20 @@ def start_job(service_id, upload_id):
     # "warning shown" log lines (issue #3319). We read this before creating the
     # job so that a failure here can't block a send.
     upload_metadata = get_csv_metadata(service_id, upload_id)
+
+    if upload_metadata.get("template_attach_personalisation"):
+        template_attach = json.loads(upload_metadata["template_attach_personalisation"])
+        current_app.logger.info(
+            "template_attachment.bulk_send",
+            extra={
+                "service_id": str(service_id),
+                "template_id": upload_metadata.get("template_id"),
+                "upload_id": upload_id,
+                "attachment_count": len(template_attach),
+                "notification_count": int(upload_metadata.get("notification_count", 0) or 0),
+            },
+        )
+
     count_of_duplicate_recipients = int(upload_metadata.get("count_of_duplicate_recipients", 0) or 0)
     if count_of_duplicate_recipients:
         current_app.logger.info(
@@ -1405,10 +1419,21 @@ def send_notification(service_id, template_id):
 
     db_template = current_service.get_template_with_user_permission_or_403(template_id, current_user)
 
+    template_attachments = build_template_attachment_personalisation(db_template["id"], db_template["template_type"])
     personalisation = {
         **session["placeholders"],
-        **build_template_attachment_personalisation(db_template["id"], db_template["template_type"]),
+        **template_attachments,
     }
+
+    if template_attachments:
+        current_app.logger.info(
+            "template_attachment.one_off_send",
+            extra={
+                "service_id": str(service_id),
+                "template_id": str(template_id),
+                "attachment_count": len(template_attachments),
+            },
+        )
 
     try:
         noti = notification_api_client.send_notification(

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -280,6 +280,14 @@ def remove_files(service_id, template_id, file_id=None):
         abort(400)
 
     file_api_client.delete_file(template_id, file_id)
+    current_app.logger.info(
+        "template_attachment.file_removed_from_template",
+        extra={
+            "service_id": service_id,
+            "template_id": str(template_id),
+            "file_id": file_id,
+        },
+    )
     return ("", 204)
 
 


### PR DESCRIPTION
# Summary | Résumé

Add log statements related to ui attachments

Working on https://github.com/cds-snc/notification-planning/issues/3328

These logs are to help us answer the following questions: https://docs.google.com/document/d/1BjMNRF7b1cAlCZlUd8ka9dsEFV4QKJQ6poMIcaRkgng/edit?tab=t.0

# Test instructions | Instructions pour tester la modification

We will have to test this later once the feature is working end-to-end.

Here are the steps we can use at that point:
1. check out the branch locally
2. set `FF_FILE_ATTACHMENTS=true` in your local .env file
3. go through the flow to add and remove a ui file attachment, verify you see the `template_attachment.file_removed_from_template` log
4. do a one-off send of a template with a ui file attachment, verify you see the `template_attachment.one_off_send` log
5. do a bulk send of a template with a ui file attachment, verify you see the `template_attachment.bulk` log