### PR TITLE
Feat/attachment UI updates

### DIFF
--- a/app/assets/javascripts/attachments/AttachFilesModal.js
+++ b/app/assets/javascripts/attachments/AttachFilesModal.js
@@ -17,6 +17,7 @@ export const AttachFilesModal = ({
 }) => {
   const [selectedFiles, setSelectedFiles] = useState([]);
   const [isAnimatingOpen, setIsAnimatingOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const dialogRef = useRef(null);
   const headingRef = useRef(null);
   const previouslyFocusedElement = useRef(null);
@@ -127,8 +128,13 @@ export const AttachFilesModal = ({
     );
   };
 
-  const submit = () => {
-    onAttach(selectedFiles.map((pendingFile) => pendingFile.file));
+  const submit = async () => {
+    setIsLoading(true);
+    try {
+      await Promise.resolve(onAttach(selectedFiles.map((pendingFile) => pendingFile.file)));
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const onPanelKeyDown = (event) => {
@@ -245,10 +251,18 @@ export const AttachFilesModal = ({
       <div className="flex gap-4 items-center">
         <button
           type="button"
-          className="button"
+          className={`button ${isLoading ? "bg-gray-400 hover:bg-gray-400 cursor-wait" : ""}`}
           data-testid="attachments-submit"
           onClick={submit}
+          aria-disabled={isLoading}
         >
+          {isLoading && (
+            <div
+              className="loading-spinner shrink-0 mr-2 inline-block"
+              role="status"
+              aria-label={copy.rowSpinnerAriaLabel}
+            />
+          )}
           {copy.modalAttachToTemplate}
         </button>
         <button
@@ -256,6 +270,7 @@ export const AttachFilesModal = ({
           className="button button-secondary text-base"
           data-testid="attachments-cancel"
           onClick={onClose}
+          disabled={isLoading}
         >
           {copy.cancel}
         </button>

--- a/app/assets/javascripts/attachments/AttachFilesModal.js
+++ b/app/assets/javascripts/attachments/AttachFilesModal.js
@@ -131,7 +131,9 @@ export const AttachFilesModal = ({
   const submit = async () => {
     setIsLoading(true);
     try {
-      await Promise.resolve(onAttach(selectedFiles.map((pendingFile) => pendingFile.file)));
+      await Promise.resolve(
+        onAttach(selectedFiles.map((pendingFile) => pendingFile.file)),
+      );
     } finally {
       setIsLoading(false);
     }

--- a/app/assets/javascripts/attachments/AttachFilesModal.js
+++ b/app/assets/javascripts/attachments/AttachFilesModal.js
@@ -251,10 +251,14 @@ export const AttachFilesModal = ({
       <div className="flex gap-4 items-center">
         <button
           type="button"
-          className={`button ${isLoading ? "bg-gray-400 hover:bg-gray-400 cursor-wait" : ""}`}
+          className={`button ${
+            isLoading || selectedFiles.length === 0
+              ? "bg-gray-400 hover:bg-gray-400 cursor-wait pointer-events-none"
+              : ""
+          }`}
           data-testid="attachments-submit"
-          onClick={submit}
-          aria-disabled={isLoading}
+          onClick={selectedFiles.length > 0 ? submit : undefined}
+          aria-disabled={isLoading || selectedFiles.length === 0}
         >
           {isLoading && (
             <div


### PR DESCRIPTION
# Summary | Résumé

This pull request improves the user experience of the `AttachFilesModal` component by adding loading state management and visual feedback during file attachment. The main focus is to prevent multiple submissions and provide clear feedback while files are being attached.

# Test instructions | Instructions pour tester la modification
## Loading indicator
- Attach a file to a template
- [x] Ensure a loading indicator is present while files are being uploaded and before being scanned

## Disable attach button
- Open attachment widget
- [x]  Attach button cannot be clicked
- Add files
- [x] Attach button can now be clicked
