### PR TITLE
Fix/attach handle api errors

### DIFF
--- a/app/assets/javascripts/attachments/AttachmentsWidget.js
+++ b/app/assets/javascripts/attachments/AttachmentsWidget.js
@@ -87,6 +87,8 @@ export const AttachmentsWidget = ({
         const errorData = await response.json();
         if (errorData.error === "over_file_limit") {
           errorMessage = copy.overFileLimit;
+        } else if (errorData.error === "unsupported_file_type") {
+          errorMessage = copy.unsupportedFileType;
         } else if (errorData.message) {
           errorMessage = errorData.message;
         }

--- a/app/assets/javascripts/attachments/AttachmentsWidget.js
+++ b/app/assets/javascripts/attachments/AttachmentsWidget.js
@@ -85,16 +85,13 @@ export const AttachmentsWidget = ({
       // Try to extract error details from API response
       try {
         const errorData = await response.json();
-        console.log("API error response:", errorData);
-        console.log("copy.overFileLimit:", copy.overFileLimit);
         if (errorData.error === "over_file_limit") {
           errorMessage = copy.overFileLimit;
-          console.log("Set errorMessage to:", errorMessage);
         } else if (errorData.message) {
           errorMessage = errorData.message;
         }
       } catch (parseError) {
-        console.error("Failed to parse error response:", parseError);
+        // Fall back to the default status-based message when response body is not JSON.
       }
 
       throw new Error(errorMessage);

--- a/app/assets/javascripts/attachments/AttachmentsWidget.js
+++ b/app/assets/javascripts/attachments/AttachmentsWidget.js
@@ -81,10 +81,14 @@ export const AttachmentsWidget = ({
 
     if (!response.ok) {
       let errorMessage = `Failed to upload attachments (${response.status})`;
+      let createdFiles = [];
 
       // Try to extract error details from API response
       try {
         const errorData = await response.json();
+        createdFiles = Array.isArray(errorData.created_files)
+          ? errorData.created_files
+          : [];
         if (errorData.error === "over_file_limit") {
           errorMessage = copy.overFileLimit;
         } else if (errorData.error === "unsupported_file_type") {
@@ -96,7 +100,9 @@ export const AttachmentsWidget = ({
         // Fall back to the default status-based message when response body is not JSON.
       }
 
-      throw new Error(errorMessage);
+      const uploadError = new Error(errorMessage);
+      uploadError.createdFiles = createdFiles;
+      throw uploadError;
     }
 
     if (!response.headers.get("content-type")?.includes("application/json")) {

--- a/app/assets/javascripts/attachments/localization.js
+++ b/app/assets/javascripts/attachments/localization.js
@@ -15,6 +15,7 @@ const en = {
   duplicateFilename: (name) => `You've already uploaded this file: ${name}.`,
   overFileLimit:
     "The total file size exceeds the 6 MB limit. Please remove some files and try again.",
+  unsupportedFileType: "File type not supported",
   summaryUploading: (count) =>
     `${count} ${count === 1 ? "file" : "files"} uploading`,
   summaryScanning: (count) =>
@@ -70,6 +71,7 @@ const fr = {
     `Vous avez déjà téléchargé ce fichier : ${name}.`,
   overFileLimit:
     "La taille totale des fichiers dépasse la limite de 6 Mo. Veuillez supprimer des fichiers et réessayer.",
+  unsupportedFileType: "Type de fichier non pris en charge",
   summaryUploading: (count) =>
     `${count} ${count === 1 ? "fichier" : "fichiers"} en préparation`,
   summaryScanning: (count) =>

--- a/app/assets/javascripts/attachments/useAttachments.js
+++ b/app/assets/javascripts/attachments/useAttachments.js
@@ -264,6 +264,31 @@ export const useAttachments = (
     [files],
   );
 
+  const mapUploadedFiles = (callbackItems, selectedFiles) =>
+    callbackItems
+      .map((item, index) => {
+        const itemData = item?.data || item;
+        const fileId = itemData?.id;
+
+        if (!fileId) {
+          return null;
+        }
+
+        const sourceFile = selectedFiles[index];
+
+        return {
+          id: fileId,
+          name: sourceFile?.name || itemData?.name || `attachment-${nextId()}`,
+          size: sourceFile?.size || itemData?.file_size || 0,
+          status: parseApiStatus(
+            itemData?.status,
+            ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
+          ),
+          sourceFile: undefined,
+        };
+      })
+      .filter(Boolean);
+
   const attachFiles = async (selectedFiles, onAttachFiles) => {
     if (!selectedFiles.length) {
       return;
@@ -282,30 +307,7 @@ export const useAttachments = (
         return;
       }
 
-      const uploadedFiles = callbackItems
-        .map((item, index) => {
-          const itemData = item?.data || item;
-          const fileId = itemData?.id;
-
-          if (!fileId) {
-            return null;
-          }
-
-          const sourceFile = selectedFiles[index];
-
-          return {
-            id: fileId,
-            name:
-              sourceFile?.name || itemData?.name || `attachment-${nextId()}`,
-            size: sourceFile?.size || itemData?.file_size || 0,
-            status: parseApiStatus(
-              itemData?.status,
-              ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,
-            ),
-            sourceFile: undefined,
-          };
-        })
-        .filter(Boolean);
+      const uploadedFiles = mapUploadedFiles(callbackItems, selectedFiles);
 
       if (!uploadedFiles.length) {
         return;
@@ -313,6 +315,15 @@ export const useAttachments = (
 
       setFiles((currentFiles) => [...currentFiles, ...uploadedFiles]);
     } catch (error) {
+      const partialItems = Array.isArray(error?.createdFiles)
+        ? error.createdFiles
+        : [];
+      const partialUploadedFiles = mapUploadedFiles(partialItems, selectedFiles);
+
+      if (partialUploadedFiles.length) {
+        setFiles((currentFiles) => [...currentFiles, ...partialUploadedFiles]);
+      }
+
       throw error;
     }
   };

--- a/app/assets/javascripts/attachments/useAttachments.js
+++ b/app/assets/javascripts/attachments/useAttachments.js
@@ -288,7 +288,7 @@ export const useAttachments = (
         return {
           id: fileId,
           name: sourceFile?.name || itemData?.name || `attachment-${nextId()}`,
-          size: sourceFile?.size || itemData?.file_size || 0,
+          file_size: toFiniteFileSize(itemData?.file_size ?? sourceFile?.size),
           status: parseApiStatus(
             itemData?.status,
             ATTACHMENT_STATUSES.PENDING_VIRUS_SCAN,

--- a/app/assets/javascripts/attachments/useAttachments.js
+++ b/app/assets/javascripts/attachments/useAttachments.js
@@ -327,7 +327,10 @@ export const useAttachments = (
       const partialItems = Array.isArray(error?.createdFiles)
         ? error.createdFiles
         : [];
-      const partialUploadedFiles = mapUploadedFiles(partialItems, selectedFiles);
+      const partialUploadedFiles = mapUploadedFiles(
+        partialItems,
+        selectedFiles,
+      );
 
       if (partialUploadedFiles.length) {
         setFiles((currentFiles) => [...currentFiles, ...partialUploadedFiles]);

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -255,9 +255,11 @@ def _build_file_upload_error_response(http_error):
 
     error_code = http_error.status_code
     error_message = getattr(http_error, "message", str(http_error))
+    api_error = error_data.get("error")
+    api_message = error_data.get("message")
 
     # Prioritize explicit API error codes from payload, even if status code is transformed.
-    if error_data.get("error") == "over_file_limit":
+    if api_error == "over_file_limit":
         return {
             "error": "over_file_limit",
             "current_usage": error_data.get("current_usage", 0),
@@ -265,13 +267,22 @@ def _build_file_upload_error_response(http_error):
             "limit": error_data.get("limit", 0),
         }
 
-    if error_data.get("error") == "file_data is not valid base64":
+    if api_error == "file_data is not valid base64":
         return {"error": "invalid_file_data"}
+
+    unsupported_doc_type_message = "unsupported document type"
+    if (isinstance(api_message, str) and unsupported_doc_type_message in api_message.lower()) or (
+        isinstance(api_error, str) and unsupported_doc_type_message in api_error.lower()
+    ):
+        return {"error": "unsupported_file_type"}
 
     # Handle specific error cases
     if error_code == 400:
         # Generic 400 error
-        return {"error": "bad_request", "message": error_data.get("error", error_message)}
+        return {
+            "error": "bad_request",
+            "message": api_message or api_error or error_message,
+        }
     elif error_code == 403:
         return {"error": "permission_denied", "message": "You don't have permission to upload files"}
     elif error_code == 404:

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -243,7 +243,7 @@ def _build_file_upload_error_response(http_error):
     Build a structured error response from an HTTPError raised by file upload.
     Handles different error types from the API:
     - over_file_limit: Returns structured response with usage details
-    - invalid base64: Returns generic error
+    - invalid base64: Returns invalid_file_data
     - permission denied (403): Returns permission error
     - not found (404): Returns not found error
     - server error (500): Returns server error

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -332,6 +332,8 @@ def attach_files(service_id, template_id):
     # If there was an error, return it with whatever files were created
     if error:
         error_response = _build_file_upload_error_response(error)
+        if created_files:
+            error_response["created_files"] = created_files
         return jsonify(error_response), error_status_code
 
     return jsonify(created_files)

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -238,6 +238,50 @@ def _abort_if_attachments_disabled_for_service():
         abort(404)
 
 
+def _build_file_upload_error_response(http_error):
+    """
+    Build a structured error response from an HTTPError raised by file upload.
+    Handles different error types from the API:
+    - over_file_limit: Returns structured response with usage details
+    - invalid base64: Returns generic error
+    - permission denied (403): Returns permission error
+    - not found (404): Returns not found error
+    - server error (500): Returns server error
+    """
+    try:
+        error_data = json.loads(http_error.response.text)
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        error_data = {}
+
+    error_code = http_error.status_code
+    error_message = getattr(http_error, "message", str(http_error))
+
+    # Prioritize explicit API error codes from payload, even if status code is transformed.
+    if error_data.get("error") == "over_file_limit":
+        return {
+            "error": "over_file_limit",
+            "current_usage": error_data.get("current_usage", 0),
+            "requested": error_data.get("requested", 0),
+            "limit": error_data.get("limit", 0),
+        }
+
+    if error_data.get("error") == "file_data is not valid base64":
+        return {"error": "invalid_file_data"}
+
+    # Handle specific error cases
+    if error_code == 400:
+        # Generic 400 error
+        return {"error": "bad_request", "message": error_data.get("error", error_message)}
+    elif error_code == 403:
+        return {"error": "permission_denied", "message": "You don't have permission to upload files"}
+    elif error_code == 404:
+        return {"error": "template_not_found", "message": "The template was not found"}
+    elif error_code >= 500:
+        return {"error": "server_error", "message": "Failed to upload file to storage"}
+    else:
+        return {"error": "unknown_error", "status_code": error_code, "message": error_message}
+
+
 @main.route(
     "/services/<service_id>/templates/<uuid:template_id>/attachments",
     methods=["POST"],
@@ -249,6 +293,7 @@ def attach_files(service_id, template_id):
     uploaded_files = request.files.getlist("files")
     created_files = []
     error = None
+    error_status_code = 500
 
     for uploaded_file in uploaded_files:
         file_contents = uploaded_file.read()
@@ -271,15 +316,12 @@ def attach_files(service_id, template_id):
             # This allows partial uploads to succeed while reporting the error
             if not error:
                 error = e
+                error_status_code = e.status_code
 
     # If there was an error, return it with whatever files were created
     if error:
-        try:
-            error_code = json.loads(error.response.text)["error"]
-        except (json.JSONDecodeError, KeyError, TypeError):
-            error_code = "unknown_error"
-
-        return jsonify({"error": error_code}), error.status_code
+        error_response = _build_file_upload_error_response(error)
+        return jsonify(error_response), error_status_code
 
     return jsonify(created_files)
 

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1,3 +1,5 @@
+import io
+import json
 from datetime import datetime
 from functools import partial
 from unittest.mock import ANY, MagicMock, Mock, patch
@@ -933,6 +935,140 @@ def test_template_attachment_download_route_returns_file(
     assert response.data == b"example content"
     assert response.headers["Content-Disposition"] == 'attachment; filename="example-file-1.txt"'
     mock_get_file_contents.assert_called_once_with(UUID(fake_uuid), "file-1")
+
+
+@pytest.mark.parametrize(
+    "status_code,error_payload,expected_payload",
+    [
+        (
+            400,
+            {
+                "error": "over_file_limit",
+                "current_usage": 5000000,
+                "requested": 2000000,
+                "limit": 6291456,
+            },
+            {
+                "error": "over_file_limit",
+                "current_usage": 5000000,
+                "requested": 2000000,
+                "limit": 6291456,
+            },
+        ),
+        (
+            400,
+            {"error": "file_data is not valid base64"},
+            {"error": "invalid_file_data"},
+        ),
+        (
+            400,
+            {"error": "some other error"},
+            {"error": "bad_request", "message": "some other error"},
+        ),
+        (
+            403,
+            {},
+            {
+                "error": "permission_denied",
+                "message": "You don't have permission to upload files",
+            },
+        ),
+        (
+            404,
+            {},
+            {
+                "error": "template_not_found",
+                "message": "The template was not found",
+            },
+        ),
+        (
+            500,
+            {},
+            {
+                "error": "server_error",
+                "message": "Failed to upload file to storage",
+            },
+        ),
+    ],
+)
+def test_template_attachment_upload_route_maps_api_errors(
+    client_request,
+    fake_uuid,
+    service_one,
+    app_,
+    mocker,
+    status_code,
+    error_payload,
+    expected_payload,
+):
+    current_user.verified_phonenumber = True
+    service_one["permissions"].append("upload_document")
+
+    error_response = Mock(status_code=status_code)
+    error_response.text = json.dumps(error_payload)
+    mocker.patch(
+        "app.main.views.templates.file_api_client.create_file",
+        side_effect=HTTPError(response=error_response, message="upload failed"),
+    )
+
+    with set_config(app_, "FF_FILE_ATTACHMENTS", True):
+        response = client_request.logged_in_client.post(
+            url_for("main.attach_files", service_id=SERVICE_ONE_ID, template_id=fake_uuid),
+            data={"files": (io.BytesIO(b"file-content"), "test.pdf")},
+            content_type="multipart/form-data",
+        )
+
+    assert response.status_code == status_code
+    assert response.get_json() == expected_payload
+
+
+def test_template_attachment_upload_continues_after_first_error(
+    client_request,
+    fake_uuid,
+    service_one,
+    app_,
+    mocker,
+):
+    current_user.verified_phonenumber = True
+    service_one["permissions"].append("upload_document")
+
+    error_response = Mock(status_code=400)
+    error_response.text = json.dumps(
+        {
+            "error": "over_file_limit",
+            "current_usage": 5000000,
+            "requested": 2000000,
+            "limit": 6291456,
+        }
+    )
+    create_file_mock = mocker.patch(
+        "app.main.views.templates.file_api_client.create_file",
+        side_effect=[
+            HTTPError(response=error_response, message="upload failed"),
+            {"id": "second-file", "status": "pending_virus_scan"},
+        ],
+    )
+
+    with set_config(app_, "FF_FILE_ATTACHMENTS", True):
+        response = client_request.logged_in_client.post(
+            url_for("main.attach_files", service_id=SERVICE_ONE_ID, template_id=fake_uuid),
+            data={
+                "files": [
+                    (io.BytesIO(b"first-file"), "first.pdf"),
+                    (io.BytesIO(b"second-file"), "second.pdf"),
+                ]
+            },
+            content_type="multipart/form-data",
+        )
+
+    assert create_file_mock.call_count == 2
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "over_file_limit",
+        "current_usage": 5000000,
+        "requested": 2000000,
+        "limit": 6291456,
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -1068,6 +1068,7 @@ def test_template_attachment_upload_continues_after_first_error(
         "current_usage": 5000000,
         "requested": 2000000,
         "limit": 6291456,
+        "created_files": [{"id": "second-file", "status": "pending_virus_scan"}],
     }
 
 

--- a/tests/app/main/views/test_templates_attach_files.py
+++ b/tests/app/main/views/test_templates_attach_files.py
@@ -1,0 +1,126 @@
+import io
+import json
+from unittest.mock import Mock
+
+from notifications_python_client.errors import HTTPError
+
+from app.main.views.templates import _build_file_upload_error_response
+
+
+def _mock_file_upload(data=None, filename="test.pdf", mimetype="application/pdf"):
+    """Helper to create a mock file upload."""
+    file_content = data or b"test file content"
+    file = io.BytesIO(file_content)
+    file.filename = filename
+    file.mimetype = mimetype
+    return file
+
+
+class TestBuildFileUploadErrorResponse:
+    def test_over_file_limit_error_includes_usage_details(self):
+        """Test that over_file_limit errors include usage breakdown."""
+        error_response = Mock()
+        error_response.status_code = 400
+        error_response.text = json.dumps(
+            {
+                "error": "over_file_limit",
+                "current_usage": 5000000,
+                "requested": 2000000,
+                "limit": 6291456,
+            }
+        )
+        http_error = HTTPError(error_response)
+
+        result = _build_file_upload_error_response(http_error)
+
+        assert result["error"] == "over_file_limit"
+        assert result["current_usage"] == 5000000
+        assert result["requested"] == 2000000
+        assert result["limit"] == 6291456
+
+    def test_invalid_base64_error_returns_specific_error(self):
+        """Test that invalid base64 errors are identified."""
+        error_response = Mock()
+        error_response.status_code = 400
+        error_response.text = json.dumps({"error": "file_data is not valid base64"})
+        http_error = HTTPError(error_response)
+
+        result = _build_file_upload_error_response(http_error)
+
+        assert result["error"] == "invalid_file_data"
+
+    def test_over_file_limit_payload_takes_precedence_over_status_code(self):
+        """Test that over_file_limit payload is preserved even if status is transformed."""
+        error_response = Mock()
+        error_response.status_code = 500
+        error_response.text = json.dumps(
+            {
+                "error": "over_file_limit",
+                "current_usage": 5000000,
+                "requested": 2000000,
+                "limit": 6291456,
+            }
+        )
+        http_error = HTTPError(error_response)
+
+        result = _build_file_upload_error_response(http_error)
+
+        assert result["error"] == "over_file_limit"
+        assert result["current_usage"] == 5000000
+        assert result["requested"] == 2000000
+        assert result["limit"] == 6291456
+
+    def test_generic_400_error_returns_bad_request(self):
+        """Test that generic 400 errors are identified."""
+        error_response = Mock()
+        error_response.status_code = 400
+        error_response.text = json.dumps({"error": "some other error"})
+        http_error = HTTPError(error_response)
+
+        result = _build_file_upload_error_response(http_error)
+
+        assert result["error"] == "bad_request"
+
+    def test_403_error_returns_permission_denied(self):
+        """Test that 403 errors are identified as permission errors."""
+        error_response = Mock()
+        error_response.status_code = 403
+        error_response.text = json.dumps({})
+        http_error = HTTPError(error_response)
+
+        result = _build_file_upload_error_response(http_error)
+
+        assert result["error"] == "permission_denied"
+
+    def test_404_error_returns_not_found(self):
+        """Test that 404 errors are identified as not found."""
+        error_response = Mock()
+        error_response.status_code = 404
+        error_response.text = json.dumps({})
+        http_error = HTTPError(error_response)
+
+        result = _build_file_upload_error_response(http_error)
+
+        assert result["error"] == "template_not_found"
+
+    def test_500_error_returns_server_error(self):
+        """Test that 500 errors are identified as server errors."""
+        error_response = Mock()
+        error_response.status_code = 500
+        error_response.text = json.dumps({})
+        http_error = HTTPError(error_response)
+
+        result = _build_file_upload_error_response(http_error)
+
+        assert result["error"] == "server_error"
+
+    def test_unparseable_error_response(self):
+        """Test handling of unparseable error responses."""
+        error_response = Mock()
+        error_response.status_code = 500
+        error_response.text = "Not JSON"
+        http_error = HTTPError(error_response)
+
+        result = _build_file_upload_error_response(http_error)
+
+        assert result["error"] == "server_error"

--- a/tests/app/main/views/test_templates_attach_files.py
+++ b/tests/app/main/views/test_templates_attach_files.py
@@ -81,6 +81,22 @@ class TestBuildFileUploadErrorResponse:
 
         assert result["error"] == "bad_request"
 
+    def test_unsupported_document_type_message_returns_specific_error(self):
+        """Test that unsupported document type messages map to unsupported_file_type."""
+        error_response = Mock()
+        error_response.status_code = 400
+        error_response.text = json.dumps(
+            {
+                "error": "bad_request",
+                "message": ("Unsupported document type 'text/html'. Supported types are: " "['application/pdf', 'text/plain']"),
+            }
+        )
+        http_error = HTTPError(error_response)
+
+        result = _build_file_upload_error_response(http_error)
+
+        assert result["error"] == "unsupported_file_type"
+
     def test_403_error_returns_permission_denied(self):
         """Test that 403 errors are identified as permission errors."""
         error_response = Mock()

--- a/tests/app/notify_client/test_file_api_client.py
+++ b/tests/app/notify_client/test_file_api_client.py
@@ -1,3 +1,6 @@
+import pytest
+from notifications_python_client.errors import HTTPError
+
 from app.notify_client.file_api_client import FileApiClient, file_api_client
 
 
@@ -38,6 +41,29 @@ class TestFileApiClient:
                 "created_by": "test-user-id",
             },
         )
+
+    def test_create_file_raises_http_error_on_api_error(self, mocker):
+        client = FileApiClient()
+        mocker.patch("app.notify_client.file_api_client.current_user", new=mocker.Mock(id="test-user-id"))
+
+        error_response = mocker.Mock()
+        error_response.status_code = 400
+        error_response.text = '{"error": "over_file_limit"}'
+        http_error = HTTPError(error_response)
+
+        mocker.patch.object(client, "post", side_effect=http_error)
+
+        with pytest.raises(HTTPError) as excinfo:
+            client.create_file(
+                "template-id",
+                "upload_document",
+                "large-file.pdf",
+                "application/pdf",
+                2000000,
+                "base64data",
+            )
+
+            assert excinfo.value is http_error
 
     def test_delete_file(self, mocker):
         client = FileApiClient()

--- a/tests/app/notify_client/test_file_api_client.py
+++ b/tests/app/notify_client/test_file_api_client.py
@@ -63,7 +63,7 @@ class TestFileApiClient:
                 "base64data",
             )
 
-            assert excinfo.value is http_error
+        assert excinfo.value is http_error
 
     def test_delete_file(self, mocker):
         client = FileApiClient()

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -726,6 +726,40 @@ describe("attachments - useAttachments", () => {
 
     harness.cleanup();
   });
+
+  test("adds partial uploaded files when upload callback throws with createdFiles", async () => {
+    const harness = setupHookHarness();
+    let thrownError = null;
+
+    await act(async () => {
+      try {
+        const uploadError = new Error("partial upload");
+        uploadError.createdFiles = [
+          {
+            id: "partial-1",
+            status: "pending_virus_scan",
+          },
+        ];
+
+        await harness.getState().attachFiles(
+          [{ name: "partial-file.pdf", size: 2048 }],
+          async () => {
+            throw uploadError;
+          },
+        );
+      } catch (error) {
+        thrownError = error;
+      }
+    });
+
+    expect(thrownError).toBeTruthy();
+    expect(thrownError.message).toBe("partial upload");
+    expect(harness.getState().files).toHaveLength(1);
+    expect(harness.getState().files[0].id).toBe("partial-1");
+    expect(harness.getState().files[0].name).toBe("partial-file.pdf");
+
+    harness.cleanup();
+  });
 });
 
 describe("attachments - download error handling", () => {

--- a/tests/javascripts/attachments.test.js
+++ b/tests/javascripts/attachments.test.js
@@ -936,7 +936,9 @@ describe("attachments - download error handling", () => {
 
     expect(onDownloadError).toHaveBeenCalledWith("file-1", expect.stringContaining("Download failed"));
 
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     document.body.removeChild(container);
   });
 
@@ -974,7 +976,9 @@ describe("attachments - download error handling", () => {
     expect(onDownloadError).not.toHaveBeenCalled();
     expect(global.fetch).toHaveBeenCalledWith("/download/file-2");
 
-    root.unmount();
+    act(() => {
+      root.unmount();
+    });
     document.body.removeChild(container);
   });
 });

--- a/tests/javascripts/attachments/AttachmentsWidget.test.js
+++ b/tests/javascripts/attachments/AttachmentsWidget.test.js
@@ -253,6 +253,58 @@ describe("AttachmentsWidget accessibility", () => {
     act(() => root.unmount());
   });
 
+  test("keeps successfully created files when API returns error with created_files", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      headers: { get: () => "application/json" },
+      json: async () => ({
+        error: "over_file_limit",
+        created_files: [
+          {
+            id: "created-1",
+            status: "pending_virus_scan",
+            file_size: 1024,
+          },
+        ],
+      }),
+    });
+
+    const { container, root } = renderComponent(
+      React.createElement(AttachmentsWidget, {
+        ...baseProps,
+        initialFiles: [],
+      }),
+    );
+
+    const openModalButton = container.querySelector(
+      '[data-testid="attachments-open-modal"]',
+    );
+    act(() => {
+      openModalButton.click();
+    });
+
+    const input = container.querySelector('[data-testid="attachments-file-input"]');
+    const file = new File(["abc"], "partial.pdf", { type: "application/pdf" });
+    selectFiles(input, [file]);
+
+    const submitButton = container.querySelector('[data-testid="attachments-submit"]');
+    await act(async () => {
+      submitButton.click();
+    });
+
+    const rows = container.querySelectorAll('[data-testid="attached-file-row"]');
+    const errors = container.querySelector('[data-testid="attach-validation-errors"]');
+
+    expect(rows).toHaveLength(1);
+    expect(container.textContent).toContain("partial.pdf");
+    expect(errors.textContent).toContain(
+      "The total file size exceeds the 6 MB limit. Please remove some files and try again.",
+    );
+
+    act(() => root.unmount());
+  });
+
   test("shows unsupported file type message when API returns unsupported_file_type", async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,

--- a/tests/javascripts/attachments/AttachmentsWidget.test.js
+++ b/tests/javascripts/attachments/AttachmentsWidget.test.js
@@ -17,6 +17,18 @@ const renderComponent = (element) => {
   return { container, root };
 };
 
+const selectFiles = (input, files) => {
+  Object.defineProperty(input, "files", {
+    value: files,
+    writable: false,
+    configurable: true,
+  });
+
+  act(() => {
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+};
+
 describe("AttachmentsWidget accessibility", () => {
   const baseProps = {
     attachEndpoint: "/attach",
@@ -153,6 +165,90 @@ describe("AttachmentsWidget accessibility", () => {
     });
 
     expect(document.activeElement).toBe(attachMoreButton);
+
+    act(() => root.unmount());
+  });
+
+  test("shows over file limit message when API returns over_file_limit", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      headers: { get: () => "application/json" },
+      json: async () => ({
+        error: "over_file_limit",
+        current_usage: 5000000,
+        requested: 2000000,
+        limit: 6291456,
+      }),
+    });
+
+    const { container, root } = renderComponent(
+      React.createElement(AttachmentsWidget, {
+        ...baseProps,
+        initialFiles: [],
+      }),
+    );
+
+    const openModalButton = container.querySelector(
+      '[data-testid="attachments-open-modal"]',
+    );
+    act(() => {
+      openModalButton.click();
+    });
+
+    const input = container.querySelector('[data-testid="attachments-file-input"]');
+    const file = new File(["abc"], "large.pdf", { type: "application/pdf" });
+    selectFiles(input, [file]);
+
+    const submitButton = container.querySelector('[data-testid="attachments-submit"]');
+    await act(async () => {
+      submitButton.click();
+    });
+
+    const errors = container.querySelector('[data-testid="attach-validation-errors"]');
+    expect(errors.textContent).toContain(
+      "The total file size exceeds the 6 MB limit. Please remove some files and try again.",
+    );
+
+    act(() => root.unmount());
+  });
+
+  test("shows generic storage error message when API returns server_error", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: { get: () => "application/json" },
+      json: async () => ({
+        error: "server_error",
+        message: "Failed to upload file to storage",
+      }),
+    });
+
+    const { container, root } = renderComponent(
+      React.createElement(AttachmentsWidget, {
+        ...baseProps,
+        initialFiles: [],
+      }),
+    );
+
+    const openModalButton = container.querySelector(
+      '[data-testid="attachments-open-modal"]',
+    );
+    act(() => {
+      openModalButton.click();
+    });
+
+    const input = container.querySelector('[data-testid="attachments-file-input"]');
+    const file = new File(["abc"], "test.pdf", { type: "application/pdf" });
+    selectFiles(input, [file]);
+
+    const submitButton = container.querySelector('[data-testid="attachments-submit"]');
+    await act(async () => {
+      submitButton.click();
+    });
+
+    const errors = container.querySelector('[data-testid="attach-validation-errors"]');
+    expect(errors.textContent).toContain("Failed to upload file to storage");
 
     act(() => root.unmount());
   });

--- a/tests/javascripts/attachments/AttachmentsWidget.test.js
+++ b/tests/javascripts/attachments/AttachmentsWidget.test.js
@@ -252,4 +252,43 @@ describe("AttachmentsWidget accessibility", () => {
 
     act(() => root.unmount());
   });
+
+  test("shows unsupported file type message when API returns unsupported_file_type", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      headers: { get: () => "application/json" },
+      json: async () => ({
+        error: "unsupported_file_type",
+      }),
+    });
+
+    const { container, root } = renderComponent(
+      React.createElement(AttachmentsWidget, {
+        ...baseProps,
+        initialFiles: [],
+      }),
+    );
+
+    const openModalButton = container.querySelector(
+      '[data-testid="attachments-open-modal"]',
+    );
+    act(() => {
+      openModalButton.click();
+    });
+
+    const input = container.querySelector('[data-testid="attachments-file-input"]');
+    const file = new File(["abc"], "fake.csv", { type: "text/csv" });
+    selectFiles(input, [file]);
+
+    const submitButton = container.querySelector('[data-testid="attachments-submit"]');
+    await act(async () => {
+      submitButton.click();
+    });
+
+    const errors = container.querySelector('[data-testid="attach-validation-errors"]');
+    expect(errors.textContent).toContain("File type not supported");
+
+    act(() => root.unmount());
+  });
 });


### PR DESCRIPTION
# Summary | Résumé

This pull request improves how file upload errors are handled and reported for template attachments, making error responses more structured and user-friendly. It introduces a new error mapping utility on the backend, updates the client to use these structured errors, and adds comprehensive tests for both backend and frontend components to ensure correct error propagation and display.

# Test instructions | Instructions pour tester la modification
## File size limit from API is respected
- Upload files totalling ~6MB
- Refresh the page
- Upload a large file
- [x] Page displays `The total file size exceeds the 6 MB limit. Please remove some files and try again.` error

## File mime type from API is respected
- Take an .html file and rename it .csv
- Upload the file
- [x] Page displays `File type not supported` error
