### PR TITLE
chore: remove gate around  ui attachment features

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -94,9 +94,6 @@ class Config(object):
     FF_ADD_TEMPLATE_PERM = env.bool("FF_ADD_TEMPLATE_PERM", False)
     FF_REPORT_API = env.bool("FF_REPORT_API", False)
 
-    # Comma-separated list of service IDs allowed to use file attachments.
-    FILE_ATTACH_SERVICES: List[str] = [id.strip() for id in os.getenv("FILE_ATTACH_SERVICES", "").split(",") if id.strip()]
-
     # OTEL Configuration
     ENABLE_CLIENT_SIDE_OTEL = env.bool("ENABLE_CLIENT_SIDE_OTEL", False)
     OTEL_CLIENT_SIDE_TOKEN_TTL = env.int("OTEL_CLIENT_SIDE_TOKEN_TTL", 5 * 60)  # seconds, default 5 minutes
@@ -219,7 +216,6 @@ class Development(Config):
     SESSION_PROTECTION = None
     SYSTEM_STATUS_URL = "https://localhost:3000"
     NO_BRANDING_ID = "0af93cf1-2c49-485f-878f-f3e662e651ef"
-    FILE_ATTACH_SERVICES = ["d6aa2c68-a2d9-4437-ab19-3ae8eb202553", "d4e8a7f4-2b8a-4c9a-8b3f-9c2d4e8a7f4b"]
 
 
 class Test(Development):
@@ -245,7 +241,6 @@ class Test(Development):
     GC_ORGANISATIONS_BUCKET_NAME = "test-gc-organisations"
     FF_USE_BILLABLE_UNITS = True
     VITE_HMR_ENABLED = False
-    FILE_ATTACH_SERVICES = ["d6aa2c68-a2d9-4437-ab19-3ae8eb202553", "d4e8a7f4-2b8a-4c9a-8b3f-9c2d4e8a7f4b"]
 
 
 class ProductionFF(Config):

--- a/app/main/views/notifications.py
+++ b/app/main/views/notifications.py
@@ -36,7 +36,6 @@ from app.template_previews import get_page_count_for_letter
 from app.utils import (
     DELIVERED_STATUSES,
     FAILURE_STATUSES,
-    file_attachments_enabled_for_service,
     generate_notifications_csv,
     get_help_argument,
     get_letter_printing_statement,
@@ -56,10 +55,7 @@ def view_notification(service_id, notification_id):
     personalisation = get_all_personalisation_from_notification(notification)
 
     # Get attachments from personalisation after redaction is applied
-    ff_enabled = file_attachments_enabled_for_service(service_id)
-    methods = ["attach"]
-    if ff_enabled:
-        methods.append("template_attach")
+    methods = ["attach", "template_attach"]
     attachments = list(get_attachments(notification, methods).values())
 
     if notification["template"]["is_precompiled_letter"]:

--- a/app/main/views/send.py
+++ b/app/main/views/send.py
@@ -67,7 +67,6 @@ from app.utils import (
     PermanentRedirect,
     Spreadsheet,
     email_or_sms_not_enabled,
-    file_attachments_enabled_for_service,
     filter_attachments,
     get_errors_for_csv,
     get_help_argument,
@@ -113,11 +112,7 @@ def build_template_attachment_personalisation(template_id, template_type):
     and the service has the upload_document permission. Only attachments with
     'uploaded' status and valid id/name are included with contiguous _file_N keys.
     """
-    if (
-        not file_attachments_enabled_for_service(current_service.id)
-        or template_type != "email"
-        or not current_service.has_permission("upload_document")
-    ):
+    if template_type != "email" or not current_service.has_permission("upload_document"):
         return {}
 
     attachments = filter_attachments(
@@ -154,11 +149,7 @@ def get_template_attachment_context(template_id, template_type):
         "has_incomplete_template_attachments": False,
     }
 
-    if (
-        not file_attachments_enabled_for_service(current_service.id)
-        or template_type != "email"
-        or not current_service.has_permission("upload_document")
-    ):
+    if template_type != "email" or not current_service.has_permission("upload_document"):
         return context
 
     attachments = current_service.get_template_attachments(template_id)

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -71,7 +71,6 @@ from app.utils import (
     SENDING_STATUSES,
     documentation_url,
     email_safe,
-    file_attachments_enabled_for_service,
     get_logo_cdn_domain,
     get_new_default_reply_to_address,
     get_verified_ses_domains,
@@ -120,7 +119,6 @@ def service_settings(service_id: str):
         sending_domain=current_service.sending_domain or current_app.config["SENDING_DOMAIN"],
         limits=limits,
         callback_api=callback_api,
-        file_attachments_enabled_for_service=file_attachments_enabled_for_service(current_service.id),
     )
 
 
@@ -441,14 +439,9 @@ def set_sensitive_service(service_id):
 def service_switch_upload_document(service_id):
     title = _("Send files by email")
     form = ServiceOnOffSettingForm(name=title, enabled=current_service.has_permission("upload_document"))
-    if file_attachments_enabled_for_service(current_service.id):
-        help = _(
-            "Allow files to be attached to email notifications.<br>Files can be attached on the templates page or through the API<br>Learn more in the <a href='{}'>API documentation</a>."
-        ).format(documentation_url("send", section="sending-a-file-by-email"))
-    else:
-        help = _(
-            "This feature is only available when sending through the API.<br>Learn more in the <a href='{}'>API documentation</a>."
-        ).format(documentation_url("send", section="sending-a-file-by-email"))
+    help = _(
+        "Allow files to be attached to email notifications.<br>Files can be attached on the templates page or through the API<br>Learn more in the <a href='{}'>API documentation</a>."
+    ).format(documentation_url("send", section="sending-a-file-by-email"))
 
     if form.validate_on_submit():
         current_service.force_permission("upload_document", on=form.enabled.data)

--- a/app/main/views/templates.py
+++ b/app/main/views/templates.py
@@ -68,7 +68,6 @@ from app.sample_template_utils import create_temporary_sample_template, get_samp
 from app.template_previews import TemplatePreview, get_page_count_for_letter
 from app.utils import (
     email_or_sms_not_enabled,
-    file_attachments_enabled_for_service,
     filter_attachments,
     get_limit_reset_time_et,
     get_template,
@@ -206,11 +205,7 @@ def view_template(service_id, template_id):
     template_folder = current_service.get_template_folder(template["folder"])
     template_attachments = []
 
-    if (
-        file_attachments_enabled_for_service(current_service.id)
-        and template["template_type"] == "email"
-        and current_service.has_permission("upload_document")
-    ):
+    if template["template_type"] == "email" and current_service.has_permission("upload_document"):
         template_attachments = filter_attachments(
             current_service.get_template_attachments(template_id),
             exclude_statuses={"deleted", "virus_scan_failed"},
@@ -221,11 +216,7 @@ def view_template(service_id, template_id):
     if should_skip_template_page(template["template_type"]):
         return redirect(url_for(".send_one_off", service_id=service_id, template_id=template_id))
 
-    if (
-        file_attachments_enabled_for_service(current_service.id)
-        and template["template_type"] == "email"
-        and current_user.has_permissions("manage_service")
-    ):
+    if template["template_type"] == "email" and current_user.has_permissions("manage_service"):
         session[f"enable_file_attachments_next_url_{service_id}"] = url_for(
             ".view_template",
             service_id=service_id,
@@ -239,15 +230,14 @@ def view_template(service_id, template_id):
         template=preview_template,
         template_postage=template["postage"],
         template_attachments=template_attachments,
-        file_attachments_enabled_for_service=file_attachments_enabled_for_service(current_service.id),
         user_has_template_permission=user_has_template_permission,
         **get_limit_stats(template["template_type"], preview_template),
     )
 
 
-# Template attachment endpoints (gated by service allowlist)
+# Template attachment endpoints (gated by service permission)
 def _abort_if_attachments_disabled_for_service():
-    if not file_attachments_enabled_for_service(current_service.id) or not current_service.has_permission("upload_document"):
+    if not current_service.has_permission("upload_document"):
         abort(404)
 
 
@@ -1350,11 +1340,7 @@ def edit_service_template(service_id, template_id):
         )
     else:
         template_attachments = None
-        if (
-            file_attachments_enabled_for_service(current_service.id)
-            and template["template_type"] == "email"
-            and current_service.has_permission("upload_document")
-        ):
+        if template["template_type"] == "email" and current_service.has_permission("upload_document"):
             template_attachments = [
                 {
                     "id": attachment.get("id"),
@@ -1381,7 +1367,6 @@ def edit_service_template(service_id, template_id):
             one_click_unsub_enabled=current_app.config.get("ONE_CLICK_UNSUB_ALL_SERVICES", False)
             or str(service_id) in current_app.config.get("ONE_CLICK_UNSUB_SERVICE_IDS", []),
             attachments=template_attachments,
-            file_attachments_enabled_for_service=file_attachments_enabled_for_service(current_service.id),
         )
 
 
@@ -1430,7 +1415,6 @@ def delete_service_template(service_id, template_id):
     return render_template(
         "views/templates/template.html",
         template=preview_template,
-        file_attachments_enabled_for_service=file_attachments_enabled_for_service(current_service.id),
         user_has_template_permission=True,
         **get_limit_stats(template["template_type"], preview_template),
     )
@@ -1446,7 +1430,6 @@ def confirm_redact_template(service_id, template_id):
     return render_template(
         "views/templates/template.html",
         template=preview_template,
-        file_attachments_enabled_for_service=file_attachments_enabled_for_service(current_service.id),
         user_has_template_permission=True,
         show_redaction_message=True,
         **get_limit_stats(template["template_type"], preview_template),

--- a/app/templates/views/edit-email-template.html
+++ b/app/templates/views/edit-email-template.html
@@ -86,7 +86,7 @@
         initialMode="rte" if current_user.default_editor_is_rte else "markdown") 
       }}
 
-      {% if file_attachments_enabled_for_service and attachments %}
+      {% if attachments %}
         <section class="mb-16">
           <h2 id="attachments-heading" class="heading-medium">
             {{ _("Attachments") }}

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -91,8 +91,7 @@
     </div>
   </div>  
     <div class="mb-16">
-      {% if file_attachments_enabled_for_service %} 
-        {% if template.template_type == 'email' and current_service.has_permission("upload_document") and current_user.has_permissions('manage_templates') %}
+      {% if template.template_type == 'email' and current_service.has_permission("upload_document") and current_user.has_permissions('manage_templates') %}
           {{ attachments_widget(
             "template-attachments",
             template_attachments,
@@ -120,7 +119,6 @@
               <p data-testid="file-attachments-ask-manager-notice">{{ _('To send attachments, ask a team member who can manage settings to turn on file sending for this service.') }}</p>
             {% endcall %}
           {% endif %}
-        {% endif %}
       {% endif %}
     </div>
 

--- a/app/templates/views/templates/template.html
+++ b/app/templates/views/templates/template.html
@@ -91,7 +91,8 @@
     </div>
   </div>  
     <div class="mb-16">
-      {% if template.template_type == 'email' and current_service.has_permission("upload_document") and current_user.has_permissions('manage_templates') %}
+      {% if template.template_type == 'email' %}
+        {% if current_service.has_permission("upload_document") and current_user.has_permissions('manage_templates') %}
           {{ attachments_widget(
             "template-attachments",
             template_attachments,
@@ -119,6 +120,7 @@
               <p data-testid="file-attachments-ask-manager-notice">{{ _('To send attachments, ask a team member who can manage settings to turn on file sending for this service.') }}</p>
             {% endcall %}
           {% endif %}
+        {% endif %}
       {% endif %}
     </div>
 

--- a/app/translations/csv/fr.csv
+++ b/app/translations/csv/fr.csv
@@ -1546,7 +1546,6 @@
 "Please contact your service manager.","Veuillez communiquez avec votre gestionnaire de service."
 "failure","échec"
 "failures","échecs"
-"This feature is only available when sending through the API.<br>Learn more in the <a href='{}'>API documentation</a>.","Cette fonctionnalité n’est disponible que pour les envois programmés par le biais de l’API.<br>Pour en savoir plus, consultez la <a href='{}'>documentation API</a>."
 "(API-only)","(API seulement)"
 "Allow files to be attached to email notifications.<br>Files can be attached on the templates page or through the API<br>Learn more in the <a href='{}'>API documentation</a>.","Permettre de joindre des fichiers aux notifications par courriel.<br>Les fichiers peuvent être joints sur la page des gabarits ou par l'API.<br>Pour en savoir plus, consultez la <a href='{}'>documentation API</a>."
 "Setting updated","Paramètre mis à jour"

--- a/app/utils.py
+++ b/app/utils.py
@@ -177,10 +177,6 @@ def user_is_platform_admin(f):
     return wrapped
 
 
-def file_attachments_enabled_for_service(service_id: str) -> bool:
-    return str(service_id) in current_app.config.get("FILE_ATTACH_SERVICES", [])
-
-
 def redirect_to_sign_in(f):
     @wraps(f)
     def wrapped(*args, **kwargs):

--- a/tests/app/main/views/test_notifications.py
+++ b/tests/app/main/views/test_notifications.py
@@ -418,14 +418,13 @@ def test_notification_status_page_template_attach_personalisation_wins_over_live
     assert "live-file.pdf" not in str(page)
 
 
-def test_notification_status_page_hides_template_attach_when_service_not_safelisted(
+def test_notification_status_page_shows_template_attach_for_any_service(
     client_request,
     mocker,
     service_one,
     fake_uuid,
     app_,
 ):
-    # template_attach personalisation should not be shown when service is not safelisted.
     notification = create_notification(
         template_type="email",
         personalisation={
@@ -440,25 +439,23 @@ def test_notification_status_page_hides_template_attach_when_service_not_safelis
     )
     mocker.patch("app.notification_api_client.get_notification", return_value=notification)
 
-    with set_config(app_, "FILE_ATTACH_SERVICES", []):
-        page = client_request.get(
-            "main.view_notification",
-            service_id=service_one["id"],
-            notification_id=fake_uuid,
-        )
+    page = client_request.get(
+        "main.view_notification",
+        service_id=service_one["id"],
+        notification_id=fake_uuid,
+    )
 
-    assert "Attachments" not in [h2.text for h2 in page.select("h2")]
-    assert "flagged-file.pdf" not in str(page)
+    assert "Attachments" in [h2.text for h2 in page.select("h2")]
+    assert "flagged-file.pdf" in str(page)
 
 
-def test_notification_status_page_does_not_call_live_api_when_service_not_safelisted(
+def test_notification_status_page_does_not_call_live_api_for_any_service(
     client_request,
     mocker,
     service_one,
     fake_uuid,
     app_,
 ):
-    # The just_sent live API fallback should not fire when service is not safelisted.
     notification = create_notification(template_type="email", personalisation={"name": "Jo"})
     mocker.patch("app.notification_api_client.get_notification", return_value=notification)
     mock_live_api = mocker.patch(
@@ -466,13 +463,12 @@ def test_notification_status_page_does_not_call_live_api_when_service_not_safeli
         return_value=[{"name": "live-file.pdf", "file_size": 694807, "status": "uploaded"}],
     )
 
-    with set_config(app_, "FILE_ATTACH_SERVICES", []):
-        page = client_request.get(
-            "main.view_notification",
-            service_id=service_one["id"],
-            notification_id=fake_uuid,
-            just_sent=True,
-        )
+    page = client_request.get(
+        "main.view_notification",
+        service_id=service_one["id"],
+        notification_id=fake_uuid,
+        just_sent=True,
+    )
 
     mock_live_api.assert_not_called()
     assert "live-file.pdf" not in str(page)

--- a/tests/app/main/views/test_send.py
+++ b/tests/app/main/views/test_send.py
@@ -861,13 +861,6 @@ def test_check_messages_ok_hides_attachment_warning_when_all_uploaded(
     assert "terms.pdf" in attachments_section.text
 
 
-@pytest.mark.parametrize(
-    "file_attach_services, has_permission",
-    [
-        ([], True),  # service not safelisted → no attachments
-        ([SERVICE_ONE_ID], False),  # no upload_document permission → no attachments
-    ],
-)
 def test_get_template_attachment_context_returns_empty_when_conditions_not_met(
     client_request,
     mocker,
@@ -882,13 +875,11 @@ def test_get_template_attachment_context_returns_empty_when_conditions_not_met(
     fake_uuid,
     app_,
     mock_get_template_attachments,
-    file_attach_services,
-    has_permission,
 ):
     with client_request.session_transaction() as session:
         session["file_uploads"] = {fake_uuid: {"template_id": fake_uuid}}
 
-    mocker.patch("app.models.service.Service.has_permission", return_value=has_permission)
+    mocker.patch("app.models.service.Service.has_permission", return_value=False)
     mock_get_template_attachments.return_value = [
         {"id": "file-1", "name": "guide.pdf", "status": "uploaded", "size": 1280},
     ]
@@ -900,14 +891,13 @@ def test_get_template_attachment_context_returns_empty_when_conditions_not_met(
     """,
     )
 
-    with set_config(app_, "FILE_ATTACH_SERVICES", file_attach_services):
-        page = client_request.get(
-            "main.check_messages",
-            service_id=SERVICE_ONE_ID,
-            template_id=fake_uuid,
-            upload_id=fake_uuid,
-            original_file_name="example.csv",
-        )
+    page = client_request.get(
+        "main.check_messages",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        upload_id=fake_uuid,
+        original_file_name="example.csv",
+    )
 
     assert page.select_one("[data-testid='template-attachments-list']") is None
 
@@ -3607,7 +3597,7 @@ def test_send_notification_includes_template_attachments_in_personalisation(
     )
 
 
-def test_send_notification_does_not_include_template_attachments_when_service_not_safelisted(
+def test_send_notification_includes_template_attachments_for_any_service(
     client_request,
     service_one,
     fake_uuid,
@@ -3625,14 +3615,24 @@ def test_send_notification_does_not_include_template_attachments_when_service_no
         session["recipient"] = "test@example.com"
         session["placeholders"] = {"email address": "test@example.com"}
 
-    with set_config(app_, "FILE_ATTACH_SERVICES", []):
-        client_request.post("main.send_notification", service_id=service_one["id"], template_id=fake_uuid)
+    client_request.post("main.send_notification", service_id=service_one["id"], template_id=fake_uuid)
 
     mock_send_notification.assert_called_once_with(
         service_one["id"],
         template_id=fake_uuid,
         recipient="test@example.com",
-        personalisation={"email address": "test@example.com"},
+        personalisation={
+            "email address": "test@example.com",
+            "_file_0": {
+                "document": {
+                    "id": "file-1",
+                    "filename": "guide.pdf",
+                    "mime_type": "application/pdf",
+                    "file_size": 1280,
+                    "sending_method": "template_attach",
+                },
+            },
+        },
         sender_id=None,
     )
 

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -3437,18 +3437,17 @@ def test_service_switch_upload_document(
     assert mocked_fn.call_args[0][0] == service_one["id"]
 
 
-def test_service_switch_upload_document_shows_api_only_help_when_service_not_allowlisted(
+def test_service_switch_upload_document_shows_template_help_for_any_service(
     client_request,
     service_one,
     app_,
 ):
-    with set_config(app_, "FILE_ATTACH_SERVICES", []):
-        page = client_request.get(
-            "main.service_switch_upload_document",
-            service_id=service_one["id"],
-        )
-        paragraph = page.select_one("#main_content p").text.strip()
-        assert "This feature is only available when sending through the API" in paragraph
+    page = client_request.get(
+        "main.service_switch_upload_document",
+        service_id=service_one["id"],
+    )
+    paragraph = page.select_one("#main_content p").text.strip()
+    assert "Allow files to be attached to email notifications" in paragraph
 
 
 def test_enable_file_attachments_turns_on_permission_and_redirects_to_next(

--- a/tests/app/main/views/test_templates.py
+++ b/tests/app/main/views/test_templates.py
@@ -874,6 +874,32 @@ def test_should_show_attached_files_heading_and_notice_when_upload_document_perm
     assert page.select_one("[data-testid='file-attachments-ask-manager-notice']") is None
 
 
+def test_should_not_show_attachment_section_on_sms_template(
+    client_request,
+    mock_get_template_folders,
+    mock_get_limit_stats,
+    fake_uuid,
+    app_,
+    mocker,
+):
+    current_user.verified_phonenumber = True
+    mocker.patch(
+        "app.service_api_client.get_service_template",
+        return_value={"data": template_json(SERVICE_ONE_ID, fake_uuid, type_="sms")},
+    )
+
+    page = client_request.get(
+        ".view_template",
+        service_id=SERVICE_ONE_ID,
+        template_id=fake_uuid,
+        _test_page_title=False,
+    )
+
+    assert page.select_one("[data-testid='attached-files-heading']") is None
+    assert page.select_one("[data-testid='file-attachments-enable-notice']") is None
+    assert page.select_one("[data-testid='file-attachments-ask-manager-notice']") is None
+
+
 def test_should_show_ask_manager_notice_without_manage_service_permission(
     client_request,
     mock_get_template_folders,


### PR DESCRIPTION
# Summary | Résumé
This pull request removes the allowlist that previously restricted file attachments to a specific set of services. Now, any service with the `upload_document` permission can use file attachments. The code is simplified by eliminating checks for the allowlist, and related tests and templates are updated accordingly.

# Test instructions | Instructions pour tester la modification
- [ ] File attachments are shown for any service that enables 
- [ ] CI passes
