### PR TITLE
removing erroneous filter heartbeat

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -314,7 +314,7 @@ def activity():
 @cache.memoize(timeout=12 * 60 * 60)
 @main.route("/activity/atom", endpoint="activity_atom")
 def activity_atom():
-    stats = get_latest_stats(get_current_locale(current_app), filter_heartbeats=True)
+    stats = get_latest_stats(get_current_locale(current_app))
     now = datetime.now(timezone.utc)
     updated_total = now.isoformat()
     updated_services = (now - timedelta(minutes=2)).isoformat()

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -598,7 +598,7 @@ def test_get_remote_addr(app_, forwarded_for, remote_addr, expected):
 
 
 def test_get_latest_stats_k8s(mocker, app_):
-    mocker.patch(
+    mock_get_stats_by_month = mocker.patch(
         "app.service_api_client.get_stats_by_month",
         return_value={
             "data": [
@@ -629,6 +629,7 @@ def test_get_latest_stats_k8s(mocker, app_):
                 "September 2020": {"sms": 3, "total": 3, "year_month": "2020-09"},
             },
         }
+    mock_get_stats_by_month.assert_called_once_with()
 
 
 def test_get_latest_stats_lambda(mocker, app_):


### PR DESCRIPTION
# Summary | Résumé

Filter heartbeat was removed, and this part was missed.

# Test instructions | Instructions pour tester la modification

Verify that the Notify by the numbers still works.
