### PR TITLE
Add the `manage_reports` permission for new api keys

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -268,6 +268,7 @@ class ProductionFF(Config):
     GC_ORGANISATIONS_BUCKET_NAME = "dev-gc-organisations"
     FF_USE_BILLABLE_UNITS = False
     FF_FILE_ATTACHMENTS = True
+    FF_REPORT_API = False
 
 
 class Production(Config):

--- a/app/config.py
+++ b/app/config.py
@@ -208,7 +208,7 @@ class Development(Config):
     DEBUG_KEY = "debug"
     FF_ADD_TEMPLATE_PERM = True
     FF_FILE_ATTACHMENTS = True
-    FF_REPORT_API = True
+    FF_REPORT_API = env.bool("FF_REPORT_API", False)
     MOU_BUCKET_NAME = "notify.tools-mou"
     ONE_CLICK_UNSUB_ALL_SERVICES = True
     REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")

--- a/app/config.py
+++ b/app/config.py
@@ -93,6 +93,7 @@ class Config(object):
     FF_USE_BILLABLE_UNITS = env.bool("FF_USE_BILLABLE_UNITS", False)
     FF_ADD_TEMPLATE_PERM = env.bool("FF_ADD_TEMPLATE_PERM", False)
     FF_FILE_ATTACHMENTS = env.bool("FF_FILE_ATTACHMENTS", False)
+    FF_REPORT_API = env.bool("FF_REPORT_API", False)
 
     # OTEL Configuration
     ENABLE_CLIENT_SIDE_OTEL = env.bool("ENABLE_CLIENT_SIDE_OTEL", False)
@@ -207,6 +208,7 @@ class Development(Config):
     DEBUG_KEY = "debug"
     FF_ADD_TEMPLATE_PERM = True
     FF_FILE_ATTACHMENTS = True
+    FF_REPORT_API = True
     MOU_BUCKET_NAME = "notify.tools-mou"
     ONE_CLICK_UNSUB_ALL_SERVICES = True
     REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1014,9 +1014,13 @@ class ChooseTimeForm(StripWhitespaceForm):
 
 
 class CreateKeyForm(StripWhitespaceForm):
-    def __init__(self, existing_keys, *args, **kwargs):
+    def __init__(self, existing_keys, ff_report_api=False, *args, **kwargs):
         self.existing_key_names = [key["name"].lower() for key in existing_keys if not key["expiry_date"]]
         super().__init__(*args, **kwargs)
+        if ff_report_api:
+            self.manage_templates.choices = list(self.manage_templates.choices) + [
+                ("manage_reports", _l("Allow this key to create and download delivery reports"))
+            ]
 
     key_type = RadioField(
         _l("Type of API key"),

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1018,7 +1018,7 @@ class CreateKeyForm(StripWhitespaceForm):
         self.existing_key_names = [key["name"].lower() for key in existing_keys if not key["expiry_date"]]
         super().__init__(*args, **kwargs)
         if ff_report_api:
-            self.manage_templates.choices = list(self.manage_templates.choices) + [
+            self.permissions.choices = list(self.permissions.choices) + [
                 ("manage_reports", _l("Allow this key to create and download delivery reports"))
             ]
 
@@ -1031,7 +1031,7 @@ class CreateKeyForm(StripWhitespaceForm):
         validators=[DataRequired(message=_l("You need to give the key a name")), Length(max=255)],
     )
 
-    manage_templates = SelectMultipleField(
+    permissions = SelectMultipleField(
         _l("API key permissions"),
         choices=[("manage_templates", _l("Allow this key to manage templates (create, update, or delete)"))],
     )

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -16,6 +16,7 @@ from app.main.forms import (
     ServiceReceiveMessagesCallbackForm,
 )
 from app.notify_client.api_key_api_client import (
+    KEY_PERMISSION_MANAGE_REPORTS,
     KEY_PERMISSION_MANAGE_TEMPLATES,
     KEY_TYPE_NORMAL,
     KEY_TYPE_TEAM,
@@ -79,7 +80,7 @@ def api_keys(service_id):
 @main.route("/services/<service_id>/api/keys/create", methods=["GET", "POST"])
 @user_has_permissions("manage_api_keys", restrict_admin_usage=True)
 def create_api_key(service_id):
-    form = CreateKeyForm(current_service.api_keys)
+    form = CreateKeyForm(current_service.api_keys, ff_report_api=current_app.config["FF_REPORT_API"])
     form.key_type.choices = [
         (KEY_TYPE_NORMAL, _l("Live – sends to anyone")),
         (KEY_TYPE_TEAM, _l("Team and safelist – limits who you can send to")),
@@ -95,8 +96,10 @@ def create_api_key(service_id):
         if form.key_type.data in disabled_options:
             abort(400)
         permissions = []
-        if form.manage_templates.data:
+        if KEY_PERMISSION_MANAGE_TEMPLATES in form.manage_templates.data:
             permissions.append(KEY_PERMISSION_MANAGE_TEMPLATES)
+        if KEY_PERMISSION_MANAGE_REPORTS in form.manage_templates.data:
+            permissions.append(KEY_PERMISSION_MANAGE_REPORTS)
         keydata = api_key_api_client.create_api_key(
             service_id=service_id,
             key_name=form.key_name.data,
@@ -115,6 +118,7 @@ def create_api_key(service_id):
         disabled_options=disabled_options,
         option_hints=option_hints,
         show_manage_templates=current_app.config["FF_ADD_TEMPLATE_PERM"] and current_user.has_permissions("manage_api_keys"),
+        show_manage_reports=current_app.config["FF_REPORT_API"] and current_user.has_permissions("manage_api_keys"),
     )
 
 

--- a/app/main/views/api_keys.py
+++ b/app/main/views/api_keys.py
@@ -96,9 +96,9 @@ def create_api_key(service_id):
         if form.key_type.data in disabled_options:
             abort(400)
         permissions = []
-        if KEY_PERMISSION_MANAGE_TEMPLATES in form.manage_templates.data:
+        if KEY_PERMISSION_MANAGE_TEMPLATES in form.permissions.data:
             permissions.append(KEY_PERMISSION_MANAGE_TEMPLATES)
-        if KEY_PERMISSION_MANAGE_REPORTS in form.manage_templates.data:
+        if KEY_PERMISSION_MANAGE_REPORTS in form.permissions.data:
             permissions.append(KEY_PERMISSION_MANAGE_REPORTS)
         keydata = api_key_api_client.create_api_key(
             service_id=service_id,

--- a/app/notify_client/api_key_api_client.py
+++ b/app/notify_client/api_key_api_client.py
@@ -7,6 +7,7 @@ KEY_TYPE_TEST = "test"
 
 # must match api key permissions in notifications-api/app/models.py
 KEY_PERMISSION_MANAGE_TEMPLATES = "manage_templates"
+KEY_PERMISSION_MANAGE_REPORTS = "manage_reports"
 
 
 class ApiKeyApiClient(NotifyAdminAPIClient):

--- a/app/templates/views/api/keys/create.html
+++ b/app/templates/views/api/keys/create.html
@@ -24,7 +24,7 @@
   {% call form_wrapper() %}
     {{ textbox(form.key_name, label=label_txt) }}
     {{ radios(form.key_type, disable=disabled_options, option_hints=option_hints, use_aria_labelledby=False) }}
-    {% if show_manage_templates %}
+    {% if show_manage_templates or show_manage_reports %}
       {{ checkboxes(form.manage_templates) }}
     {% endif %}
     {{ page_footer(button_txt) }}

--- a/app/templates/views/api/keys/create.html
+++ b/app/templates/views/api/keys/create.html
@@ -25,7 +25,7 @@
     {{ textbox(form.key_name, label=label_txt) }}
     {{ radios(form.key_type, disable=disabled_options, option_hints=option_hints, use_aria_labelledby=False) }}
     {% if show_manage_templates or show_manage_reports %}
-      {{ checkboxes(form.manage_templates) }}
+      {{ checkboxes(form.permissions) }}
     {% endif %}
     {{ page_footer(button_txt) }}
   {% endcall %}

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2475,6 +2475,7 @@
 "Use ((unsubscribe_url)) for one-click unsubscribe","Utilisez ((unsubscribe_url)) pour le désabonnement en un clic"
 "Use ((unsub_link)) for one-click unsubscribe","Utilisez ((unsub_link)) pour le désabonnement en un clic"
 "Allow this key to manage templates (create, update, or delete)","Permettre à cette clé de gérer les gabarits (créer, mettre à jour ou supprimer)"
+"Allow this key to create and download delivery reports","Permettre à cette clé de créer et de télécharger des rapports de livraison"
 "API key permissions","Permissions de la clé API"
 "Manage templates","Gestion des gabarits"
 "File upload in progress","Fichier en préparation"

--- a/tests/app/main/test_create_api_key_form.py
+++ b/tests/app/main/test_create_api_key_form.py
@@ -237,3 +237,89 @@ class TestApiKeyApiClient:
                 "created_by": "user-id",
             },
         )
+
+
+class TestManageReportsPermission:
+    def test_manage_reports_choice_added_when_ff_report_api_enabled(self, client):
+        form = CreateKeyForm([], ff_report_api=True)
+        choice_values = [value for value, _ in form.manage_templates.choices]
+        assert "manage_reports" in choice_values
+
+    def test_manage_reports_choice_label(self, client):
+        form = CreateKeyForm([], ff_report_api=True)
+        choices = dict(form.manage_templates.choices)
+        assert choices["manage_reports"] == "Allow this key to create and download delivery reports"
+
+    def test_manage_reports_choice_not_added_when_ff_report_api_disabled(self, client):
+        form = CreateKeyForm([], ff_report_api=False)
+        choice_values = [value for value, _ in form.manage_templates.choices]
+        assert "manage_reports" not in choice_values
+
+    def test_create_api_key_page_shows_manage_reports_checkbox_when_ff_enabled(
+        self,
+        app_,
+        client_request,
+        mock_get_api_keys,
+        mock_get_live_service,
+        mock_has_permissions,
+    ):
+        with set_config(app_, "FF_REPORT_API", True):
+            page = client_request.get("main.create_api_key", service_id=SERVICE_ONE_ID)
+
+        checkbox = page.find("input", {"name": "manage_templates", "value": "manage_reports", "type": "checkbox"})
+        assert checkbox is not None
+
+    def test_create_api_key_page_hides_manage_reports_checkbox_when_ff_disabled(
+        self,
+        app_,
+        client_request,
+        mock_get_api_keys,
+        mock_get_live_service,
+        mock_has_permissions,
+    ):
+        with set_config(app_, "FF_REPORT_API", False):
+            page = client_request.get("main.create_api_key", service_id=SERVICE_ONE_ID)
+
+        checkbox = page.find("input", {"name": "manage_templates", "value": "manage_reports", "type": "checkbox"})
+        assert checkbox is None
+
+    def test_create_api_key_with_manage_reports_permission(
+        self,
+        app_,
+        client_request,
+        api_user_active,
+        mock_login,
+        mock_get_api_keys,
+        mock_get_live_service,
+        mock_has_permissions,
+        fake_uuid,
+        mocker,
+    ):
+        key_name_from_user = "Reports key"
+        key_name_fixed = "reports_key"
+        post = mocker.patch(
+            "app.notify_client.api_key_api_client.ApiKeyApiClient.post",
+            return_value={"data": {"key": fake_uuid, "key_name": key_name_fixed}},
+        )
+
+        with set_config(app_, "FF_REPORT_API", True):
+            client_request.post(
+                "main.create_api_key",
+                service_id=SERVICE_ONE_ID,
+                _data={
+                    "key_name": key_name_from_user,
+                    "key_type": "normal",
+                    "manage_templates": "manage_reports",
+                },
+                _expected_status=200,
+            )
+
+        post.assert_called_once_with(
+            url="/service/{}/api-key".format(SERVICE_ONE_ID),
+            data={
+                "name": key_name_from_user,
+                "key_type": "normal",
+                "permissions": ["manage_reports"],
+                "created_by": api_user_active["id"],
+            },
+        )

--- a/tests/app/main/test_create_api_key_form.py
+++ b/tests/app/main/test_create_api_key_form.py
@@ -53,7 +53,7 @@ class TestCreateKeyFormValidation:
         form = CreateKeyForm([], formdata=MultiDict([("key_name", "Some key"), ("key_type", "a")]))
         form.key_type.choices = [("a", "a"), ("b", "b")]
         form.validate()
-        assert form.manage_templates.data == []
+        assert form.permissions.data == []
 
     def test_manage_templates_field_is_selected_when_checked(self, client):
         form = CreateKeyForm(
@@ -62,7 +62,7 @@ class TestCreateKeyFormValidation:
         )
         form.key_type.choices = [("a", "a"), ("b", "b")]
         form.validate()
-        assert form.manage_templates.data == ["manage_templates"]
+        assert form.permissions.data == ["manage_templates"]
 
 
 class TestCreateApiKeyView:
@@ -242,17 +242,17 @@ class TestApiKeyApiClient:
 class TestManageReportsPermission:
     def test_manage_reports_choice_added_when_ff_report_api_enabled(self, client):
         form = CreateKeyForm([], ff_report_api=True)
-        choice_values = [value for value, _ in form.manage_templates.choices]
+        choice_values = [value for value, _ in form.permissions.choices]
         assert "manage_reports" in choice_values
 
     def test_manage_reports_choice_label(self, client):
         form = CreateKeyForm([], ff_report_api=True)
-        choices = dict(form.manage_templates.choices)
+        choices = dict(form.permissions.choices)
         assert choices["manage_reports"] == "Allow this key to create and download delivery reports"
 
     def test_manage_reports_choice_not_added_when_ff_report_api_disabled(self, client):
         form = CreateKeyForm([], ff_report_api=False)
-        choice_values = [value for value, _ in form.manage_templates.choices]
+        choice_values = [value for value, _ in form.permissions.choices]
         assert "manage_reports" not in choice_values
 
     def test_create_api_key_page_shows_manage_reports_checkbox_when_ff_enabled(

--- a/tests/app/main/test_create_api_key_form.py
+++ b/tests/app/main/test_create_api_key_form.py
@@ -77,7 +77,7 @@ class TestCreateApiKeyView:
         with set_config(app_, "FF_ADD_TEMPLATE_PERM", True):
             page = client_request.get("main.create_api_key", service_id=SERVICE_ONE_ID)
 
-        checkbox = page.find("input", {"name": "manage_templates", "type": "checkbox"})
+        checkbox = page.find("input", {"name": "permissions", "type": "checkbox"})
         assert checkbox is not None
 
     def test_create_api_key_with_manage_templates_permission(
@@ -106,7 +106,7 @@ class TestCreateApiKeyView:
                 _data={
                     "key_name": key_name_from_user,
                     "key_type": "normal",
-                    "manage_templates": "manage_templates",
+                    "permissions": "manage_templates",
                 },
                 _expected_status=200,
             )
@@ -266,7 +266,7 @@ class TestManageReportsPermission:
         with set_config(app_, "FF_REPORT_API", True):
             page = client_request.get("main.create_api_key", service_id=SERVICE_ONE_ID)
 
-        checkbox = page.find("input", {"name": "manage_templates", "value": "manage_reports", "type": "checkbox"})
+        checkbox = page.find("input", {"name": "permissions", "value": "manage_reports", "type": "checkbox"})
         assert checkbox is not None
 
     def test_create_api_key_page_hides_manage_reports_checkbox_when_ff_disabled(
@@ -280,7 +280,7 @@ class TestManageReportsPermission:
         with set_config(app_, "FF_REPORT_API", False):
             page = client_request.get("main.create_api_key", service_id=SERVICE_ONE_ID)
 
-        checkbox = page.find("input", {"name": "manage_templates", "value": "manage_reports", "type": "checkbox"})
+        checkbox = page.find("input", {"name": "permissions", "value": "manage_reports", "type": "checkbox"})
         assert checkbox is None
 
     def test_create_api_key_with_manage_reports_permission(
@@ -309,7 +309,7 @@ class TestManageReportsPermission:
                 _data={
                     "key_name": key_name_from_user,
                     "key_type": "normal",
-                    "manage_templates": "manage_reports",
+                    "permissions": "manage_reports",
                 },
                 _expected_status=200,
             )

--- a/tests/app/main/test_create_api_key_form.py
+++ b/tests/app/main/test_create_api_key_form.py
@@ -58,7 +58,7 @@ class TestCreateKeyFormValidation:
     def test_manage_templates_field_is_selected_when_checked(self, client):
         form = CreateKeyForm(
             [],
-            formdata=MultiDict([("key_name", "Some key"), ("key_type", "a"), ("manage_templates", "manage_templates")]),
+            formdata=MultiDict([("key_name", "Some key"), ("key_type", "a"), ("permissions", "manage_templates")]),
         )
         form.key_type.choices = [("a", "a"), ("b", "b")]
         form.validate()


### PR DESCRIPTION
# Summary | Résumé

Add the `manage_reports` permission for new api keys. This is hidden behind the `FF_REPORT_API`.



# Test instructions | Instructions pour tester la modification

1. check out the branch locally 
2. add `FF_REPORT_API=true` to your .env for admin and api
3. run admin and api locally
4. create a new api key, verify that you see the new checkbox for the "manage reports" permission
5. look in your local db in the `api_keys` table, verify that the new api key has "manage_reports` in the permissions column.