### PR TITLE
Fix bug with negative "in transit" counts for jobs

### DIFF
--- a/app/main/views/jobs.py
+++ b/app/main/views/jobs.py
@@ -404,7 +404,7 @@ def get_status_filters(service, message_type, statistics):
         }
     else:
         stats = statistics[message_type]
-    stats["sending"] = stats["requested"] - stats["delivered"] - stats["failed"]
+    stats["sending"] = max(0, stats["requested"] - stats["delivered"] - stats["failed"])
 
     filters = [
         # key, label, option
@@ -431,11 +431,20 @@ def get_status_filters(service, message_type, statistics):
 
 
 def _get_job_counts(job):
-    sending = (
-        0
-        if job["job_status"] == "scheduled"
-        else (job.get("notification_count", 0) - job.get("notifications_delivered", 0) - job.get("notifications_failed", 0))
-    )
+    # "in transit" is the number of notifications still being sent. Use the
+    # actual sending/pending/created count from the job statistics rather than
+    # deriving it as (notification_count - delivered - failed): a job can create
+    # more notifications than notification_count (e.g. duplicate rows from task
+    # retries), which made the derived value go negative.
+    if job["job_status"] == "scheduled":
+        sending = 0
+    elif "notifications_sending" in job:
+        sending = job["notifications_sending"]
+    else:
+        sending = max(
+            0,
+            job.get("notification_count", 0) - job.get("notifications_delivered", 0) - job.get("notifications_failed", 0),
+        )
     return [
         (
             label,

--- a/app/notify_client/job_api_client.py
+++ b/app/notify_client/job_api_client.py
@@ -45,6 +45,7 @@ class JobApiClient(NotifyAdminAPIClient):
         job["data"]["notifications_delivered"] = stats["delivered"]
         job["data"]["notifications_failed"] = stats["failed"]
         job["data"]["notifications_requested"] = stats["requested"]
+        job["data"]["notifications_sending"] = stats["sending"]
 
         return job
 
@@ -64,6 +65,7 @@ class JobApiClient(NotifyAdminAPIClient):
             job["notifications_delivered"] = stats["delivered"]
             job["notifications_failed"] = stats["failed"]
             job["notifications_requested"] = stats["requested"]
+            job["notifications_sending"] = stats["sending"]
 
         return jobs
 
@@ -124,6 +126,7 @@ class JobApiClient(NotifyAdminAPIClient):
         job["data"]["notifications_delivered"] = stats["delivered"]
         job["data"]["notifications_failed"] = stats["failed"]
         job["data"]["notifications_requested"] = stats["requested"]
+        job["data"]["notifications_sending"] = stats["sending"]
 
         return job
 
@@ -136,6 +139,7 @@ class JobApiClient(NotifyAdminAPIClient):
         job["data"]["notifications_delivered"] = stats["delivered"]
         job["data"]["notifications_failed"] = stats["failed"]
         job["data"]["notifications_requested"] = stats["requested"]
+        job["data"]["notifications_sending"] = stats["sending"]
 
         return job
 

--- a/app/templates/views/dashboard/_jobs.html
+++ b/app/templates/views/dashboard/_jobs.html
@@ -30,7 +30,7 @@
     {% endcall %}
     {% call field() %}
       {{ big_number(
-        item.get('notification_count', 0) - item.get('notifications_delivered', 0) - item.get('notifications_failed', 0),
+        item.get('notifications_sending', [0, item.get('notification_count', 0) - item.get('notifications_delivered', 0) - item.get('notifications_failed', 0)] | max),
         smallest=True
       ) }}
     {% endcall %}

--- a/tests/app/main/views/test_jobs.py
+++ b/tests/app/main/views/test_jobs.py
@@ -5,6 +5,7 @@ import pytest
 from flask import url_for
 from freezegun import freeze_time
 
+from app.main.views.jobs import _get_job_counts
 from tests import job_json, notification_json, sample_uuid
 from tests.conftest import (
     JOB_API_KEY_NAME,
@@ -15,6 +16,58 @@ from tests.conftest import (
     mock_get_notifications,
     normalize_spaces,
 )
+
+
+@pytest.mark.parametrize(
+    "job, expected_in_transit",
+    [
+        # Uses the actual sending statistic when present.
+        (
+            {
+                "job_status": "finished",
+                "notification_count": 33169,
+                "notifications_delivered": 33006,
+                "notifications_failed": 166,
+                "notifications_sending": 57,
+            },
+            57,
+        ),
+        # Scheduled jobs are always shown as 0 in transit.
+        (
+            {
+                "job_status": "scheduled",
+                "notification_count": 30,
+                "notifications_delivered": 0,
+                "notifications_failed": 0,
+                "notifications_sending": 0,
+            },
+            0,
+        ),
+        # Falls back to the clamped subtraction when no sending stat is available,
+        # and never returns a negative number (delivered + failed can exceed
+        # notification_count when duplicate notifications are created).
+        (
+            {
+                "job_status": "finished",
+                "notification_count": 33169,
+                "notifications_delivered": 33006,
+                "notifications_failed": 166,
+            },
+            0,
+        ),
+        (
+            {"job_status": "finished", "notification_count": 30, "notifications_delivered": 10, "notifications_failed": 5},
+            15,
+        ),
+    ],
+)
+def test_get_job_counts_in_transit(app_, job, expected_in_transit):
+    job = {"service": SERVICE_ONE_ID, "id": "job-id", **job}
+
+    with app_.test_request_context():
+        counts = dict((label, count) for label, _query_param, _link, count in _get_job_counts(job))
+
+    assert counts["in transit"] == expected_in_transit
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary | Résumé

This PR changes the in-transit calculation in admin to use the real number for that status, whereas before it was using a value arrived at by subtracting delivered and failed from the total rows:
```
notification_count − delivered − failed = 33169 − 33006 − 166 = −3
```

Which is wrong when the delivery total includes duplicates.

This is a long-standing bug that we have just received a support ticket for. The underlying problem is that duplicate notifications are sometimes sent for a given job. I have confirmed this by running the following query:

```
select count(id), n.job_row_number
from notifications n 
where n.job_id = '74677119-94f3-4d46-b937-a586c0647e50'
group by n.job_row_number  
order by count(id)
```

and observed that there are 60 rows (out of a 33,169 row job) that have been inserted twice.

Looking at the actual counts with this query:
```
select count(id), n.notification_status
from notifications n 
where n.job_id = '74677119-94f3-4d46-b937-a586c0647e50'
group by n.notification_status 
```
We get:

```
32 temporary-failure
57 sending
134 permanent-failure
33006 delivered
```


I connected my locally running admin to the prod api to verify that the fix works:

Before:
<img width="1093" height="356" alt="Screenshot 2026-07-08 at 3 50 51 PM" src="https://github.com/user-attachments/assets/862519cf-1f49-42c1-8770-528d50e5f8f7" />

After:
<img width="1107" height="215" alt="Screenshot 2026-07-08 at 3 51 36 PM" src="https://github.com/user-attachments/assets/e6618eff-68f4-4ca7-a3f3-a09ab5d2f600" />


# Test instructions | Instructions pour tester la modification

1. check out the branch
2. modify your .env to connect to the prod api
3. visit the following link: http://localhost:6012/services/8cc00648-0b2e-474e-a5a5-9da3c72b2560/jobs/74677119-94f3-4d46-b937-a586c0647e50?status=sending
4. verify that you see the correct (non-negative) total for in transit notifications.