### PR TITLE
Revert: unpin cds-snc/notification-pr-bot back to @main

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -73,7 +73,7 @@ jobs:
         app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
         private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
 
-    - uses: cds-snc/notification-pr-bot@b70dc73610a8e72a7af40e5ccc320e14ce773988 # main as of 2026-08-18
+    - uses: cds-snc/notification-pr-bot@main
       env:
         TOKEN: ${{ steps.notify-pr-bot.outputs.token }}
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,5 @@
   "extends": [
     "local>cds-snc/renovate-config"
   ],
-  "ignoreDeps": ["Werkzeug"]
+  "ignoreDeps": ["Werkzeug", "cds-snc/notification-pr-bot"]
 }


### PR DESCRIPTION
Our internal PR bot updates frequently; the recent GitHub Actions SHA-pinning work pinned it to a fixed commit, which defeats the purpose since we always want the latest version. Reverts to `@main` and adds it to renovate.json's `ignoreDeps` so Renovate doesn't re-pin it.