### PR TITLE
Display the API key that requested the delivery report

### DIFF
--- a/app/templates/views/reports/reports-table.html
+++ b/app/templates/views/reports/reports-table.html
@@ -33,9 +33,13 @@
         {% endif %}
         <div class="file-list-hint">
           <p>
-            <span>{{ _("Requested by") }} {{ item.requesting_user.name }}</span>
-            {% if item.requesting_user_id == current_user.id %}
-              <span>({{ _("You") }})</span>
+            {% if item.requesting_user %}
+              <span>{{ _("Requested by") }} {{ item.requesting_user.name }}</span>
+              {% if item.requesting_user_id == current_user.id %}
+                <span>({{ _("You") }})</span>
+              {% endif %}
+            {% elif item.api_key %}
+              <span>{{ _("Requested by API key:") }} {{ item.api_key.name }}</span>
             {% endif %}
           </p>
         </div>

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2212,6 +2212,7 @@
 "Preparing report","En préparation"
 "Visit dashboard","Accéder au tableau de bord"
 "Requested by","Demandé par"
+"Requested by API key:","Demandé par clé API :"
 "Download before","À télécharger avant le"
 "Failed. Try again","Échec. Réessayer"
 "Deleted at","Supprimé le"

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -2212,7 +2212,7 @@
 "Preparing report","En préparation"
 "Visit dashboard","Accéder au tableau de bord"
 "Requested by","Demandé par"
-"Requested by API key:","Demandé par clé API :"
+"Requested by API key:","Demandé par clé API&nbsp;:"
 "Download before","À télécharger avant le"
 "Failed. Try again","Échec. Réessayer"
 "Deleted at","Supprimé le"

--- a/tests/app/main/views/test_reports.py
+++ b/tests/app/main/views/test_reports.py
@@ -35,6 +35,34 @@ def test_get_reports_shows_list_of_reports(client_request, active_user_with_perm
 
 
 @freeze_time("2025-01-01 00:01:00.000000")
+def test_get_reports_shows_requesting_api_key_when_requested_via_api(
+    client_request, active_user_with_permissions, mocker, service_one
+):
+    client_request.login(active_user_with_permissions)
+    mocker.patch(
+        "app.reports_api_client.get_reports_for_service",
+        return_value=[
+            {
+                "id": "report-1",
+                "status": "ready",
+                "language": "en",
+                "expires_at": (datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
+                "requested_at": datetime.now(timezone.utc).isoformat(),
+                "requesting_user": None,
+                "api_key": {"id": "api-key-1", "name": "Test API Key"},
+                "url": "https://example.com/report-1.csv",
+            }
+        ],
+    )
+
+    response = client_request.get("main.reports", service_id=service_one["id"], _expected_status=200)
+
+    reports_table = response.find("table")
+    row = reports_table.find_all("tr")[1]
+    assert "Requested by API key: Test API Key" in row.text
+
+
+@freeze_time("2025-01-01 00:01:00.000000")
 def test_download_report_csv_streams_the_report(
     client_request,
     active_user_with_permissions,


### PR DESCRIPTION
# Summary | Résumé


Display the API key that requested the delivery report

# Test instructions | Instructions pour tester la modification

1. checkout and run this branch and the api branch from https://github.com/cds-snc/notification-api/pull/2988 locally (run `flask db upgrade` on the api first)
2. request a new report via api
```
curl -X POST "http://localhost:6011/v2/reports" \
  -H "Authorization: ApiKey-v1 YOUR_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"report_type": "email", "language": "en"}'
```
3. go to the reports page in admin and verify that you see the name of the api key you used:
<img width="1031" height="142" alt="Screenshot 2026-07-30 at 4 33 23 PM" src="https://github.com/user-attachments/assets/41de1db6-097f-4cda-b6df-a15d4500821c" />
