### PR TITLE
fix: update submit button logic to disable when issues are present

### DIFF
--- a/app/assets/javascripts/attachments/AttachFilesModal.js
+++ b/app/assets/javascripts/attachments/AttachFilesModal.js
@@ -254,13 +254,17 @@ export const AttachFilesModal = ({
         <button
           type="button"
           className={`button ${
-            isLoading || selectedFiles.length === 0
+            isLoading || selectedFiles.length === 0 || issues.length > 0
               ? "bg-gray-400 hover:bg-gray-400 cursor-wait pointer-events-none"
               : ""
           }`}
           data-testid="attachments-submit"
-          onClick={selectedFiles.length > 0 ? submit : undefined}
-          aria-disabled={isLoading || selectedFiles.length === 0}
+          onClick={
+            selectedFiles.length > 0 && issues.length === 0 ? submit : undefined
+          }
+          aria-disabled={
+            isLoading || selectedFiles.length === 0 || issues.length > 0
+          }
         >
           {isLoading && (
             <div


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the `AttachFilesModal` component to improve user experience and validation when submitting file attachments. The main change is to ensure that the submit button is disabled if there are any issues present, in addition to the existing checks for loading state and file selection.

**User interface and validation improvements:**

* The submit button in `AttachFilesModal.js` is now disabled if there are any issues detected (i.e., if `issues.length > 0`), preventing users from attempting to submit files until all issues are resolved. The button's click handler and `aria-disabled` attribute have been updated accordingly.

# Test instructions | Instructions pour tester la modification
- Choose a file greater than 6mb and try to add it to the template
- [ ] Ensure you see an error
- [ ] Ensure you cannot click the `Attach to template` button
