### PR TITLE
fix: improve variable mark test by using a minimal document for clarity

### DIFF
--- a/tests_cypress/cypress/e2e/admin/components/rte/LiveRegion.cy.js
+++ b/tests_cypress/cypress/e2e/admin/components/rte/LiveRegion.cy.js
@@ -182,11 +182,14 @@ describe("Live region announces context as user navigates the editor", () => {
   });
 
   it("announces Variable when cursor is inside a variable mark", () => {
-    // The variable mark has inclusive:false, so marks() only returns it when
-    // textOffset > 0 (cursor strictly inside, not at a boundary).
-    // realClick() fires native OS-level mouse events so the browser resolves
-    // the cursor to the centre of the span text (~textOffset 4), triggering
-    // ProseMirror's selectionchange → selectionSet transaction → announcer.
+    // Use a minimal document so the click target is unambiguous.
+    RichTextEditor.Components.ViewMarkdownButton().click();
+    RichTextEditor.Components.MarkdownEditor().clear().type("((variable))", {
+      delay: 0,
+    });
+    RichTextEditor.Components.ViewMarkdownButton().click();
+
+    // Place the cursor inside the variable mark to trigger announcement.
     RichTextEditor.Components.Editor()
       .find('span[data-type="variable"]')
       .first()


### PR DESCRIPTION
# Summary | Résumé
This pull request updates the test for live region announcements in the rich text editor to make the test for variable marks more robust and less ambiguous. The test now uses a minimal document to ensure the click target is clear and the correct element is interacted with.

# Test instructions | Instructions pour tester la modification
- [ ] CI passes