### PR TITLE
fix: change loading spinner color to white for better contrast

### DIFF
--- a/app/assets/stylesheets/tailwind/components/loading-spinner.css
+++ b/app/assets/stylesheets/tailwind/components/loading-spinner.css
@@ -8,7 +8,7 @@
     margin-right: 10px;
     border: 3px solid rgba(0, 0, 0, 0.1);
     border-radius: 50%;
-    border-top-color: #00703c; /* Green color from the image */
+    border-top-color: #fff;
     animation: spin 1s ease-in-out infinite;
     vertical-align: middle;
   }


### PR DESCRIPTION
# Summary | Résumé
This pull request makes a minor update to the loading spinner's appearance by changing the top border color from green to white in the `loading-spinner.css` file.

Before:
<img width="210" height="48" alt="image" src="https://github.com/user-attachments/assets/72046237-9e27-4980-89fb-f1ad209faba8" />

After:
<img width="271" height="78" alt="image" src="https://github.com/user-attachments/assets/c725e23b-9257-47ee-902c-d6369ed1fd48" />

# Test instructions | Instructions pour tester la modification
- Upload some files to a tempalte
- [ ] Ensure the spinner is white
