### PR TITLE
Update site map and styles

### DIFF
--- a/app/assets/stylesheets/tailwind/toolkit/wp-guides.css
+++ b/app/assets/stylesheets/tailwind/toolkit/wp-guides.css
@@ -12,6 +12,11 @@
     }
   }
 
+  /* Toolbar guide */
+  .guide-toolbar {
+    @apply mt-0;
+  }
+
   /* Symbols list */
   .page-content ul.guide-symbols-list {
     @apply p-0 flex flex-wrap lg:flex-nowrap items-stretch;

--- a/app/assets/stylesheets/tailwind/toolkit/wp-guides.css
+++ b/app/assets/stylesheets/tailwind/toolkit/wp-guides.css
@@ -13,8 +13,15 @@
   }
 
   /* Toolbar guide */
+  /* Toolbar is a block-media-text with an additional .guide-toolbar class.  */
   .guide-toolbar {
-    @apply mt-0;
+    @apply flex mt-0;
+  }
+  .guide-toolbar .wp-block-media-text__media {
+    @apply w-gutterAndAHalf;
+  }
+  .guide-toolbar .wp-block-media-text__content :last-child {
+    @apply mb-0;
   }
 
   /* Symbols list */

--- a/app/main/sitemap.py
+++ b/app/main/sitemap.py
@@ -42,7 +42,7 @@ def get_sitemap():
                     {"href": documentation_url(), "link_text": _("API documentation")},
                     {"href": gca_url_for("getting_started"), "link_text": _("Getting started")},
                     {"href": gca_url_for("guidance"), "link_text": _("Guidance")},
-                    {"href": gca_url_for("formatting_guide"), "link_text": _("Formatting emails")},
+                    {"href": gca_url_for("formatting_guide"), "link_text": _("Using markdown for email messages")},
                     {"href": gca_url_for("spreadsheets"), "link_text": _("Using a spreadsheet")},
                     {"href": gca_url_for("personalisation_guide"), "link_text": _("Sending custom content")},
                     {"href": gca_url_for("message_delivery_status"), "link_text": _("Understanding delivery and failure")},

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1263,6 +1263,7 @@
 "You cannot remove the only user for a service","Vous ne pouvez pas retirer le seul utilisateur d’un service."
 "User cannot be removed from service. Check that all services have another team member who can manage settings","L’utilisateur ne peut pas être retiré du service. Vérifiez que tous les services ont un autre membre de l’équipe qui peut gérer les paramètres"
 "Email formatting guide","Guide de mise en forme de courriels"
+"Using markdown for email messages","Balisage markdown pour les courriels"
 "Use this guide to write email message templates. Make sure to send yourself a message before sending to recipients to ensure formatting looks good.","Utilisez ce guide pour créer les gabarits de vos courriels. Vous devriez vous envoyer un message test avant de l’envoyer à des destinataires pour vous assurer que la mise en forme est correcte."
 "To tailor messages to each recipient, read the <a id='link-format-guide' href='{}' target='_blank'>personalisation guide</a>.","Pour adapter les messages à chaque destinataire, consultez le <a id='link-format-guide' href='{}' target='_blank'>guide de personalisation</a>."
 "Personalisation guide","Guide de personnalisation"


### PR DESCRIPTION
# Summary | Résumé

- Updating sitemap after a guide title change
- Updating styles to help explain RTE with icons. 


# Test instructions | Instructions pour tester la modification
- [ ] Check the sitemap
- [ ] "Formatting emails" is now "Using markdown for email messages"
- [ ] Check `/sending-custom-content`, should look like:
<img width="1099" height="341" alt="Capture d’écran, le 2026-08-12 à 13 35 18" src="https://github.com/user-attachments/assets/767b76fe-2c24-4177-ae80-1fb36890d27d" />