### PR TITLE
Prevent localhost urls when configuring callbacks

### DIFF
--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -1,3 +1,4 @@
+import ipaddress
 import re
 import time
 from email.utils import formataddr
@@ -179,8 +180,13 @@ def _is_localhost_url(url):
     """Check if a URL references localhost or a loopback address."""
     try:
         parsed = urlparse(url)
-        hostname = parsed.hostname or ""
-        return hostname in ("localhost", "127.0.0.1", "::1") or hostname.endswith(".localhost")
+        hostname = (parsed.hostname or "").rstrip(".")
+        if hostname == "localhost" or hostname.endswith(".localhost"):
+            return True
+        try:
+            return ipaddress.ip_address(hostname).is_loopback
+        except ValueError:
+            return False
     except Exception:
         return False
 

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -1,6 +1,7 @@
 import re
 import time
 from email.utils import formataddr
+from urllib.parse import urlparse
 
 import pwnedpasswords
 import requests
@@ -174,6 +175,16 @@ class ValidCallbackUrl:
             validate_callback_url(field.data, form.bearer_token.data)
 
 
+def _is_localhost_url(url):
+    """Check if a URL references localhost or a loopback address."""
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname or ""
+        return hostname in ("localhost", "127.0.0.1", "::1") or hostname.endswith(".localhost")
+    except Exception:
+        return False
+
+
 def validate_callback_url(service_callback_url, bearer_token):
     """Validates a callback URL, checking that it is https and by sending a POST request to the URL with a health_check parameter.
     4xx responses are considered invalid. 5xx responses are considered valid as it indicates there is at least a service running
@@ -186,6 +197,12 @@ def validate_callback_url(service_callback_url, bearer_token):
     Raises:
         ValidationError: If the URL is not HTTPS or the http response is 4xx.
     """
+    if _is_localhost_url(service_callback_url):
+        current_app.logger.warning(
+            f"Unable to create callback for service: {current_service.id}. Error: Localhost callback URLs are not allowed: URL: {service_callback_url}"
+        )
+        raise ValidationError(_l("Enter a public URL. Localhost URLs cannot be used for callbacks."))
+
     if not validators.url(service_callback_url):
         current_app.logger.warning(
             f"Unable to create callback for service: {current_service.id}. Error: Invalid callback URL format: URL: {service_callback_url}"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -821,6 +821,7 @@
 "Add an endpoint where GC Notify should send POST requests","Ajouter un point de terminaison où Notification GC peut envoyer les requêtes « POST »"
 "Must start with https://","Doit commencer par https://"
 "Enter a URL that starts with https://","Entrez une URL qui commence par https://"
+"Enter a public URL. Localhost URLs cannot be used for callbacks.","Entrez une URL publique. Les URL localhost ne peuvent pas être utilisées pour les fonctions de rappel."
 "Add a secret value for authentication","Ajouter une valeur secrète pour l’authentification"
 "At least 10 characters","Au moins 10 caractères"
 "Callbacks for received text messages","Fonctions de rappel pour les messages texte reçus"

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -6,7 +6,7 @@ from wtforms import ValidationError
 from wtforms.validators import StopValidation
 
 from app.main.forms import OptionalIntegerRange, RegisterUserForm, ServiceSmsSenderForm, ValidTeamMemberDomain
-from app.main.validators import NoCommasInPlaceHolders, OnlySMSCharacters, ValidGovEmail
+from app.main.validators import NoCommasInPlaceHolders, OnlySMSCharacters, ValidGovEmail, _is_localhost_url
 
 
 @pytest.mark.parametrize("password", ["notification", "11111111", "kittykat", "blackbox"])
@@ -276,3 +276,31 @@ def test_optional_integer_range_custom_message():
     with pytest.raises(ValidationError) as exc:
         validator(form, field)
     assert str(exc.value) == "Custom error message"
+
+
+class TestIsLocalhostUrl:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://localhost/callback",
+            "https://localhost:8080/callback",
+            "https://127.0.0.1/callback",
+            "https://127.0.0.1:443/callback",
+            "https://[::1]/callback",
+            "http://localhost/callback",
+            "https://sub.localhost/path",
+        ],
+    )
+    def test_detects_localhost_urls(self, url):
+        assert _is_localhost_url(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/callback",
+            "https://my-service.gc.ca/callback",
+            "https://notlocalhost.com/callback",
+        ],
+    )
+    def test_allows_non_localhost_urls(self, url):
+        assert _is_localhost_url(url) is False

--- a/tests/app/main/test_validators.py
+++ b/tests/app/main/test_validators.py
@@ -284,9 +284,13 @@ class TestIsLocalhostUrl:
         [
             "https://localhost/callback",
             "https://localhost:8080/callback",
+            "https://localhost./callback",
             "https://127.0.0.1/callback",
             "https://127.0.0.1:443/callback",
+            "https://127.0.0.2/callback",
+            "https://127.255.255.255/callback",
             "https://[::1]/callback",
+            "https://[0:0:0:0:0:0:0:1]/callback",
             "http://localhost/callback",
             "https://sub.localhost/path",
         ],


### PR DESCRIPTION
# Summary | Résumé
This PR adds validation to prevent `localhost`, `127.0.0.1/8`,  and `.localhost` subdomains (that loopback to localhost) from being used when configuration notification callbacks.

# Test instructions | Instructions pour tester la modification
1. Configure a callback
2. Try to add a url with each:
    - `localhost`
    - `127.0.0.1` & variations
    - `app.localhost`
- [ ] Note that you receive an error message indicating that local URLs cannot be used. (EN/FR) 
