### PR TITLE
feat: replace FF_SALESFORCE_CONTACT env var

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -254,7 +254,10 @@ def create_app(application):
     application.jinja_env.globals["NotifyEnv"] = NotifyEnv
 
     # Initialize the GC Organisation list
-    if application.config["FF_SALESFORCE_CONTACT"]:
+    application.config["IS_GC_ORGANISATIONS"] = bool(
+        application.config["GC_ORGANISATIONS_BUCKET_NAME"] and application.config["GC_ORGANISATIONS_FILENAME"]
+    )
+    if application.config["IS_GC_ORGANISATIONS"]:
         application.config["CRM_ORG_LIST"] = get_gc_organisations(application)
 
     # Specify packages to be traced by MonkeyType. This can be overriden

--- a/app/config.py
+++ b/app/config.py
@@ -88,7 +88,6 @@ class Config(object):
     EXTRA_ROUTES = [item for sublist in map(lambda x: x.values(), GC_ARTICLES_ROUTES.values()) for item in sublist]
 
     # FEATURE FLAGS
-    FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", True)
     FF_CARETAKER = env.bool("FF_CARETAKER", False)
     FF_USE_BILLABLE_UNITS = env.bool("FF_USE_BILLABLE_UNITS", False)
     FF_ADD_TEMPLATE_PERM = env.bool("FF_ADD_TEMPLATE_PERM", False)
@@ -235,10 +234,9 @@ class Test(Development):
     TESTING = True
     WTF_CSRF_ENABLED = False
     GC_ARTICLES_API = "articles.alpha.canada.ca/notification-gc-notify"
-    FF_SALESFORCE_CONTACT = False
     SYSTEM_STATUS_URL = "https://localhost:3000"
     NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
-    GC_ORGANISATIONS_BUCKET_NAME = "test-gc-organisations"
+    GC_ORGANISATIONS_BUCKET_NAME = None
     FF_USE_BILLABLE_UNITS = True
     VITE_HMR_ENABLED = False
 
@@ -260,7 +258,6 @@ class ProductionFF(Config):
     TESTING = True
     WTF_CSRF_ENABLED = False
     GC_ARTICLES_API = "articles.alpha.canada.ca/notification-gc-notify"
-    FF_SALESFORCE_CONTACT = False
     SYSTEM_STATUS_URL = "https://localhost:3000"
     NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
     GC_ORGANISATIONS_BUCKET_NAME = "dev-gc-organisations"

--- a/app/config.py
+++ b/app/config.py
@@ -265,7 +265,7 @@ class ProductionFF(Config):
     GC_ARTICLES_API = "articles.alpha.canada.ca/notification-gc-notify"
     SYSTEM_STATUS_URL = "https://localhost:3000"
     NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
-    GC_ORGANISATIONS_BUCKET_NAME = "dev-gc-organisations"
+    GC_ORGANISATIONS_BUCKET_NAME = None
     FF_USE_BILLABLE_UNITS = False
     FF_REPORT_API = False
 

--- a/app/config.py
+++ b/app/config.py
@@ -260,7 +260,7 @@ class ProductionFF(Config):
     GC_ARTICLES_API = "articles.alpha.canada.ca/notification-gc-notify"
     SYSTEM_STATUS_URL = "https://localhost:3000"
     NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
-    GC_ORGANISATIONS_BUCKET_NAME = "dev-gc-organisations"
+    GC_ORGANISATIONS_BUCKET_NAME = None
     FF_USE_BILLABLE_UNITS = False
     FF_REPORT_API = False
 

--- a/app/config.py
+++ b/app/config.py
@@ -88,7 +88,6 @@ class Config(object):
     EXTRA_ROUTES = [item for sublist in map(lambda x: x.values(), GC_ARTICLES_ROUTES.values()) for item in sublist]
 
     # FEATURE FLAGS
-    FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", True)
     FF_CARETAKER = env.bool("FF_CARETAKER", False)
     FF_USE_BILLABLE_UNITS = env.bool("FF_USE_BILLABLE_UNITS", False)
     FF_ADD_TEMPLATE_PERM = env.bool("FF_ADD_TEMPLATE_PERM", False)
@@ -239,10 +238,9 @@ class Test(Development):
     TESTING = True
     WTF_CSRF_ENABLED = False
     GC_ARTICLES_API = "articles.alpha.canada.ca/notification-gc-notify"
-    FF_SALESFORCE_CONTACT = False
     SYSTEM_STATUS_URL = "https://localhost:3000"
     NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
-    GC_ORGANISATIONS_BUCKET_NAME = "test-gc-organisations"
+    GC_ORGANISATIONS_BUCKET_NAME = None
     FF_USE_BILLABLE_UNITS = True
     VITE_HMR_ENABLED = False
     FILE_ATTACH_SERVICES = ["d6aa2c68-a2d9-4437-ab19-3ae8eb202553", "d4e8a7f4-2b8a-4c9a-8b3f-9c2d4e8a7f4b"]
@@ -265,7 +263,6 @@ class ProductionFF(Config):
     TESTING = True
     WTF_CSRF_ENABLED = False
     GC_ARTICLES_API = "articles.alpha.canada.ca/notification-gc-notify"
-    FF_SALESFORCE_CONTACT = False
     SYSTEM_STATUS_URL = "https://localhost:3000"
     NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
     GC_ORGANISATIONS_BUCKET_NAME = "dev-gc-organisations"

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -67,7 +67,7 @@ ORGANISIATION_STEP_DICT: dict[str, dict[str, Any]] = {
 
 
 def get_wizard_order() -> list[str]:
-    if current_app.config["FF_SALESFORCE_CONTACT"]:
+    if current_app.config["IS_GC_ORGANISATIONS"]:
         return [STEP_LOGO, STEP_SERVICE_AND_EMAIL, STEP_ORGANISATION]
     return [STEP_LOGO, STEP_SERVICE_AND_EMAIL]
 
@@ -157,7 +157,7 @@ def _renderTemplateStep(form, current_step: str, government_type: Optional[str])
     step_num = WIZARD_ORDER.index(current_step) + 1
 
     autocomplete_data = None
-    if current_app.config["FF_SALESFORCE_CONTACT"] and current_step == STEP_ORGANISATION:
+    if current_app.config["IS_GC_ORGANISATIONS"] and current_step == STEP_ORGANISATION:
         autocomplete_data = current_app.config["CRM_ORG_LIST"].get("names", {})
 
     if step_num > 1:
@@ -232,9 +232,9 @@ def add_service():
     service_name = data["name"]
     default_branding_is_french = data["default_branding"] == FieldWithLanguageOptions.FRENCH_OPTION_VALUE
     # organisation_notes will be visible at the go live request
-    if current_app.config["FF_SALESFORCE_CONTACT"] and government_type != GOVERNMENT_TYPE_OTHER:
+    if current_app.config["IS_GC_ORGANISATIONS"] and government_type != GOVERNMENT_TYPE_OTHER:
         organisation_notes = f"{data['parent_organisation_name']} > {data['child_organisation_name']}"
-    elif current_app.config["FF_SALESFORCE_CONTACT"] and government_type == GOVERNMENT_TYPE_OTHER:
+    elif current_app.config["IS_GC_ORGANISATIONS"] and government_type == GOVERNMENT_TYPE_OTHER:
         organisation_notes = data["other_organisation_name"]
     else:
         organisation_notes = None

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -264,7 +264,7 @@ def terms_of_use(service_id):
 @user_is_gov_user
 def use_case(service_id):
     DEFAULT_STEP = "about-service"
-    display_org_question = not current_service.organisation_notes or not current_app.config["FF_SALESFORCE_CONTACT"]
+    display_org_question = not current_service.organisation_notes or not current_app.config["IS_GC_ORGANISATIONS"]
     steps = [
         {
             "form": GoLiveAboutServiceForm if display_org_question else GoLiveAboutServiceFormNoOrg,

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -266,7 +266,7 @@ def terms_of_use(service_id):
 @user_is_gov_user
 def use_case(service_id):
     DEFAULT_STEP = "about-service"
-    display_org_question = not current_service.organisation_notes or not current_app.config["FF_SALESFORCE_CONTACT"]
+    display_org_question = not current_service.organisation_notes or not current_app.config["IS_GC_ORGANISATIONS"]
     steps = [
         {
             "form": GoLiveAboutServiceForm if display_org_question else GoLiveAboutServiceFormNoOrg,

--- a/app/templates/partials/add-service/step-create-service.html
+++ b/app/templates/partials/add-service/step-create-service.html
@@ -41,7 +41,7 @@
   </p>
   <p>{{ _("This email address cannot receive replies. In Settings, you can enter a different email for replies. Currently your service is set to prevent replies.") }}</p>
 
-  {% if config["FF_SALESFORCE_CONTACT"] %}
+  {% if config["IS_GC_ORGANISATIONS"] %}
     {% set button_txt = _('Continue') %}
   {% else %}
     {% set button_txt = _('Create service') %}

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -183,13 +183,13 @@ def test_wizard_flow_with_step_2_should_call_email_from_is_unique(
     assert mock_create_or_update_free_sms_fragment_limit.called is True
 
 
-def test_wizard_flow_with_step_2_post_should_go_to_step_3_with_ff(
+def test_wizard_flow_with_step_2_post_should_go_to_step_3_with_gc_organisations(
     app_: Flask,
     client_request,
     mock_service_email_from_is_unique,
     mock_service_name_is_unique,
 ):
-    app_.config["FF_SALESFORCE_CONTACT"] = True
+    app_.config["IS_GC_ORGANISATIONS"] = True
     app_.config["CRM_ORG_LIST"] = {"en": ["CDS", "TBS"]}
     with client_request.session_transaction() as session:
         session["add_service_form"] = dict(default_branding=FieldWithLanguageOptions.ENGLISH_OPTION_VALUE)
@@ -227,7 +227,7 @@ def test_wizard_flow_with_step_3_should_create_service(
 ):
     mocker.patch("app.service_api_client.is_service_name_unique", return_value=True)
     mocker.patch("app.service_api_client.is_service_email_from_unique", return_value=True)
-    app_.config["FF_SALESFORCE_CONTACT"] = True
+    app_.config["IS_GC_ORGANISATIONS"] = True
     app_.config["CRM_ORG_LIST"] = {"en": ["CDS", "TBS"]}
     with client_request.session_transaction() as session:
         session["add_service_form"] = dict(
@@ -259,7 +259,7 @@ def test_wizard_flow_with_step_3_should_not_create_service_no_parent_org(
     mock_create_service,
     mock_create_or_update_free_sms_fragment_limit,
 ):
-    app_.config["FF_SALESFORCE_CONTACT"] = True
+    app_.config["IS_GC_ORGANISATIONS"] = True
     app_.config["CRM_ORG_LIST"] = {"en": ["CDS", "TBS"]}
     with client_request.session_transaction() as session:
         session["add_service_form"] = dict(
@@ -287,7 +287,7 @@ def test_wizard_flow_with_step_3b_should_create_service(
 ):
     mocker.patch("app.service_api_client.is_service_name_unique", return_value=True)
     mocker.patch("app.service_api_client.is_service_email_from_unique", return_value=True)
-    app_.config["FF_SALESFORCE_CONTACT"] = True
+    app_.config["IS_GC_ORGANISATIONS"] = True
     app_.config["CRM_ORG_LIST"] = {"en": ["CDS", "TBS"]}
     with client_request.session_transaction() as session:
         session["add_service_form"] = dict(
@@ -316,7 +316,7 @@ def test_wizard_flow_with_step_3b_create_service_no_org(
     mock_create_service,
     mock_create_or_update_free_sms_fragment_limit,
 ):
-    app_.config["FF_SALESFORCE_CONTACT"] = True
+    app_.config["IS_GC_ORGANISATIONS"] = True
     app_.config["CRM_ORG_LIST"] = {"en": ["CDS", "TBS"]}
     with client_request.session_transaction() as session:
         session["add_service_form"] = dict(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -1104,7 +1104,7 @@ def test_request_to_go_live_use_case_page(
 
 
 @pytest.mark.parametrize(
-    "salesforce_feature_flag, organisation_notes, organisation_question_visible",
+    "is_gc_organisations, organisation_notes, organisation_question_visible",
     (
         (False, "Some department > Some group", True),
         (False, "", True),
@@ -1117,11 +1117,11 @@ def test_request_to_go_live_use_case_page_hides_organisation(
     mocker: MockerFixture,
     app_: Flask,
     service_one: Service,
-    salesforce_feature_flag: bool,
+    is_gc_organisations: bool,
     organisation_notes: str,
     organisation_question_visible: bool,
 ):
-    with set_config(app_, "FF_SALESFORCE_CONTACT", salesforce_feature_flag):
+    with set_config(app_, "IS_GC_ORGANISATIONS", is_gc_organisations):
         use_case_data_mock = mocker.patch("app.service_api_client.get_use_case_data")
         use_case_data_mock.return_value = None
         service_one.organisation_notes = organisation_notes  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ from flask import Flask, template_rendered, url_for
 from freezegun import freeze_time
 from notifications_python_client.errors import HTTPError
 from notifications_utils.url_safe_token import generate_token
-from pytest_mock import MockerFixture
 from werkzeug.exceptions import NotFound
 
 from app import create_app
@@ -4669,18 +4668,6 @@ def mock_GCA_404(mocker):
     mocker.patch(
         "app.main.views.index.get_nav_items", return_value=[{"title": "Home", "url": "/", "target": "", "description": "main"}]
     )
-
-
-@pytest.fixture(scope="function")
-def mock_salesforce_get_accounts(mocker: MockerFixture):
-    mock_crm_orgs = [
-        "Accessibility Standards Canada",
-        "Canada Post",
-        "Canada Revenue Agency",
-        "National Film Board",
-        "Royal Canadian Mint",
-    ]
-    return mocker.patch("app.salesforce_account.get_accounts", return_value=mock_crm_orgs)
 
 
 def create_api_user_active(with_unique_id=False):


### PR DESCRIPTION
# Summary | Résumé
Replace the feature flag with an inferred `IS_GC_ORGANISATIONS` boolean based on the existence of the GC organisation bucket and filename.

This is being done as part of the Notify Salesforce disconnect.

# Related
- https://github.com/cds-snc/notification-api/pull/2955
- https://github.com/cds-snc/ADR/pull/92