### PR TITLE
Pass `user_id` to the `/archive` API endpoint

### DIFF
--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -514,7 +514,7 @@ def archive_service(service_id):
     if not current_service.active and (current_service.trial_mode or current_user.platform_admin):
         abort(403)
     if request.method == "POST":
-        service_api_client.archive_service(service_id)
+        service_api_client.archive_service(service_id, current_user.id)
         session.pop("service_id", None)
         flash(
             _("‘%(service_name)s’ was deleted", service_name=current_service.name),

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -186,8 +186,8 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         return self.update_service(service_id, **properties)
 
     @cache.delete("service-{service_id}")
-    def archive_service(self, service_id):
-        return self.post("/service/{}/archive".format(service_id), data=None)
+    def archive_service(self, service_id, user_id):
+        return self.post("/service/{}/archive/{}".format(service_id, user_id), data=None)
 
     @cache.delete("service-{service_id}")
     def suspend_service(self, service_id, user_id):

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3616,7 +3616,10 @@ def test_archive_service_after_confirm(
         _follow_redirects=True,
     )
 
-    mocked_fn.assert_called_once_with("/service/{}/archive".format(SERVICE_ONE_ID), data=None)
+    mocked_fn.assert_called_once_with(
+        "/service/{}/archive/{}".format(SERVICE_ONE_ID, user.id),
+        data=None,
+    )
     assert normalize_spaces(page.select_one("h1").text) == "Your services"
     assert normalize_spaces(page.select_one(".banner-default-with-tick").text) == ("‘service one’ was deleted")
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3617,7 +3617,7 @@ def test_archive_service_after_confirm(
     )
 
     mocked_fn.assert_called_once_with(
-        "/service/{}/archive/{}".format(SERVICE_ONE_ID, user.id),
+        "/service/{}/archive/{}".format(SERVICE_ONE_ID, user["id"]),
         data=None,
     )
     assert normalize_spaces(page.select_one("h1").text) == "Your services"

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -346,7 +346,7 @@ def test_returns_value_from_cache(
             [SERVICE_ONE_ID],
             {"properties": {}},
         ),
-        (service_api_client, "archive_service", [SERVICE_ONE_ID], {}),
+        (service_api_client, "archive_service", [SERVICE_ONE_ID, "1"], {}),
         (service_api_client, "suspend_service", [SERVICE_ONE_ID, "1"], {}),
         (service_api_client, "resume_service", [SERVICE_ONE_ID], {}),
         (service_api_client, "remove_user_from_service", [SERVICE_ONE_ID, ""], {}),


### PR DESCRIPTION
# Summary | Résumé
This PR updates the call to the `/archive` API endpoint to pass along the `user_id` who confirmed service deletion.

# Test instructions | Instructions pour tester la modification
- [ ] Test steps in the [API PR](https://github.com/cds-snc/notification-api/pull/2969) have been followed and completed
