### PR TITLE
Auto-remove malware-containing files

### DIFF
--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -67,6 +67,7 @@ from app.utils import (
     PermanentRedirect,
     Spreadsheet,
     email_or_sms_not_enabled,
+    filter_attachments,
     get_errors_for_csv,
     get_help_argument,
     get_limit_reset_time_et,
@@ -118,17 +119,14 @@ def build_template_attachment_personalisation(template_id, template_type):
     ):
         return {}
 
-    attachments = current_service.get_template_attachments(template_id)
+    attachments = filter_attachments(
+        current_service.get_template_attachments(template_id),
+        include_statuses={"uploaded"},
+    )
     result = {}
     file_index = 0  # Track contiguous index for included attachments
 
     for attachment in attachments:
-        status = attachment.get("status") or "uploaded"
-
-        # Only include fully uploaded attachments
-        if status != "uploaded":
-            continue
-
         # Skip if missing required fields
         attachment_id = attachment.get("id")
         filename = attachment.get("name") or attachment.get("filename")

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -111,6 +111,20 @@ def get_email_preview_template(template, template_id, service_id):
     return email_preview_template
 
 
+def _get_visible_template_attachments(attachments):
+    visible_attachments = []
+
+    for attachment in attachments:
+        status = attachment.get("status") or "uploaded"
+
+        if status in ("deleted", "virus_scan_failed"):
+            continue
+
+        visible_attachments.append(attachment)
+
+    return visible_attachments
+
+
 def set_preview_data(data, service_id, template_id=None):
     key = f"template-preview:{service_id}:{template_id}"
     redis_client.set(key=key, value=json.dumps(data), ex=int(timedelta(days=1).total_seconds()))
@@ -209,7 +223,7 @@ def view_template(service_id, template_id):
         and template["template_type"] == "email"
         and current_service.has_permission("upload_document")
     ):
-        template_attachments = current_service.get_template_attachments(template_id)
+        template_attachments = _get_visible_template_attachments(current_service.get_template_attachments(template_id))
 
     user_has_template_permission = current_user.has_template_folder_permission(template_folder)
 

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -68,6 +68,7 @@ from app.sample_template_utils import create_temporary_sample_template, get_samp
 from app.template_previews import TemplatePreview, get_page_count_for_letter
 from app.utils import (
     email_or_sms_not_enabled,
+    filter_attachments,
     get_limit_reset_time_et,
     get_template,
     should_skip_template_page,
@@ -109,20 +110,6 @@ def get_email_preview_template(template, template_id, service_id):
     )
 
     return email_preview_template
-
-
-def _get_visible_template_attachments(attachments):
-    visible_attachments = []
-
-    for attachment in attachments:
-        status = attachment.get("status") or "uploaded"
-
-        if status in ("deleted", "virus_scan_failed"):
-            continue
-
-        visible_attachments.append(attachment)
-
-    return visible_attachments
 
 
 def set_preview_data(data, service_id, template_id=None):
@@ -223,7 +210,10 @@ def view_template(service_id, template_id):
         and template["template_type"] == "email"
         and current_service.has_permission("upload_document")
     ):
-        template_attachments = _get_visible_template_attachments(current_service.get_template_attachments(template_id))
+        template_attachments = filter_attachments(
+            current_service.get_template_attachments(template_id),
+            exclude_statuses={"deleted", "virus_scan_failed"},
+        )
 
     user_has_template_permission = current_user.has_template_folder_permission(template_folder)
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -687,6 +687,21 @@ def guess_name_from_email_address(email_address):
     )
 
 
+def filter_attachments(attachments, exclude_statuses=None, include_statuses=None):
+    if exclude_statuses and include_statuses:
+        raise ValueError("Cannot specify both exclude_statuses and include_statuses")
+
+    filtered = []
+    for attachment in attachments:
+        status = attachment.get("status") or "uploaded"
+        if include_statuses is not None and status not in include_statuses:
+            continue
+        if exclude_statuses is not None and status in exclude_statuses:
+            continue
+        filtered.append(attachment)
+    return filtered
+
+
 def should_skip_template_page(template_type):
     return (
         current_user.has_permissions("send_messages")

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -793,6 +793,48 @@ def test_should_show_attachments_widget_on_email_template_page(
     assert url_for("main.download_template_attachment", service_id=SERVICE_ONE_ID, template_id=fake_uuid) in str(page)
 
 
+def test_should_not_render_unsafe_or_deleted_template_attachments_on_template_page_reload(
+    client_request,
+    mock_get_template_folders,
+    mock_get_limit_stats,
+    fake_uuid,
+    app_,
+    service_one,
+    mocker,
+):
+    current_user.verified_phonenumber = True
+    service_one["permissions"].append("upload_document")
+
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="email")},
+    )
+    mocker.patch(
+        "app.models.service.Service.get_template_attachments",
+        return_value=[
+            {"id": "uploaded-1", "name": "safe-file.pdf", "status": "uploaded"},
+            {"id": "pending-1", "name": "still-scanning.pdf", "status": "pending_virus_scan"},
+            {"id": "unsafe-1", "name": "unsafe-file.pdf", "status": "virus_scan_failed"},
+            {"id": "deleted-1", "name": "deleted-file.pdf", "status": "deleted"},
+        ],
+    )
+
+    with set_config(app_, "FF_FILE_ATTACHMENTS", True):
+        page = client_request.get(
+            ".view_template",
+            service_id=SERVICE_ONE_ID,
+            template_id=fake_uuid,
+            _test_page_title=False,
+        )
+
+    page_html = str(page)
+
+    assert "safe-file.pdf" in page_html
+    assert "still-scanning.pdf" in page_html
+    assert "unsafe-file.pdf" not in page_html
+    assert "deleted-file.pdf" not in page_html
+
+
 def test_should_not_show_attachments_widget_without_send_files_permission(
     client_request,
     mock_get_template_folders,


### PR DESCRIPTION
# Summary | Résumé
This PR updates the file attachment component to exclude file attachments which failed malware scanning. Upon initial upload the file will be displayed in the list of attachments with the existing error message about malware. Upon leaving the page for that template and returning to it the file that failed malware scanning will not be listed in the attached files section.

# Test instructions | Instructions pour tester la modification
1. Upload a file that will fail the malware scan:
```
X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
```
- [x] Note that the file appears in the attachment list with an error
3. Navigate away from the template --> Navigate back to the template
- [x] Note that the "malicious" file is no longer listed as an attachment for that template.