### PR TITLE
Fix RTE ally errors

### DIFF
--- a/app/assets/javascripts/tiptap/InfoPane/CustomContent.js
+++ b/app/assets/javascripts/tiptap/InfoPane/CustomContent.js
@@ -19,7 +19,7 @@ const CustomContentInfoPane = ({ t, isActive }) => {
         {pane.title}
       </h2>
       <p>
-        {pane.p1} <Icon iconNode={variableIcon} title={pane.p1Icon} />
+        {pane.p1} <Icon iconNode={variableIcon} role="img" aria-label={pane.p1Icon} />
       </p>
       <p>{pane.p2}</p>
       <h3 className="heading-small">{pane.title2}</h3>
@@ -28,11 +28,11 @@ const CustomContentInfoPane = ({ t, isActive }) => {
         <li>{pane.li1}</li>
         <li>
           {pane.li2}{" "}
-          <Icon iconNode={conditionalInlineIcon} title={pane.li2Icon} />
+          <Icon iconNode={conditionalInlineIcon} role="img" aria-label={pane.li2Icon} />
         </li>
         <li>
           {pane.li3}{" "}
-          <Icon iconNode={conditionalBlockIcon} title={pane.li3Icon} />
+          <Icon iconNode={conditionalBlockIcon} role="img" aria-label={pane.li3Icon} />
         </li>
       </ul>
     </section>

--- a/app/assets/javascripts/tiptap/InfoPane/CustomContent.js
+++ b/app/assets/javascripts/tiptap/InfoPane/CustomContent.js
@@ -19,7 +19,8 @@ const CustomContentInfoPane = ({ t, isActive }) => {
         {pane.title}
       </h2>
       <p>
-        {pane.p1} <Icon iconNode={variableIcon} role="img" aria-label={pane.p1Icon} />
+        {pane.p1}{" "}
+        <Icon iconNode={variableIcon} role="img" aria-label={pane.p1Icon} />
       </p>
       <p>{pane.p2}</p>
       <h3 className="heading-small">{pane.title2}</h3>
@@ -28,11 +29,19 @@ const CustomContentInfoPane = ({ t, isActive }) => {
         <li>{pane.li1}</li>
         <li>
           {pane.li2}{" "}
-          <Icon iconNode={conditionalInlineIcon} role="img" aria-label={pane.li2Icon} />
+          <Icon
+            iconNode={conditionalInlineIcon}
+            role="img"
+            aria-label={pane.li2Icon}
+          />
         </li>
         <li>
           {pane.li3}{" "}
-          <Icon iconNode={conditionalBlockIcon} role="img" aria-label={pane.li3Icon} />
+          <Icon
+            iconNode={conditionalBlockIcon}
+            role="img"
+            aria-label={pane.li3Icon}
+          />
         </li>
       </ul>
     </section>

--- a/app/assets/javascripts/tiptap/InfoPane/CustomContent.js
+++ b/app/assets/javascripts/tiptap/InfoPane/CustomContent.js
@@ -19,7 +19,7 @@ const CustomContentInfoPane = ({ t, isActive }) => {
         {pane.title}
       </h2>
       <p>
-        {pane.p1} <Icon iconNode={variableIcon} aria-label={pane.p1Icon} />
+        {pane.p1} <Icon iconNode={variableIcon} title={pane.p1Icon} />
       </p>
       <p>{pane.p2}</p>
       <h3 className="heading-small">{pane.title2}</h3>
@@ -28,11 +28,11 @@ const CustomContentInfoPane = ({ t, isActive }) => {
         <li>{pane.li1}</li>
         <li>
           {pane.li2}{" "}
-          <Icon iconNode={conditionalInlineIcon} aria-label={pane.li2Icon} />
+          <Icon iconNode={conditionalInlineIcon} title={pane.li2Icon} />
         </li>
         <li>
           {pane.li3}{" "}
-          <Icon iconNode={conditionalBlockIcon} aria-label={pane.li3Icon} />
+          <Icon iconNode={conditionalBlockIcon} title={pane.li3Icon} />
         </li>
       </ul>
     </section>

--- a/app/assets/javascripts/tiptap/InfoPane/EmailLinks.js
+++ b/app/assets/javascripts/tiptap/InfoPane/EmailLinks.js
@@ -4,11 +4,7 @@ const EmailLinksInfoPane = ({ t, isActive }) => {
   const pane = t.infoPane3;
 
   return (
-    <section
-      id="email-links"
-      aria-label={pane.label}
-      hidden={!isActive}
-    >
+    <section id="email-links" aria-label={pane.label} hidden={!isActive}>
       <p>{pane.p1}</p>
       <p>{pane.p2}</p>
       <ol className="list list-number ml-10">

--- a/app/assets/javascripts/tiptap/InfoPane/EmailLinks.js
+++ b/app/assets/javascripts/tiptap/InfoPane/EmailLinks.js
@@ -6,7 +6,7 @@ const EmailLinksInfoPane = ({ t, isActive }) => {
   return (
     <section
       id="email-links"
-      aria-labelledby="email-links-title"
+      aria-label={pane.label}
       hidden={!isActive}
     >
       <p>{pane.p1}</p>

--- a/app/assets/javascripts/tiptap/InfoPane/MultipleLanguages.js
+++ b/app/assets/javascripts/tiptap/InfoPane/MultipleLanguages.js
@@ -9,11 +9,11 @@ const MultipleLanguagesInfoPane = ({ t, isActive }) => {
       <p>{pane.p1}</p>
       <ul className="list list-bullet ml-10">
         <li>
-          {pane.li1} <Icon iconNode={englishBlockIcon} title={pane.li1Icon1} />{" "}
-          {pane.li1or} <Icon iconNode={frenchBlockIcon} title={pane.li1Icon2} />
+          {pane.li1} <Icon iconNode={englishBlockIcon} role="img" aria-label={pane.li1Icon1} />{" "}
+          {pane.li1or} <Icon iconNode={frenchBlockIcon} role="img" aria-label={pane.li1Icon2} />
         </li>
         <li>
-          {pane.li2} <Icon iconNode={rightToLeftIcon} title={pane.li2Icon} />
+          {pane.li2} <Icon iconNode={rightToLeftIcon} role="img" aria-label={pane.li2Icon} />
         </li>
       </ul>
     </section>

--- a/app/assets/javascripts/tiptap/InfoPane/MultipleLanguages.js
+++ b/app/assets/javascripts/tiptap/InfoPane/MultipleLanguages.js
@@ -7,20 +7,20 @@ const MultipleLanguagesInfoPane = ({ t, isActive }) => {
   return (
     <section
       id="multiple-languages"
-      aria-labelledby="multiple-languages-title"
+      aria-label={pane.label}
       hidden={!isActive}
     >
       <p>{pane.p1}</p>
       <ul className="list list-bullet ml-10">
         <li>
           {pane.li1}{" "}
-          <Icon iconNode={englishBlockIcon} aria-label={pane.li1Icon1} />{" "}
+          <Icon iconNode={englishBlockIcon} title={pane.li1Icon1} />{" "}
           {pane.li1or}{" "}
-          <Icon iconNode={frenchBlockIcon} aria-label={pane.li1Icon2} />
+          <Icon iconNode={frenchBlockIcon} title={pane.li1Icon2} />
         </li>
         <li>
           {pane.li2}{" "}
-          <Icon iconNode={rightToLeftIcon} aria-label={pane.li2Icon} />
+          <Icon iconNode={rightToLeftIcon} title={pane.li2Icon} />
         </li>
       </ul>
     </section>

--- a/app/assets/javascripts/tiptap/InfoPane/MultipleLanguages.js
+++ b/app/assets/javascripts/tiptap/InfoPane/MultipleLanguages.js
@@ -5,22 +5,15 @@ const MultipleLanguagesInfoPane = ({ t, isActive }) => {
   const pane = t.infoPane2;
 
   return (
-    <section
-      id="multiple-languages"
-      aria-label={pane.label}
-      hidden={!isActive}
-    >
+    <section id="multiple-languages" aria-label={pane.label} hidden={!isActive}>
       <p>{pane.p1}</p>
       <ul className="list list-bullet ml-10">
         <li>
-          {pane.li1}{" "}
-          <Icon iconNode={englishBlockIcon} title={pane.li1Icon1} />{" "}
-          {pane.li1or}{" "}
-          <Icon iconNode={frenchBlockIcon} title={pane.li1Icon2} />
+          {pane.li1} <Icon iconNode={englishBlockIcon} title={pane.li1Icon1} />{" "}
+          {pane.li1or} <Icon iconNode={frenchBlockIcon} title={pane.li1Icon2} />
         </li>
         <li>
-          {pane.li2}{" "}
-          <Icon iconNode={rightToLeftIcon} title={pane.li2Icon} />
+          {pane.li2} <Icon iconNode={rightToLeftIcon} title={pane.li2Icon} />
         </li>
       </ul>
     </section>

--- a/app/assets/javascripts/tiptap/InfoPane/MultipleLanguages.js
+++ b/app/assets/javascripts/tiptap/InfoPane/MultipleLanguages.js
@@ -9,11 +9,26 @@ const MultipleLanguagesInfoPane = ({ t, isActive }) => {
       <p>{pane.p1}</p>
       <ul className="list list-bullet ml-10">
         <li>
-          {pane.li1} <Icon iconNode={englishBlockIcon} role="img" aria-label={pane.li1Icon1} />{" "}
-          {pane.li1or} <Icon iconNode={frenchBlockIcon} role="img" aria-label={pane.li1Icon2} />
+          {pane.li1}{" "}
+          <Icon
+            iconNode={englishBlockIcon}
+            role="img"
+            aria-label={pane.li1Icon1}
+          />{" "}
+          {pane.li1or}{" "}
+          <Icon
+            iconNode={frenchBlockIcon}
+            role="img"
+            aria-label={pane.li1Icon2}
+          />
         </li>
         <li>
-          {pane.li2} <Icon iconNode={rightToLeftIcon} role="img" aria-label={pane.li2Icon} />
+          {pane.li2}{" "}
+          <Icon
+            iconNode={rightToLeftIcon}
+            role="img"
+            aria-label={pane.li2Icon}
+          />
         </li>
       </ul>
     </section>

--- a/tests_cypress/cypress/e2e/admin/ci-shard-1.cy.js
+++ b/tests_cypress/cypress/e2e/admin/ci-shard-1.cy.js
@@ -2,3 +2,4 @@ import "./sign_out/sign_out.cy";
 import "./go-live-form.cy";
 import "./tou_dialog.cy";
 import "./your_profile.cy";
+import "./components/rte/InfoPane.cy";

--- a/tests_cypress/cypress/e2e/admin/ci-shard-1.cy.js
+++ b/tests_cypress/cypress/e2e/admin/ci-shard-1.cy.js
@@ -2,4 +2,3 @@ import "./sign_out/sign_out.cy";
 import "./go-live-form.cy";
 import "./tou_dialog.cy";
 import "./your_profile.cy";
-import "./components/rte/InfoPane.cy";


### PR DESCRIPTION
# Summary | Résumé

Fixes a11y errors introduced by the RTE info pane:

- svg icons were missing role=img
- some tabs were referencing an id that did not exist. Replaced with an aria-label. 

# Test instructions | Instructions pour tester la modification
- [ ] On rte component
- [ ] Open info pane
- [ ] Run a11y scanner - no warnings for the RTE itself
