### PR TITLE
Update verbiage for send files by email setting

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -436,10 +436,13 @@ def set_sensitive_service(service_id):
 )
 @user_has_permissions("manage_service")
 def service_switch_upload_document(service_id):
+    if not current_app.config.get("FF_FILE_ATTACHMENTS"):
+        abort(404)
+
     title = _("Send files by email")
     form = ServiceOnOffSettingForm(name=title, enabled=current_service.has_permission("upload_document"))
     help = _(
-        "This feature is only available when sending through the API.<br>Learn more in the <a href='{}'>API documentation</a>."
+        "Allow files to be attached to email notifications.<br>Learn more in the <a href='{}'>API documentation</a>."
     ).format(documentation_url("send", section="sending-a-file-by-email"))
 
     if form.validate_on_submit():

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -438,11 +438,14 @@ def set_sensitive_service(service_id):
 def service_switch_upload_document(service_id):
     title = _("Send files by email")
     form = ServiceOnOffSettingForm(name=title, enabled=current_service.has_permission("upload_document"))
-    help = _(
-        "Allow files to be attached to email notifications.<br>Files can be attached on the templates page or through the API<br>Learn more in the <a href='{}'>API documentation</a>."
-        if current_app.config.get("FF_FILE_ATTACHMENTS")
-        else "This feature is only available when sending through the API.<br>Learn more in the <a href='{}'>API documentation</a>."
-    ).format(documentation_url("send", section="sending-a-file-by-email"))
+    if current_app.config.get("FF_FILE_ATTACHMENTS"):
+        help = _(
+            "Allow files to be attached to email notifications.<br>Files can be attached on the templates page or through the API<br>Learn more in the <a href='{}'>API documentation</a>."
+        ).format(documentation_url("send", section="sending-a-file-by-email"))
+    else:
+        help = _(
+            "This feature is only available when sending through the API.<br>Learn more in the <a href='{}'>API documentation</a>."
+        ).format(documentation_url("send", section="sending-a-file-by-email"))
 
     if form.validate_on_submit():
         current_service.force_permission("upload_document", on=form.enabled.data)

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -436,13 +436,12 @@ def set_sensitive_service(service_id):
 )
 @user_has_permissions("manage_service")
 def service_switch_upload_document(service_id):
-    if not current_app.config.get("FF_FILE_ATTACHMENTS"):
-        abort(404)
-
     title = _("Send files by email")
     form = ServiceOnOffSettingForm(name=title, enabled=current_service.has_permission("upload_document"))
     help = _(
-        "Allow files to be attached to email notifications.<br>Learn more in the <a href='{}'>API documentation</a>."
+        "Allow files to be attached to email notifications.<br>Files can be attached on the templates page or through the API<br>Learn more in the <a href='{}'>API documentation</a>."
+        if current_app.config.get("FF_FILE_ATTACHMENTS")
+        else "This feature is only available when sending through the API.<br>Learn more in the <a href='{}'>API documentation</a>."
     ).format(documentation_url("send", section="sending-a-file-by-email"))
 
     if form.validate_on_submit():

--- a/app/templates/views/service-settings.html
+++ b/app/templates/views/service-settings.html
@@ -150,17 +150,19 @@
             for=txt
           )}}
         {% endcall %}
-        {% call settings_row(if_has_permission='email') %}
-          {% set txt = _('Send files by email') %}
-          {{ text_field(txt) }}
-          {{ boolean_field('upload_document' in current_service.permissions, suffix=_('(API-only)')) }}
-          {{ edit_field(
-            change_txt,
-            url_for('.service_switch_upload_document', service_id=current_service.id),
-            permissions=['manage_service'],
-            for=txt
-          )}}
-        {% endcall %}
+        {% if config['FF_FILE_ATTACHMENTS'] %}
+          {% call settings_row(if_has_permission='email') %}
+            {% set txt = _('Send files by email') %}
+            {{ text_field(txt) }}
+            {{ boolean_field('upload_document' in current_service.permissions) }}
+            {{ edit_field(
+              change_txt,
+              url_for('.service_switch_upload_document', service_id=current_service.id),
+              permissions=['manage_service'],
+              for=txt
+            )}}
+          {% endcall %}
+        {% endif %}
 
         {% call settings_row(if_has_permission='email') %}
           {% set txt = _('Daily maximum') %}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1541,7 +1541,7 @@
 "failures","échecs"
 "This feature is only available when sending through the API.<br>Learn more in the <a href='{}'>API documentation</a>.","Cette fonctionnalité n’est disponible que pour les envois programmés par le biais de l’API.<br>Pour en savoir plus, consultez la <a href='{}'>documentation API</a>."
 "(API-only)","(API seulement)"
-"Allow files to be attached to email notifications.<br>Learn more in the <a href='{}'>API documentation</a>.","Permettre de joindre des fichiers aux notifications par courriel.<br>Pour en savoir plus, consultez la <a href='{}'>documentation API</a>."
+"Allow files to be attached to email notifications.<br>Files can be attached on the templates page or through the API<br>Learn more in the <a href='{}'>API documentation</a>.","Permettre de joindre des fichiers aux notifications par courriel.<br>Les fichiers peuvent être joints sur la page des gabarits ou par l'API.<br>Pour en savoir plus, consultez la <a href='{}'>documentation API</a>."
 "Setting updated","Paramètre mis à jour"
 "Target audience","Public cible"
 "Features list","Liste de fonctionnalités"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1541,6 +1541,7 @@
 "failures","échecs"
 "This feature is only available when sending through the API.<br>Learn more in the <a href='{}'>API documentation</a>.","Cette fonctionnalité n’est disponible que pour les envois programmés par le biais de l’API.<br>Pour en savoir plus, consultez la <a href='{}'>documentation API</a>."
 "(API-only)","(API seulement)"
+"Allow files to be attached to email notifications.<br>Learn more in the <a href='{}'>API documentation</a>.","Permettre de joindre des fichiers aux notifications par courriel.<br>Pour en savoir plus, consultez la <a href='{}'>documentation API</a>."
 "Setting updated","Paramètre mis à jour"
 "Target audience","Public cible"
 "Features list","Liste de fonctionnalités"

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -68,7 +68,7 @@ def mock_get_service_settings_page_common(
                 "Send emails On Change",
                 "Reply-to addresses Not set Manage",
                 "Email branding English Government of Canada signature Change",
-                "Send files by email Off (API-only) Change",
+                "Send files by email Off Change",
                 "Daily maximum 1,000 emails No value",
                 "Annual maximum(April 1 to March 31) 20,000,000 emails No value",
                 "Label Value Action",
@@ -91,7 +91,7 @@ def mock_get_service_settings_page_common(
                 "Send emails On Change",
                 "Reply-to addresses Not set Manage",
                 "Email branding English Government of Canada signature Change",
-                "Send files by email Off (API-only) Change",
+                "Send files by email Off Change",
                 "Daily maximum 1,000 emails No value",
                 "Annual maximum(April 1 to March 31) 20,000,000 emails No value",
                 "Label Value Action",
@@ -226,7 +226,7 @@ def test_organisation_name_links_to_org_dashboard(
                 "Send emails On Change",
                 "Reply-to addresses test@example.com Manage",
                 "Email branding Your branding (Organisation name) Change",
-                "Send files by email Off (API-only) Change",
+                "Send files by email Off Change",
                 "Daily maximum 1,000 emails No value",
                 "Annual maximum(April 1 to March 31) 20,000,000 emails No value",
                 "Label Value Action",
@@ -247,7 +247,7 @@ def test_organisation_name_links_to_org_dashboard(
                 "Send emails On Change",
                 "Reply-to addresses test@example.com Manage",
                 "Email branding Your branding (Organisation name) Change",
-                "Send files by email Off (API-only) Change",
+                "Send files by email Off Change",
                 "Daily maximum 1,000 emails No value",
                 "Annual maximum(April 1 to March 31) 20,000,000 emails No value",
                 "Label Value Action",
@@ -3419,7 +3419,7 @@ def test_service_switch_upload_document(
     assert page.h1.text == "Send files by email"
 
     paragraph = page.select_one("#main_content p").text.strip()
-    assert "This feature is only available when sending through the API" in paragraph
+    assert "Allow files to be attached to email notifications" in paragraph
 
     assert page.select_one("input[checked]")["value"] == expected_initial_value
     assert len(page.select("input[checked]")) == 1
@@ -3432,6 +3432,19 @@ def test_service_switch_upload_document(
     )
     assert set(mocked_fn.call_args[1]["permissions"]) == set(expected_updated_permissions)
     assert mocked_fn.call_args[0][0] == service_one["id"]
+
+
+def test_service_switch_upload_document_returns_404_when_feature_flag_is_off(
+    client_request,
+    service_one,
+    app_,
+):
+    with set_config(app_, "FF_FILE_ATTACHMENTS", False):
+        client_request.get(
+            "main.service_switch_upload_document",
+            service_id=service_one["id"],
+            _expected_status=404,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3434,17 +3434,18 @@ def test_service_switch_upload_document(
     assert mocked_fn.call_args[0][0] == service_one["id"]
 
 
-def test_service_switch_upload_document_returns_404_when_feature_flag_is_off(
+def test_service_switch_upload_document_shows_api_only_help_when_feature_flag_is_off(
     client_request,
     service_one,
     app_,
 ):
     with set_config(app_, "FF_FILE_ATTACHMENTS", False):
-        client_request.get(
+        page = client_request.get(
             "main.service_switch_upload_document",
             service_id=service_one["id"],
-            _expected_status=404,
         )
+        paragraph = page.select_one("#main_content p").text.strip()
+        assert "This feature is only available when sending through the API" in paragraph
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary | Résumé
This PR removes the `(API Only)`text from the `Send files by email` setting as we can now send via the UI and API

# Related
* https://docs.google.com/document/d/1m_EzXNJbqjJH-WLzxRKMtO4k5CAHwk51uCXi7xJQR44/edit?pli=1&tab=t.0#task=doULW0OCbF-OneiL

# Test instructions | Instructions pour tester la modification
1. Navigate to service settings
- [ ] Note that the `Send files by email` setting no longer indicates (API only)
