### PR TITLE
chore: bump utils to 53.2.31

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1645,7 +1645,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "53.2.30"
+version = "53.2.31"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.12.7"
@@ -1681,8 +1681,8 @@ werkzeug = "3.1.6"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "53.2.30"
-resolved_reference = "21a241b6697ce07da316bd5c435298d76380ba71"
+reference = "53.2.31"
+resolved_reference = "036f39bf1996ac8b048fcdea68a3ed62fd937a6e"
 
 [[package]]
 name = "openpyxl"
@@ -2947,4 +2947,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "785492b4936303b94f5d79661a11f13271fa2933f0cd2b8c9f6dd55b84590fb0"
+content-hash = "4b4b0db15dc72a1cd90a236efba0531333fa2ccc839f3c1233c3ac6d935262f5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ gunicorn = "22.0.0"
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous = "2.2.0"  # pyup: <1.0.0
 notifications-python-client = "6.4.1"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "53.2.30" }
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "53.2.31" }
 pwnedpasswords = "2.0.0"
 pyexcel = "0.7.4"
 pyexcel-io = "0.6.7"

--- a/tests_cypress/cypress/e2e/admin/branding/edit-branding.cy.js
+++ b/tests_cypress/cypress/e2e/admin/branding/edit-branding.cy.js
@@ -59,7 +59,7 @@ describe("Edit Branding", () => {
       .should(
         "have.attr",
         "alt",
-        "Government of Canada / Gouvernement du Canada",
+        "Government of Canada",
       );
   });
 
@@ -74,7 +74,7 @@ describe("Edit Branding", () => {
       .should(
         "have.attr",
         "alt",
-        "Gouvernement du Canada / Government of Canada",
+        "Gouvernement du Canada",
       );
   });
 

--- a/tests_cypress/cypress/e2e/admin/branding/edit-branding.cy.js
+++ b/tests_cypress/cypress/e2e/admin/branding/edit-branding.cy.js
@@ -56,11 +56,7 @@ describe("Edit Branding", () => {
       .and("contain", "Setting updated");
     BrandingSettingsPage.Components.TemplatePreview()
       .first()
-      .should(
-        "have.attr",
-        "alt",
-        "Government of Canada",
-      );
+      .should("have.attr", "alt", "Government of Canada");
   });
 
   it("Saves French-first logo when selected", () => {
@@ -71,11 +67,7 @@ describe("Edit Branding", () => {
       .and("contain", "Setting updated");
     BrandingSettingsPage.Components.TemplatePreview()
       .first()
-      .should(
-        "have.attr",
-        "alt",
-        "Gouvernement du Canada",
-      );
+      .should("have.attr", "alt", "Gouvernement du Canada");
   });
 
   it("Navigates to branding pool when select another logo from test link is clicked", () => {


### PR DESCRIPTION
# Summary | Résumé
This pull request updates the `notifications-utils` dependency to `53.2.31` which includes the update to the alt text for both French and English Government of Canada branding:
- https://github.com/cds-snc/notification-utils/pull/422

# Test instructions | Instructions pour tester la modification
**French first branding**
- Preview a french-first branding email
- [x] Alt text is only in French

**English first branding**
- Preview an English-first branding email
- [x] Alt text is only in English
