### PR TITLE
Add roadmap links to footer and sitemap

### DIFF
--- a/app/articles/routing.py
+++ b/app/articles/routing.py
@@ -29,6 +29,7 @@ GC_ARTICLES_ROUTES = {
     "register_for_demo": {"en": "/register-for-a-demo", "fr": "/sinscrire-a-une-demo"},
     "getting_started": {"en": "/getting-started", "fr": "/decouvrir-notification-gc"},
     "counting_text_messages": {"en": "/counting-text-messages", "fr": "/compter-les-messages-texte"},
+    "roadmap": {"en": "/roadmap-2026-2027", "fr": "/feuille-de-route-2026-2027"},
 }
 
 

--- a/app/main/sitemap.py
+++ b/app/main/sitemap.py
@@ -16,6 +16,7 @@ def get_sitemap():
                     {"href": url_for("main.activity"), "link_text": _("Activity on GC Notify")},
                     {"href": url_for("main.contact"), "link_text": _("Contact us")},
                     {"href": gca_url_for("features"), "link_text": _("Features")},
+                    {"href": gca_url_for("roadmap"), "link_text": _("Roadmap")},
                     {"href": gca_url_for("new_features"), "link_text": _("New features")},
                     {"href": gca_url_for("register_for_demo"), "link_text": _("Register for a demo")},
                     {"href": gca_url_for("whynotify"), "link_text": _("By and for the Government of Canada")},

--- a/app/templates/partials/nav/footer.html
+++ b/app/templates/partials/nav/footer.html
@@ -18,6 +18,7 @@
             {{ nav_link_dark(id_key='nav-footer-primary-features', label=_('Features'), href=gca_url_for('features'), class="-ml-2") }}
             {{ nav_link_dark(id_key='nav-footer-primary-new-features', label=_('New features'), href=gca_url_for('new_features'), class="-ml-2") }}
             {{ nav_link_dark(id_key='nav-footer-primary-activity', label=_('Activity on GC Notify'), href=url_for('main.activity'), class="-ml-2") }}
+            {{ nav_link_dark(id_key='nav-footer-primary-roadmap', label=_('Roadmap'), href=gca_url_for('roadmap'), class="-ml-2") }}
           {% endif %}
         </div>
         <div class="grid grid-cols-1 gap-y-1 auto-rows-min place-items-start">


### PR DESCRIPTION
# Summary | Résumé

Adds new roadmap endpoints to the footer and site map

# Test instructions | Instructions pour tester la modification

- [ ] Roadmap link is in footer, on GCA and admin pages. 
- [ ] Roadmap link is in the site map, in alphabetical order