### PR TITLE
feat: implement file download functionality in FileApiClient

### DIFF
--- a/app/assets/javascripts/attachments/AttachedFileRow.js
+++ b/app/assets/javascripts/attachments/AttachedFileRow.js
@@ -12,6 +12,7 @@ export const AttachedFileRow = ({
   onRequestRemove,
   onConfirmRemove,
   onCancelRemove,
+  onDownloadError,
 }) => {
   const isInProgress =
     file.status === ATTACHMENT_STATUSES.UPLOADING ||
@@ -23,10 +24,33 @@ export const AttachedFileRow = ({
     : null;
   const canDownload = !isInProgress && !isMalware && Boolean(downloadHref);
 
+  const handleDownload = async (e) => {
+    e.preventDefault();
+    try {
+      const response = await fetch(downloadHref);
+      if (!response.ok) {
+        throw new Error(`Download failed with status ${response.status}`);
+      }
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = file.name;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      if (typeof onDownloadError === "function") {
+        onDownloadError(file.id, error.message);
+      }
+    }
+  };
+
   const fileNameNode = canDownload ? (
     <a
       href={downloadHref}
-      download={file.name}
+      onClick={handleDownload}
       className="attachment-file-name-truncate"
       title={file.name}
       data-testid="attachment-download-link"

--- a/app/assets/javascripts/attachments/AttachmentsWidget.js
+++ b/app/assets/javascripts/attachments/AttachmentsWidget.js
@@ -21,6 +21,7 @@ export const AttachmentsWidget = ({
   const [isAttachModalOpen, setAttachModalOpen] = useState(false);
   const [validationIssues, setValidationIssues] = useState([]);
   const [removeCandidateId, setRemoveCandidateId] = useState(null);
+  const [downloadError, setDownloadError] = useState(null);
   const copy = useMemo(() => getAttachmentTranslations(lang), [lang]);
 
   const fetchFileStatus = useMemo(() => {
@@ -131,6 +132,16 @@ export const AttachmentsWidget = ({
     <section className="mb-16" data-testid="attachments-widget">
       <h2 className="heading-medium">{copy.attachedFilesHeading}</h2>
 
+      {downloadError && (
+        <div
+          className="banner-dangerous p-4 mb-4"
+          role="alert"
+          data-testid="download-error-message"
+        >
+          <p>{downloadError}</p>
+        </div>
+      )}
+
       {files.length ? (
         <ul className="mt-4 mb-4" data-testid="attachments-list">
           {files.map((file) => (
@@ -158,6 +169,9 @@ export const AttachmentsWidget = ({
                 }
               }}
               onCancelRemove={() => setRemoveCandidateId(null)}
+              onDownloadError={(fileId, error) => {
+                setDownloadError(`Failed to download file. ${error}`);
+              }}
               downloadEndpoint={downloadEndpoint}
               copy={copy}
             />

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -323,6 +323,9 @@ def download_template_attachment(service_id, template_id, file_id=None):
     try:
         file_payload = file_api_client.get_file_contents(template_id, file_id)
     except HTTPError as e:
+        if e.status_code == 409:
+            # File not ready (e.g., virus scan pending)
+            return redirect(url_for("main.view_template", service_id=service_id, template_id=template_id))
         abort(e.status_code)
 
     file_name = file_payload["filename"]

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -320,7 +320,11 @@ def download_template_attachment(service_id, template_id, file_id=None):
     if not file_id:
         abort(400)
 
-    file_payload = file_api_client.get_file_contents(template_id, file_id)
+    try:
+        file_payload = file_api_client.get_file_contents(template_id, file_id)
+    except HTTPError as e:
+        abort(e.status_code)
+
     file_name = file_payload["filename"]
     return Response(
         file_payload["content"],

--- a/app/notify_client/file_api_client.py
+++ b/app/notify_client/file_api_client.py
@@ -1,3 +1,5 @@
+import base64
+
 from flask_login import current_user
 
 from app.notify_client import NotifyAdminAPIClient
@@ -23,14 +25,12 @@ class FileApiClient(NotifyAdminAPIClient):
         return self.get(f"/templates/{template_id}/files/{file_id}/status")
 
     def get_file_contents(self, template_id, file_id):
-        # TODO: Call the API download endpoint when backend support is available.
-        # For now, return a predictable example file payload for the UI flow.
+        response = self.get(f"/templates/{template_id}/files/{file_id}/download")
+
         return {
-            "filename": f"example-{file_id}.txt",
-            "mime_type": "text/plain",
-            "content": (
-                f"Example file contents for template {template_id}, file {file_id}.\n" "Backend download integration is pending."
-            ).encode("utf-8"),
+            "filename": response.get("name"),
+            "mime_type": response.get("mime_type"),
+            "content": base64.b64decode(response.get("file_data")),
         }
 
     def delete_file(self, template_id, file_id):

--- a/app/notify_client/file_api_client.py
+++ b/app/notify_client/file_api_client.py
@@ -28,9 +28,9 @@ class FileApiClient(NotifyAdminAPIClient):
         response = self.get(f"/templates/{template_id}/files/{file_id}/download")
 
         return {
-            "filename": response.get("name"),
-            "mime_type": response.get("mime_type"),
-            "content": base64.b64decode(response.get("file_data")),
+            "filename": response["name"],
+            "mime_type": response["mime_type"],
+            "content": base64.b64decode(response["file_data"]),
         }
 
     def delete_file(self, template_id, file_id):

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -945,9 +945,10 @@ def test_template_attachment_download_returns_404_when_file_not_found(
         "app.service_api_client.get_service_template",
         return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
     )
+    resp_mock = Mock(status_code=404)
     mocker.patch(
         "app.main.views.templates.file_api_client.get_file_contents",
-        side_effect=HTTPError(status_code=404),
+        side_effect=HTTPError(response=resp_mock, message="File not found"),
     )
 
     with set_config(app_, "FF_FILE_ATTACHMENTS", True):
@@ -979,9 +980,10 @@ def test_template_attachment_download_shows_error_when_file_not_ready(
         "app.service_api_client.get_service_template",
         return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
     )
+    resp_mock = Mock(status_code=409)
     mocker.patch(
         "app.main.views.templates.file_api_client.get_file_contents",
-        side_effect=HTTPError(status_code=409),
+        side_effect=HTTPError(response=resp_mock, message="File not ready"),
     )
 
     with set_config(app_, "FF_FILE_ATTACHMENTS", True):
@@ -992,6 +994,7 @@ def test_template_attachment_download_shows_error_when_file_not_ready(
             file_id="file-1",
             _test_page_title=False,
             _return_response=True,
+            _expected_status=302,
         )
 
     assert response.status_code == 302
@@ -1013,23 +1016,19 @@ def test_template_attachment_download_returns_500_when_api_errors(
         "app.service_api_client.get_service_template",
         return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
     )
+    resp_mock = Mock(status_code=500)
     mocker.patch(
         "app.main.views.templates.file_api_client.get_file_contents",
-        side_effect=HTTPError(status_code=500),
+        side_effect=HTTPError(response=resp_mock, message="Internal server error"),
     )
 
     with set_config(app_, "FF_FILE_ATTACHMENTS", True):
-        response = client_request.get(
-            ".download_template_attachment",
-            service_id=SERVICE_ONE_ID,
-            template_id=fake_uuid,
-            file_id="file-1",
-            _test_page_title=False,
-            _return_response=True,
-            _expected_status=500,
-        )
+        from werkzeug.exceptions import InternalServerError
 
-    assert response.status_code == 500
+        with pytest.raises(InternalServerError):
+            client_request.logged_in_client.get(
+                f"/services/{SERVICE_ONE_ID}/templates/{fake_uuid}/attachments/download/file-1",
+            )
 
 
 def test_should_show_logos_on_template_page(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -930,6 +930,108 @@ def test_template_attachment_routes_return_404_without_upload_document_permissio
         assert response.status_code == 404
 
 
+def test_template_attachment_download_returns_404_when_file_not_found(
+    client_request,
+    mock_get_template_folders,
+    mock_get_limit_stats,
+    fake_uuid,
+    service_one,
+    app_,
+    mocker,
+):
+    current_user.verified_phonenumber = True
+    service_one["permissions"].append("upload_document")
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
+    )
+    mocker.patch(
+        "app.main.views.templates.file_api_client.get_file_contents",
+        side_effect=HTTPError(status_code=404),
+    )
+
+    with set_config(app_, "FF_FILE_ATTACHMENTS", True):
+        response = client_request.get(
+            ".download_template_attachment",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            file_id="file-1",
+            _test_page_title=False,
+            _return_response=True,
+            _expected_status=404,
+        )
+
+    assert response.status_code == 404
+
+
+def test_template_attachment_download_shows_error_when_file_not_ready(
+    client_request,
+    mock_get_template_folders,
+    mock_get_limit_stats,
+    fake_uuid,
+    service_one,
+    app_,
+    mocker,
+):
+    current_user.verified_phonenumber = True
+    service_one["permissions"].append("upload_document")
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
+    )
+    mocker.patch(
+        "app.main.views.templates.file_api_client.get_file_contents",
+        side_effect=HTTPError(status_code=409),
+    )
+
+    with set_config(app_, "FF_FILE_ATTACHMENTS", True):
+        response = client_request.get(
+            ".download_template_attachment",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            file_id="file-1",
+            _test_page_title=False,
+            _return_response=True,
+        )
+
+    assert response.status_code == 302
+    assert response.location.endswith(f"/services/{SERVICE_ONE_ID}/templates/{fake_uuid}")
+
+
+def test_template_attachment_download_returns_500_when_api_errors(
+    client_request,
+    mock_get_template_folders,
+    mock_get_limit_stats,
+    fake_uuid,
+    service_one,
+    app_,
+    mocker,
+):
+    current_user.verified_phonenumber = True
+    service_one["permissions"].append("upload_document")
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
+    )
+    mocker.patch(
+        "app.main.views.templates.file_api_client.get_file_contents",
+        side_effect=HTTPError(status_code=500),
+    )
+
+    with set_config(app_, "FF_FILE_ATTACHMENTS", True):
+        response = client_request.get(
+            ".download_template_attachment",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            file_id="file-1",
+            _test_page_title=False,
+            _return_response=True,
+            _expected_status=500,
+        )
+
+    assert response.status_code == 500
+
+
 def test_should_show_logos_on_template_page(
     client_request,
     fake_uuid,

--- a/tests/app/notify_client/test_file_api_client.py
+++ b/tests/app/notify_client/test_file_api_client.py
@@ -59,11 +59,12 @@ class TestFileApiClient:
             {"status": "uploaded"},
         )
 
-    def test_get_file_contents_returns_stub_example_file(self, mocker):
+    def test_get_file_contents_decodes_base64_response(self, mocker):
         import base64
 
         client = FileApiClient()
-        file_data = base64.b64encode(b"Example content for template-id, file-id.").decode("ascii")
+        expected_content = b"Example content for template-id, file-id."
+        file_data = base64.b64encode(expected_content).decode("ascii")
         mock_get = mocker.patch.object(
             client,
             "get",
@@ -79,7 +80,7 @@ class TestFileApiClient:
 
         assert ret["filename"] == "example-file-id.txt"
         assert ret["mime_type"] == "text/plain"
-        assert b"template-id" in ret["content"] or b"Example content" in ret["content"]
+        assert ret["content"] == expected_content
         mock_get.assert_called_once_with("/templates/template-id/files/file-id/download")
 
 

--- a/tests/app/notify_client/test_file_api_client.py
+++ b/tests/app/notify_client/test_file_api_client.py
@@ -59,15 +59,28 @@ class TestFileApiClient:
             {"status": "uploaded"},
         )
 
-    def test_get_file_contents_returns_stub_example_file(self):
+    def test_get_file_contents_returns_stub_example_file(self, mocker):
+        import base64
+
         client = FileApiClient()
+        file_data = base64.b64encode(b"Example content for template-id, file-id.").decode("ascii")
+        mock_get = mocker.patch.object(
+            client,
+            "get",
+            return_value={
+                "name": "example-file-id.txt",
+                "mime_type": "text/plain",
+                "file_data": file_data,
+                "file_size": 100,
+            },
+        )
 
         ret = client.get_file_contents("template-id", "file-id")
 
         assert ret["filename"] == "example-file-id.txt"
         assert ret["mime_type"] == "text/plain"
-        assert b"template-id" in ret["content"]
-        assert b"file-id" in ret["content"]
+        assert b"template-id" in ret["content"] or b"Example content" in ret["content"]
+        mock_get.assert_called_once_with("/templates/template-id/files/file-id/download")
 
 
 def test_singleton_client_exposes_methods():

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -736,3 +736,105 @@ describe("attachments - useAttachments", () => {
     harness.cleanup();
   });
 });
+
+describe("attachments - download error handling", () => {
+  const setupGlobalFetch = (ok, statusCode = 200) => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok,
+        status: statusCode,
+        blob: () => Promise.resolve(new Blob(["test content"])),
+        headers: {
+          get: () => null,
+        },
+      }),
+    );
+    global.URL.createObjectURL = jest.fn(() => "blob:mock-url");
+    global.URL.revokeObjectURL = jest.fn();
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+    delete global.URL.createObjectURL;
+    delete global.URL.revokeObjectURL;
+  });
+
+  test("AttachedFileRow calls onDownloadError when fetch fails", async () => {
+    setupGlobalFetch(false, 500);
+    const onDownloadError = jest.fn();
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(AttachedFileRow, {
+          file: {
+            id: "file-1",
+            name: "test.pdf",
+            status: ATTACHMENT_STATUSES.UPLOADED,
+          },
+          downloadEndpoint: "/download",
+          isConfirmingRemoval: false,
+          onRequestRemove: () => {},
+          onConfirmRemove: () => {},
+          onCancelRemove: () => {},
+          onDownloadError,
+        }),
+      );
+    });
+
+    const downloadLink = container.querySelector("[data-testid='attachment-download-link']");
+    await act(async () => {
+      downloadLink.click();
+    });
+
+    expect(onDownloadError).toHaveBeenCalledWith("file-1", expect.stringContaining("Download failed"));
+
+    root.unmount();
+    document.body.removeChild(container);
+  });
+
+  test("AttachedFileRow successfully downloads file when fetch succeeds", async () => {
+    setupGlobalFetch(true);
+    const onDownloadError = jest.fn();
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = ReactDOMClient.createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(AttachedFileRow, {
+          file: {
+            id: "file-2",
+            name: "success.pdf",
+            status: ATTACHMENT_STATUSES.UPLOADED,
+          },
+          downloadEndpoint: "/download",
+          isConfirmingRemoval: false,
+          onRequestRemove: () => {},
+          onConfirmRemove: () => {},
+          onCancelRemove: () => {},
+          onDownloadError,
+        }),
+      );
+    });
+
+    const downloadLink = container.querySelector("[data-testid='attachment-download-link']");
+    await act(async () => {
+      downloadLink.click();
+    });
+
+    expect(onDownloadError).not.toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalledWith("/download/file-2");
+
+    root.unmount();
+    document.body.removeChild(container);
+  });
+});


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the file download functionality in the `NotifyAdminAPIClient` to integrate with the backend API for retrieving file contents, replacing the previous placeholder implementation. 

## Related cards
-  https://github.com/cds-snc/notification-planning/issues/3211

# Test instructions | Instructions pour tester la modification
- [x] Attached files can be downloaded via admin using this branch: https://github.com/cds-snc/notification-api/pull/2940
