### PR TITLE
Show list of attachments on template edit page

### DIFF
--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1281,6 +1281,7 @@ def edit_service_template(service_id, template_id):
             )
         )
     else:
+        template_attachments = None
         if (
             current_app.config.get("FF_FILE_ATTACHMENTS")
             and template["template_type"] == "email"

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1287,10 +1287,19 @@ def edit_service_template(service_id, template_id):
             and template["template_type"] == "email"
             and current_service.has_permission("upload_document")
         ):
-            template_attachments = filter_attachments(
-                current_service.get_template_attachments(template_id),
-                exclude_statuses={"deleted", "virus_scan_failed"},
-            )
+            template_attachments = [
+                {
+                    "id": attachment.get("id"),
+                    "filename": attachment.get("name") or attachment.get("filename"),
+                    "file_size": attachment.get("size") or attachment.get("file_size"),
+                    "status": attachment.get("status") or "uploaded",
+                }
+                for attachment in filter_attachments(
+                    current_service.get_template_attachments(template_id),
+                    exclude_statuses={"deleted", "virus_scan_failed"},
+                )
+                if attachment.get("name") or attachment.get("filename")
+            ]
 
         return render_template(
             f"views/edit-{template['template_type']}-template.html",

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -1281,6 +1281,16 @@ def edit_service_template(service_id, template_id):
             )
         )
     else:
+        if (
+            current_app.config.get("FF_FILE_ATTACHMENTS")
+            and template["template_type"] == "email"
+            and current_service.has_permission("upload_document")
+        ):
+            template_attachments = filter_attachments(
+                current_service.get_template_attachments(template_id),
+                exclude_statuses={"deleted", "virus_scan_failed"},
+            )
+
         return render_template(
             f"views/edit-{template['template_type']}-template.html",
             form=form,
@@ -1292,6 +1302,7 @@ def edit_service_template(service_id, template_id):
             sms_char_count_limit=SMS_CHAR_COUNT_LIMIT,
             one_click_unsub_enabled=current_app.config.get("ONE_CLICK_UNSUB_ALL_SERVICES", False)
             or str(service_id) in current_app.config.get("ONE_CLICK_UNSUB_SERVICE_IDS", []),
+            attachments=template_attachments,
         )
 
 

--- a/app/templates/partials/template-attachments-list.html
+++ b/app/templates/partials/template-attachments-list.html
@@ -15,7 +15,8 @@
   - summary text and warning behavior should track product decisions in send views.
  #}
 {% if template.template_type == 'email' and template_attachments %}
-  <section class="mb-8 border border-gray-300 p-4 attachment-list-flush-top" data-testid="template-attachments-list">
+  {% set attachment_list_classes = attachment_list_classes|default('attachment-list-flush-top') %}
+  <section class="mb-8 border border-gray-300 p-4 {{ attachment_list_classes }}" data-testid="template-attachments-list">
     <ul class="list-none m-0 p-0" data-testid="template-attachments-items">
       {% for attachment in template_attachments %}
         <li class="attachment-file-row border border-gray-300 p-3 mb-2" data-testid="template-attachments-item">

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -10,6 +10,7 @@
 {% from "components/template-content.html" import template_content with context %}
 {% from "components/links.html" import content_link with context %}
 {% from "components/tiptap-editor.html" import tiptap_editor with context %}
+{% from "components/notice.html" import notice %}
 
 {% block service_page_title %}
   {{ heading }}
@@ -84,6 +85,50 @@
         templateType=template_type if template_type else template.template_type,
         initialMode="rte" if current_user.default_editor_is_rte else "markdown") 
       }}
+
+      {% if config['FF_FILE_ATTACHMENTS'] and attachments %}
+        {% set attachment_count = attachments|length %}
+
+        <section class="mb-16">
+          <h2 id="attachments-heading" class="heading-medium">
+            {{ _("Attachments") }}
+          </h2>
+
+          {% call notice('info') %}
+            <p data-testid="file-attachments-edit-template-notice">
+              {{ _('To edit attachments, save changes to your template or press back.') }}
+            </p>
+          {% endcall %}
+
+          <ul
+            class="mt-5 mb-4"
+            data-testid="attachments-list-static"
+            aria-label="{{ _('Files attached to this template') }}"
+          >
+            {% for attachment in attachments %}
+              {% set readable_size = attachment['file_size'] | filesizeformat %}
+
+              <li
+                class="attachment-file-row border border-gray-300 p-3 mb-2"
+                data-testid="attached-file-row-static"
+                tabindex="0"
+                aria-label="{{ _('Attachment') }} {{ attachment['name'] }}, {{ readable_size }}"
+              >
+                <div class="flex justify-between gap-6 items-start">
+                  <div class="flex flex-col min-w-0">
+                    {{ attachment['name'] }}
+                  </div>
+
+                  <div class="inline-flex items-center gap-2" aria-hidden="true">
+                    {{ readable_size }}
+                  </div>
+                </div>
+              </li>
+            {% endfor %}
+          </ul>
+          <p id="template-attachments-attachments-status" class="hint" data-testid="attachments-summary-static" aria-live="polite" aria-atomic="true">{{ attachment_count }} {{ _('files attached') }} </p>
+        </section>
+      {% endif %}
 
       <h2 class="heading-medium">{{ _('Template category') }}</h2>
       {% call template_category(form.template_category_id, true if template_category_mode == 'expand' else false) %}

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -87,8 +87,6 @@
       }}
 
       {% if config['FF_FILE_ATTACHMENTS'] and attachments %}
-        {% set attachment_count = attachments|length %}
-
         <section class="mb-16">
           <h2 id="attachments-heading" class="heading-medium">
             {{ _("Attachments") }}
@@ -100,33 +98,9 @@
             </p>
           {% endcall %}
 
-          <ul
-            class="mt-5 mb-4"
-            data-testid="attachments-list-static"
-            aria-label="{{ _('Files attached to this template') }}"
-          >
-            {% for attachment in attachments %}
-              {% set readable_size = attachment['file_size'] | filesizeformat %}
-
-              <li
-                class="attachment-file-row border border-gray-300 p-3 mb-2"
-                data-testid="attached-file-row-static"
-                tabindex="0"
-                aria-label="{{ _('Attachment') }} {{ attachment['name'] }}, {{ readable_size }}"
-              >
-                <div class="flex justify-between gap-6 items-start">
-                  <div class="flex flex-col min-w-0">
-                    {{ attachment['name'] }}
-                  </div>
-
-                  <div class="inline-flex items-center gap-2" aria-hidden="true">
-                    {{ readable_size }}
-                  </div>
-                </div>
-              </li>
-            {% endfor %}
-          </ul>
-          <p id="template-attachments-attachments-status" class="hint" data-testid="attachments-summary-static" aria-live="polite" aria-atomic="true">{{ attachment_count }} {{ _('files attached') }} </p>
+          {% set template_attachments = attachments %}
+          {% set attachment_list_classes = 'mt-4' %}
+          {% include "partials/template-attachments-list.html" %}
         </section>
       {% endif %}
 

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2494,3 +2494,7 @@
 "Counted as 1 text message part.","Compté comme 1 partie de message texte."
 "Counted as {} text message parts.","Compté comme {} parties de messages texte."
 "Text message parts count toward your sending limits.","Les parties de message texte comptent envers vos limites d'envoi."
+"To edit attachments, save changes to your template or press back.","Pour modifier les pièces jointes, enregistrez les modifications apportées à votre modèle ou appuyez sur Retour."
+"Attachment,","Pièce jointe"
+"files attached","fichiers joints"
+"Files attached to this template","Fichiers joints à ce gabarit"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2495,6 +2495,6 @@
 "Counted as {} text message parts.","Compté comme {} parties de messages texte."
 "Text message parts count toward your sending limits.","Les parties de message texte comptent envers vos limites d'envoi."
 "To edit attachments, save changes to your template or press back.","Pour modifier les pièces jointes, enregistrez les modifications apportées à votre modèle ou appuyez sur Retour."
-"Attachment,","Pièce jointe"
+"Attachment","Pièce jointe"
 "files attached","fichiers joints"
 "Files attached to this template","Fichiers joints à ce gabarit"


### PR DESCRIPTION
# Summary | Résumé
This PR adds a non-editable list of template file attachments to the edit template page. The design mirrors what is displayed on the template page but as simple static markup with the "cancel" button replaced by the file size

# Test instructions | Instructions pour tester la modification
1. Navigate to a template with files attached --> click edit
- [ ] Note the new section just below the editor that displays file attachments
3. Turn on VoiceOver and navigate through the elements
- [ ] `<ul>` focused --> "Files attached to this template"
- [ ] `<li>` focused --> "Attachment, `<filename>`, `<filesize>`"

